### PR TITLE
移除 Top Bar 與 Trip Intro 區塊

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,6 @@
 
         .container { max-width: 800px; margin: 0 auto; }
 
-        /* ===== Top Bar ===== */
-        .top-bar { position: relative; background: var(--white); padding: 12px 20px; text-align: center; border-bottom: 2px solid var(--blue-light); }
-        .top-bar h1 { font-size: var(--fs-lg); color: var(--blue); }
 
         /* ===== Menu Dropdown ===== */
         .menu-dropdown { display: none; position: fixed; background: var(--white); border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.18); padding: 6px; min-width: 180px; z-index: 300; }
@@ -233,10 +230,6 @@
         /* ===== Info Header ===== */
         .info-header { background: var(--text) !important; }
 
-        /* ===== Trip Intro ===== */
-        .trip-intro { background: var(--white); padding: 14px 20px; text-align: center; border-bottom: 1px solid var(--gray-light); }
-        .trip-intro-route { font-size: var(--fs-sm); color: var(--gray); }
-        .trip-intro-badge { display: inline-block; margin-top: 6px; padding: 4px 14px; background: var(--blue); color: #FFFFFF; border-radius: 12px; font-size: var(--fs-sm); font-weight: 600; }
 
         /* ===== Menu Separator ===== */
         .menu-sep { border-top: 1px solid var(--gray-light); margin: 4px 0; }
@@ -254,7 +247,6 @@
         body.dark .map-link.mapcode { color: var(--sand); border-color: var(--sand); }
         body.dark .map-link.mapcode:hover { background: var(--sand); color: #1E1E1E; }
         body.dark .hw-block { border-color: #333; }
-        body.dark .top-bar { border-bottom-color: #333; }
         body.dark .menu-dropdown { background: #2A2A2A; box-shadow: 0 8px 32px rgba(0,0,0,0.4); }
         body.dark .ov-card { background: #1A2A3A; }
         body.dark .ov-card.warm { background: #2A2218; }
@@ -273,17 +265,6 @@
 </head>
 <body>
     <div class="container">
-
-        <!-- ===== Top Bar ===== -->
-        <div class="top-bar">
-            <h1>🌊 2026 沖繩五日自駕遊</h1>
-        </div>
-
-        <!-- ===== Trip Intro ===== -->
-        <div class="trip-intro">
-            <div class="trip-intro-route">那霸 → 北谷美國村 → 青之洞窟 → 美麗海水族館 → 古宇利島</div>
-            <div class="trip-intro-badge">🚗 自駕遊｜租車 3 天（Day 1 ~ Day 4 還車）</div>
-        </div>
 
         <!-- ==================== Day 1 ==================== -->
         <section>


### PR DESCRIPTION
- 移除頁面頂部標題列（🌊 2026 沖繩五日自駕遊）
- 移除路線摘要與租車資訊 badge
- 清除對應 CSS 樣式（.top-bar、.trip-intro、dark mode）

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01XzBsDDooQnXxnAX4U68eNX