### PR TITLE
fix: 旅伴請求 500 錯誤 + 重複送出修復

### DIFF
--- a/functions/api/requests.ts
+++ b/functions/api/requests.ts
@@ -78,6 +78,25 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     return json({ error: '無此行程權限' }, 403);
   }
 
+  // 30 秒去重保護：防止因網路重試或使用者重複點擊造成重複寫入
+  const dupCheck = await env.DB
+    .prepare(
+      'SELECT COUNT(*) as cnt FROM requests WHERE trip_id = ? AND message = ? AND submitted_by = ? AND created_at > datetime(\'now\', \'-30 seconds\')'
+    )
+    .bind(tripId, message, auth.email)
+    .first<{ cnt: number }>();
+
+  if (dupCheck && dupCheck.cnt > 0) {
+    // 已存在近期相同請求，回傳最新一筆（200 而非 201）
+    const existing = await env.DB
+      .prepare(
+        'SELECT * FROM requests WHERE trip_id = ? AND message = ? AND submitted_by = ? ORDER BY created_at DESC LIMIT 1'
+      )
+      .bind(tripId, message, auth.email)
+      .first();
+    return json(existing, 200);
+  }
+
   const result = await env.DB
     .prepare(
       'INSERT INTO requests (trip_id, mode, message, submitted_by) VALUES (?, ?, ?, ?) RETURNING *'
@@ -86,14 +105,19 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     .first();
 
   const newRow = result as Record<string, unknown>;
-  await logAudit(env.DB, {
-    tripId,
-    tableName: 'requests',
-    recordId: newRow ? (newRow.id as number) : null,
-    action: 'insert',
-    changedBy: auth.email,
-    diffJson: JSON.stringify({ mode, message: message.substring(0, 100) }),
-  });
+  // logAudit 失敗不阻擋主流程，INSERT 已成功
+  try {
+    await logAudit(env.DB, {
+      tripId,
+      tableName: 'requests',
+      recordId: newRow ? (newRow.id as number) : null,
+      action: 'insert',
+      changedBy: auth.email,
+      diffJson: JSON.stringify({ mode, message: message.substring(0, 100) }),
+    });
+  } catch (auditErr) {
+    console.error('[requests] logAudit failed (non-fatal):', auditErr);
+  }
 
   return json(result, 201);
 };

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -258,24 +258,32 @@ export default function ManagePage() {
         }),
       });
 
-      if (res.status === 201) {
+      if (res.status === 201 || res.status === 200) {
         const req = (await res.json()) as RawRequest;
         setSubmitStatus({ type: 'success', message: '已送出' });
         setText('');
         if (textareaRef.current) {
           textareaRef.current.style.height = 'auto';
         }
-        // Optimistic insert to top
-        setRequests((prev) => [req, ...prev]);
+        // Reload list to reflect latest state (including dedup 200 case)
+        if (currentTripId) {
+          await loadRequests(currentTripId);
+        } else {
+          setRequests((prev) => [req, ...prev]);
+        }
       } else if (res.status === 403) {
         throw new Error('你沒有此行程的權限');
       } else {
         throw new Error('送出失敗（' + res.status + '）');
       }
     } catch (err) {
+      // 失敗後重新載入列表，讓使用者確認是否已送出
+      if (currentTripId) {
+        await loadRequests(currentTripId).catch(() => {/* ignore reload error */});
+      }
       setSubmitStatus({
         type: 'error',
-        message: err instanceof Error ? err.message : '送出失敗',
+        message: (err instanceof Error ? err.message : '送出失敗') + '（請重新整理確認是否已送出）',
       });
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
## Summary
- **Fix 1**: API logAudit 失敗不再阻擋主流程（try-catch 包裹，INSERT 成功即回 201）
- **Fix 2**: 前端失敗後提示「請重新整理確認是否已送出」+ 自動重新載入請求列表
- **Fix 3**: API 30 秒去重保護（同 trip_id + message + submitted_by 不重複寫入）

## Test plan
- [x] `npx tsc --noEmit` — 零錯誤
- [x] `npm test` — 686 tests 全過
- [x] `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)