### PR TITLE
feat: Trip Page V2 — Tailwind tokens + QA fixes + Vite CSS 分離

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -192,6 +192,11 @@ body {
     .svg-icon { display: inline-flex; align-items: center; justify-content: center; width: 1em; height: 1em; flex-shrink: 0; vertical-align: -0.125em; }
     .svg-icon svg { width: 100%; height: 100%; }
     button:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+    /* Tripline logo — responsive mobile/desktop SVG switch */
+    .tripline-logo { flex-shrink: 0; display: flex; align-items: center; position: relative; line-height: 0; }
+    .tripline-logo-mobile { display: block; }
+    .tripline-logo-desktop { display: none; }
+    @media (min-width: 768px) { .tripline-logo-mobile { display: none; } .tripline-logo-desktop { display: block; } }
 }
 
 /* ===== Theme overrides (@layer base) ===== */

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -187,6 +187,13 @@ body {
     --z-print-exit: 9999;
 }
 
+/* ===== Global component base (shared.css 替代) ===== */
+@layer base {
+    .svg-icon { display: inline-flex; align-items: center; justify-content: center; width: 1em; height: 1em; flex-shrink: 0; vertical-align: -0.125em; }
+    .svg-icon svg { width: 100%; height: 100%; }
+    button:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+}
+
 /* ===== Theme overrides (@layer base) ===== */
 /* NOTE: Light theme first, then dark override. Dark inherits --cmp-* from light. */
 

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -187,6 +187,11 @@ body {
     --z-print-exit: 9999;
 }
 
+/* ===== Global reset (shared.css 替代 — 不可用 * shorthand，會覆蓋 Tailwind longhand) ===== */
+@layer base {
+    body { margin: 0; }
+}
+
 /* ===== Global component base (shared.css 替代) ===== */
 @layer base {
     .svg-icon { display: inline-flex; align-items: center; justify-content: center; width: 1em; height: 1em; flex-shrink: 0; vertical-align: -0.125em; }

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -733,3 +733,8 @@ body {
     0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 40%, transparent); }
     50% { box-shadow: 0 0 8px 4px color-mix(in srgb, var(--color-accent) 20%, transparent); }
 }
+
+@keyframes tl-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(1.4); }
+}

--- a/features.json
+++ b/features.json
@@ -1,0 +1,52 @@
+{
+  "feature": "trip-page-v2",
+  "branch": "feat/trip-page-v2",
+  "description": "TripPage V1 → V2 全面改造：31 個子元件 + TripPage 本身從 shared.css/style.css 改為 Tailwind inline (tokens.css)",
+  "status": "in-progress",
+  "created": "2026-03-26",
+  "scope": {
+    "tripPage": "src/pages/TripPage.tsx (1190 lines)",
+    "components": "src/components/trip/*.tsx (31 files, ~5800 lines)",
+    "sharedComponents": ["Icon.tsx", "TriplineLogo.tsx", "Toast.tsx"],
+    "css": ["shared.css", "style.css", "map.css"],
+    "target_css": "tokens.css (Tailwind @theme)"
+  },
+  "approach": {
+    "method": "一次全改，不分 phase",
+    "steps": [
+      "1. 建立 TripPageV2.tsx — copy TripPage.tsx，改所有 CSS class 為 Tailwind inline",
+      "2. 逐一改 31 個子元件 — 每個元件的 CSS class 改為 Tailwind inline + @theme token",
+      "3. 更新 mainV2.tsx — route /trip/:tripId 到 TripPageV2",
+      "4. 更新 main.tsx — /trip 加入 V2_CUTOVER_PATHS",
+      "5. 驗證：tsc + vitest + build",
+      "6. 驗證：localhost dev server V1 vs V2 比對",
+      "7. 驗證：production build (vite preview) 截圖比對",
+      "8. 驗證：CSS computed styles 比對（7 個關鍵屬性）",
+      "9. 驗證：HTML 結構比對",
+      "10. 驗證：手機版 (375px) 截圖比對",
+      "11. 驗證：功能測試 — DayNav 切換、InfoSheet 開關、QuickPanel、SpeedDial",
+      "12. Push preview → staging 測試",
+      "13. PR → production"
+    ],
+    "verification": {
+      "compare_v1_v2": "localhost 同時開 V1 和 V2 做完整比對",
+      "css_properties": ["background-color", "color", "font-size", "font-family", "padding", "margin", "border-radius", "gap", "max-width", "backdrop-filter", "box-shadow", "border"],
+      "viewports": ["1280x900 (desktop)", "375x812 (mobile)"],
+      "functional": ["DayNav 切天", "Timeline 捲動", "InfoSheet 展開/收合", "QuickPanel 開關", "SpeedDial 按鈕", "EditFab 連結", "Toast 離線通知", "Dark mode 切換", "行程切換 select"]
+    }
+  },
+  "tailwind_rules": {
+    "namespace": "用 @theme token 直接 utility（bg-accent、text-muted、px-4），不用 arbitrary [var(--xxx)]",
+    "exceptions": ["color-mix → bg-(--color-glass-*)", "calc → 保留 arbitrary", "animate 自訂 keyframe → @theme --animate-*", "vendor prefix → Tailwind auto-prefix"],
+    "css_layer": "@layer base 的 reset 不可用 shorthand margin/padding（會覆蓋 Tailwind longhand）",
+    "dark_mode": "composite tokens (color-mix) 定義在 body 不是 :root（讓 dark theme override 生效）"
+  },
+  "known_issues": [
+    "Tailwind CSS 4 @theme 只認 namespace prefix（--color-*, --spacing-*, --radius-* 等）",
+    "production build 的 CSS 是靜態的，dev server (HMR) 是即時的 — 必須用 vite preview 測 production",
+    "V2 cutover 頁面從 V1 跳過去必須用 <a href>（full page nav），不能用 React Router <Link>",
+    "manage/admin 子目錄的 index.html 複製自 v2.html（build script）",
+    "Cloudflare Pages Pretty URLs 會把 /manage 308 redirect 到 /（找不到 manage.html）— 必須帶 trailing slash",
+    "global reset * { padding: 0; margin: 0 } 會覆蓋 Tailwind utilities — 已移除"
+  ]
+}

--- a/openspec/specs/scoped-styles-refactor.md
+++ b/openspec/specs/scoped-styles-refactor.md
@@ -1,0 +1,146 @@
+# SCOPED_STYLES 重構設計文件
+
+## 現況
+
+TripPage V2 轉換過程中，Tailwind 無法表達的 CSS 規則被放在各元件的 `SCOPED_STYLES` 常數中，透過 `<style>{SCOPED_STYLES}</style>` 注入 DOM。
+
+### 使用分布
+
+| 檔案 | 行數 | 內容 |
+|------|------|------|
+| `TripPageV2.tsx` | ~143 行 | day-header、keyframes、glass、print、section cards、link styles |
+| `DayNav.tsx` | ~9 行 | dark pill border、desktop font size、tooltip animation |
+| `InfoSheet.tsx` | ~29 行 | dark mode bg/shadow、focus management、mobile detent |
+| `QuickPanel.tsx` | ~24 行 | dark mode shadows、focus management、print hide |
+
+## 壞味道
+
+### 1. TripPageV2 的 SCOPED_STYLES 過大（143 行）
+不是 "scoped styles"，是一個完整的 stylesheet 塞在 JS template literal 裡。
+
+### 2. 每次 render 插入 `<style>` tag
+4 個元件各自插入 `<style>`，共 4 個 `<style>` tag 在 DOM 中。雖然瀏覽器能處理，但不是最佳實踐。
+
+### 3. IDE 無法 lint
+template literal 裡的 CSS 沒有語法高亮、autocomplete、也無法被 stylelint 檢查。
+
+### 4. CSS 規則散落三處
+同一個元素的樣式分散在：
+- Tailwind inline className
+- SCOPED_STYLES `<style>` block
+- tokens.css `@layer base`
+
+維護者需要查三個地方才能理解完整樣式。
+
+### 5. 規則分類不清
+SCOPED_STYLES 混合了「Tailwind 真的不支援」和「只是懶得放 tokens.css」的規則。
+
+## 什麼該留在 SCOPED_STYLES（合理用途）
+
+只有 Tailwind 4 **真正無法表達**的 CSS pattern：
+
+- `body.dark .xxx` — 需要 body class context 的 dark mode 覆寫
+- `body:not(.dark) .xxx` — 需要 body context 的 light mode 規則
+- `.parent > :not([attr])` — 複雜子元素選擇器
+- `:focus:not(:focus-visible)` — focus 管理
+- `@keyframes` — 動畫定義（Tailwind `animate-*` 只能引用已定義的 keyframe）
+- `@media print` — 列印覆寫
+- `@media (max-width: ...)` + 多屬性 — 複雜媒體查詢
+
+## 什麼該搬到 tokens.css `@layer base`
+
+不需要 body context 或特殊選擇器的基礎樣式：
+
+| 目前位置 | 規則 | 搬到 |
+|---------|------|------|
+| TripPageV2 SCOPED | `[data-tl-card] { background: color-mix... }` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `.skeleton-bone { ... }` + `@keyframes shimmer` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `#tripContent-v2 section { bg, radius, margin }` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `#tripContent-v2 a { color, underline }` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `.info-panel { display, bg, radius }` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `.day-header-v2 { ... }` light/dark | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `.edit-fab-v2:hover { ... }` | tokens.css `@layer base` |
+| TripPageV2 SCOPED | `.nav-inline-title-v2 { ... }` | tokens.css `@layer base` |
+
+## 重構後結構
+
+### tokens.css
+```css
+/* ===== V2 page-level base styles ===== */
+@layer base {
+    /* Day header */
+    body:not(.dark) .day-header-v2 { background: var(--color-accent-subtle); background-image: var(--theme-header-gradient); color: var(--color-foreground); }
+    body.dark .day-header-v2 { background: var(--color-accent-bg); background-image: var(--theme-header-gradient); }
+
+    /* Timeline card glass */
+    [data-tl-card] { background: color-mix(in srgb, var(--color-background) 92%, transparent); backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    body.dark [data-tl-card] { background: color-mix(in srgb, var(--color-tertiary) 88%, transparent); box-shadow: 0 1px 0 rgba(255,255,255,0.04); }
+    body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
+
+    /* Skeleton shimmer */
+    @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+    .skeleton-bone { background: linear-gradient(90deg, var(--color-tertiary) 25%, var(--color-secondary) 50%, var(--color-tertiary) 75%); background-size: 200% 100%; animation: shimmer 1.5s infinite; border-radius: var(--radius-sm); }
+
+    /* Section cards */
+    #tripContent-v2 section { background: var(--color-secondary); border-radius: var(--radius-md); margin-bottom: var(--spacing-3); overflow: hidden; }
+    #tripContent-v2 a:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); text-decoration: underline; }
+
+    /* Info panel */
+    .info-panel { display: none; background: var(--color-secondary); border-radius: var(--radius-lg); }
+    @media (min-width: 1200px) { .info-panel { display: block; position: fixed; right: 0; top: var(--spacing-nav-h); width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h)); overflow-y: auto; padding: var(--spacing-3); } }
+
+    /* Nav inline title */
+    .nav-inline-title-v2 { opacity: 0; transition: opacity var(--duration-nav-fade, 250ms) ease; }
+    .nav-inline-title-v2.visible { opacity: 1; }
+
+    /* Edit FAB */
+    .edit-fab-v2:hover { transform: scale(1.1); box-shadow: var(--shadow-lg); }
+}
+```
+
+### TripPageV2 SCOPED_STYLES（精簡到 ~30 行）
+```css
+/* 只留 Tailwind 無法表達的 */
+@keyframes fadeSlideIn { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.day-content-enter-v2 { animation: fadeSlideIn var(--transition-duration-normal) var(--transition-timing-function-apple) both; }
+.day-content-loaded-v2 { animation: fadeIn 300ms var(--transition-timing-function-apple) both; }
+.sticky-nav-v2 > :not([aria-hidden="true"]) { position: relative; z-index: 1; }
+/* Print mode */
+.print-mode .sticky-nav-v2 { display: none; }
+.print-mode .edit-fab-v2 { display: none !important; }
+.print-mode .print-exit-btn-v2 { display: block; }
+.print-mode #tripContent-v2 section { background: var(--color-background) !important; }
+.print-mode .day-header-v2 { background: var(--color-background); position: relative !important; }
+@media print { .sticky-nav-v2, .edit-fab-v2, .print-exit-btn-v2 { display: none !important; } }
+/* Desktop info-panel layout offset */
+@media (min-width: 1200px) { .page-layout-v2:has(.info-panel) { padding-right: calc(var(--info-panel-w) + var(--spacing-3)); } }
+/* Appearance cards (border active state) */
+.color-mode-card-v2, .color-theme-card-v2 { ... }
+```
+
+### 元件 SCOPED_STYLES（保持精簡）
+DayNav、InfoSheet、QuickPanel 的 SCOPED_STYLES 已經很小（9-29 行），且都是 body.dark / @keyframes / @media 規則，屬於合理用途，保持不動。
+
+## 效果
+
+| 指標 | 重構前 | 重構後 |
+|------|--------|--------|
+| TripPageV2 SCOPED 行數 | 143 | ~30 |
+| tokens.css base 規則 | 7 行 | ~40 行 |
+| `<style>` tag 數量 | 4 | 4（不變，但 TripPageV2 的大幅縮小） |
+| IDE CSS lint 覆蓋 | 部分 | tokens.css 完整覆蓋 |
+| 樣式查找位置 | 3 處 | 2 處（tokens.css + inline Tailwind） |
+
+## 風險
+
+- `@layer base` 優先級低於 `@layer utilities`，base 規則不會覆蓋 Tailwind utilities ✅（這是期望行為）
+- `body.dark` context selector 在 `@layer base` 中的特異性足夠覆蓋 Tailwind utilities ✅（body.dark 是 class selector，比 utility 更 specific）
+- 已知陷阱：`@layer base` 的 shorthand `margin: 0` 會覆蓋 Tailwind longhand `margin-top` — 避免使用 shorthand
+
+## 實施計畫
+
+1. 將上述規則搬到 tokens.css `@layer base`
+2. 從 TripPageV2 SCOPED_STYLES 移除搬走的規則
+3. 跑 tsc + vitest + vite build 驗證
+4. 瀏覽器截圖比對確認無視覺變化

--- a/progress.jsonl
+++ b/progress.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-03-26T13:20:00+08:00","step":"init","status":"done","detail":"分支 feat/trip-page-v2 建立，features.json 交班檔完成"}

--- a/progress.jsonl
+++ b/progress.jsonl
@@ -1,1 +1,8 @@
 {"ts":"2026-03-26T13:20:00+08:00","step":"init","status":"done","detail":"分支 feat/trip-page-v2 建立，features.json 交班檔完成"}
+{"ts":"2026-03-26T14:45:00+08:00","step":"build","status":"done","detail":"31 元件 + TripPageV2 全面 Tailwind 轉換，hybrid CSS class 消除，tsc/build/724 tests 全過"}
+{"ts":"2026-03-26T15:00:00+08:00","step":"review","status":"done","detail":"/tp-code-verify 🟢 + /review 16 issues all fixed + adversarial review 14 findings resolved"}
+{"ts":"2026-03-26T15:30:00+08:00","step":"test-qa","status":"done","detail":"/qa 10 issues found+fixed: svg-icon、InfoSheet pointer-events/z-index、Day header gradient、layout width、card glass、segment color、body margin、pill font、DestinationArt selector、card shadow"}
+{"ts":"2026-03-26T15:45:00+08:00","step":"test-cso","status":"done","detail":"/cso CLEAN — CSS-only changes, zero security findings"}
+{"ts":"2026-03-26T15:50:00+08:00","step":"test-benchmark","status":"done","detail":"/benchmark Grade A, NET -8.1kB gzip improvement"}
+{"ts":"2026-03-26T18:15:00+08:00","step":"visual-parity","status":"done","detail":"V1 vs V2 逐元素比對完成：nav glass 92%、card glass、layout offset、segment dark color、body margin reset、pill desktop font、DestinationArt position、InfoPanel bg、sheet handle iOS style、card shadow 移除"}
+{"ts":"2026-03-26T18:20:00+08:00","step":"next","status":"pending","detail":"待做：SCOPED_STYLES 重構（搬到 tokens.css @layer base）→ /ship → /retro → archive"}

--- a/src/components/trip/Backup.tsx
+++ b/src/components/trip/Backup.tsx
@@ -27,16 +27,16 @@ interface BackupProps {
 export default function Backup({ data }: BackupProps) {
   if (data.cards && data.cards.length) {
     return (
-      <div className="ov-grid ov-grid-2">
+      <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
         {data.cards.map((card, i) => (
-          <div key={i} className="ov-card">
-            {card.title && <h4>{card.title}</h4>}
+          <div key={i} className="bg-accent-bg rounded-sm p-4">
+            {card.title && <h4 className="relative pl-4 mt-0"><span className="absolute left-0 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full bg-accent" />{card.title}</h4>}
             {card.description && <p>{card.description}</p>}
             {card.weatherItems && card.weatherItems.length > 0 && (
-              <ul className="weather-list">
+              <ul className="list-none p-0">
                 {card.weatherItems.map((w, j) => (
-                  <li key={j}>
-                    <span className="list-icon">
+                  <li key={j} className="text-callout py-1 flex items-baseline gap-2">
+                    <span className="shrink-0">
                       <Icon name="wave" />
                     </span>
                     {w}
@@ -62,10 +62,10 @@ export default function Backup({ data }: BackupProps) {
 
   if (data.items && data.items.length) {
     return (
-      <ul className="notes-list">
+      <ul className="list-none p-0 mt-2">
         {data.items.map((item, i) => (
-          <li key={i}>
-            <span className="list-icon">
+          <li key={i} className="py-1 text-body flex items-baseline gap-2">
+            <span className="shrink-0">
               <Icon name="pin" />
             </span>
             {item}

--- a/src/components/trip/Checklist.tsx
+++ b/src/components/trip/Checklist.tsx
@@ -25,10 +25,10 @@ interface ChecklistProps {
 export default function Checklist({ data }: ChecklistProps) {
   if (data.cards && data.cards.length) {
     return (
-      <div className="ov-grid">
+      <div className="grid grid-cols-3 gap-3 max-sm:grid-cols-1">
         {data.cards.map((card, i) => (
-          <div key={i} className="ov-card">
-            {card.title && <h4>{card.title}</h4>}
+          <div key={i} className="bg-accent-bg rounded-sm p-4">
+            {card.title && <h4 className="relative pl-4 mt-0"><span className="absolute left-0 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full bg-accent" />{card.title}</h4>}
             {card.items && card.items.length > 0 && (
               <p>
                 {card.items.map((item, j) => (
@@ -47,10 +47,10 @@ export default function Checklist({ data }: ChecklistProps) {
 
   if (data.items && data.items.length) {
     return (
-      <ul className="notes-list">
+      <ul className="list-none p-0 mt-2">
         {data.items.map((item, i) => (
-          <li key={i}>
-            <span className="list-icon">
+          <li key={i} className="py-1 text-body flex items-baseline gap-2">
+            <span className="shrink-0">
               <Icon name="pin" />
             </span>
             {item}

--- a/src/components/trip/Countdown.tsx
+++ b/src/components/trip/Countdown.tsx
@@ -24,10 +24,10 @@ export default function Countdown({ autoScrollDates }: CountdownProps) {
   if (today < startDate) {
     const diff = Math.ceil((startDate.getTime() - today.getTime()) / MS_PER_DAY);
     return (
-      <div className="info-card countdown-card">
-        <div className="countdown-number">
-          <span className="countdown-num">{diff}</span>
-          <span className="countdown-unit">天</span>
+      <div className="bg-secondary rounded-md p-4 mb-3 text-center">
+        <div className="font-bold text-accent leading-tight flex items-baseline justify-center gap-1">
+          <span className="text-title2">{diff}</span>
+          <span className="text-body font-semibold">天</span>
         </div>
       </div>
     );
@@ -36,21 +36,21 @@ export default function Countdown({ autoScrollDates }: CountdownProps) {
   if (today <= endDate) {
     const dayN = Math.floor((today.getTime() - startDate.getTime()) / MS_PER_DAY) + 1;
     return (
-      <div className="info-card countdown-card">
-        <div className="countdown-number">
-          <span className="countdown-num">Day {dayN}</span>
+      <div className="bg-secondary rounded-md p-4 mb-3 text-center">
+        <div className="font-bold text-accent leading-tight flex items-baseline justify-center gap-1">
+          <span className="text-title2">Day {dayN}</span>
         </div>
-        <div className="countdown-label">旅行進行中</div>
+        <div className="text-callout text-muted mt-1">旅行進行中</div>
       </div>
     );
   }
 
   return (
-    <div className="info-card countdown-card">
-      <div className="countdown-number">
+    <div className="bg-secondary rounded-md p-4 mb-3 text-center">
+      <div className="font-bold text-accent leading-tight flex items-baseline justify-center gap-1">
         <Icon name="plane" />
       </div>
-      <div className="countdown-label">旅程已結束</div>
+      <div className="text-callout text-muted mt-1">旅程已結束</div>
     </div>
   );
 }

--- a/src/components/trip/DayMap.tsx
+++ b/src/components/trip/DayMap.tsx
@@ -206,15 +206,15 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
   const mapId = `day-map-${dayNum}`;
 
   return (
-    <div className="day-map-section" data-testid="day-map-section">
+    <div data-testid="day-map-section">
       {/* Header：標籤 + 收合按鈕 */}
-      <div className="day-map-header">
-        <span className="day-map-header-label">
+      <div className="flex items-center justify-between p-2 px-1 mb-2">
+        <span className="text-footnote font-semibold text-muted uppercase tracking-[0.04em]">
           <Icon name="map" />
           動線地圖
         </span>
         <button
-          className="day-map-toggle-btn"
+          className="flex items-center gap-2 py-2 px-4 bg-transparent rounded-sm text-muted text-footnote font-medium cursor-pointer min-h-tap-min min-w-[var(--spacing-tap-min)] transition-colors duration-fast ease-apple hover:text-foreground hover:bg-tertiary"
           aria-expanded={!collapsed}
           aria-controls={mapId}
           onClick={handleToggle}
@@ -231,15 +231,15 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
         role="region"
         aria-label={`第 ${dayNum} 天動線地圖`}
         className={clsx(
-          'day-map-wrap',
-          collapsed ? 'day-map-wrap--collapsed' : 'day-map-wrap--expanded',
+          'overflow-hidden transition-[max-height] duration-normal ease-apple',
+          collapsed ? 'max-h-0' : 'max-h-[420px] md:max-h-[460px] lg:max-h-[520px]',
         )}
         aria-hidden={collapsed}
       >
         {/* Case 1：SDK 載入中 → skeleton */}
         {status === 'loading' || status === 'idle' ? (
           <div
-            className="day-map-skeleton"
+            className="h-[250px] md:h-[300px] lg:h-[350px] bg-tertiary rounded-md animate-pulse"
             role="status"
             aria-label="地圖載入中"
             data-testid="day-map-skeleton"
@@ -249,17 +249,17 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
         {/* Case 2：SDK 載入失敗 → error fallback */}
         {status === 'error' ? (
           <div
-            className="day-map-error"
+            className="flex flex-col items-center justify-center gap-3 p-8 bg-secondary rounded-md h-[250px] md:h-[300px] lg:h-[350px] text-center"
             role="alert"
             data-testid="day-map-error"
           >
             <Icon name="warning" />
-            <p className="day-map-error-title">地圖無法載入</p>
-            <p className="day-map-error-desc">
+            <p className="text-subheadline font-semibold text-foreground">地圖無法載入</p>
+            <p className="text-footnote text-muted">
               {error ?? 'Google Maps SDK 無法載入，請確認網路連線。'}
             </p>
             <a
-              className="day-map-error-link"
+              className="inline-flex items-center gap-2 py-2 px-4 bg-accent text-accent-foreground rounded-sm text-footnote font-semibold no-underline min-h-tap-min min-w-[var(--spacing-tap-min)] justify-center"
               href={buildFallbackUrl(dayNum)}
               target="_blank"
               rel="noopener noreferrer"
@@ -274,7 +274,7 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
         {/* Case 3：SDK ready + 無座標資料 → empty state */}
         {status === 'ready' && !hasData ? (
           <div
-            className="day-map-empty"
+            className="flex items-center justify-center h-[250px] md:h-[300px] lg:h-[350px] bg-secondary rounded-md text-footnote text-muted text-center p-4"
             data-testid="day-map-empty"
           >
             今天沒有排程景點座標
@@ -283,10 +283,10 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
 
         {/* Case 4：SDK ready + 有資料 → 地圖容器 + markers */}
         {status === 'ready' && hasData ? (
-          <div className="day-map-container" data-testid="day-map-container">
+          <div className="relative touch-none bg-secondary rounded-md overflow-hidden" data-testid="day-map-container">
             <div
               ref={mapRef}
-              className="day-map"
+              className="h-[250px] md:h-[300px] lg:h-[350px] w-full rounded-md"
               aria-label={`第 ${dayNum} 天互動地圖`}
               data-testid="day-map-canvas"
             />
@@ -317,7 +317,7 @@ export default function DayMap({ day, dayNum }: DayMapProps) {
       {/* 部分座標缺失提示條（展開時顯示） */}
       {!collapsed && status === 'ready' && missingCount > 0 && (
         <div
-          className="day-map-warning"
+          className="flex items-center gap-2 py-2 px-3 bg-accent-subtle rounded-sm text-caption text-muted mt-2"
           role="status"
           data-testid="day-map-warning"
         >

--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -2,6 +2,17 @@ import { useRef, useCallback, useEffect, useState, useLayoutEffect } from 'react
 import clsx from 'clsx';
 import type { DaySummary } from '../../types/trip';
 
+/* ===== Scoped styles (pseudo-elements + dark mode that Tailwind cannot express) ===== */
+
+const SCOPED_STYLES = `
+.dn-today-dot { width: 6px; height: 6px; }
+body.dark [data-dn]:not(.active) { background: transparent; border: 1.5px solid var(--color-accent); }
+@keyframes dn-tooltip-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(4px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+`;
+
 /* ===== Helpers ===== */
 
 const WEEKDAYS = '日一二三四五六';
@@ -112,7 +123,7 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
   useEffect(() => {
     if (!currentDayNum || !navRef.current) return;
     const btn = navRef.current.querySelector<HTMLElement>(
-      `.dn[data-day="${currentDayNum}"]`,
+      `[data-dn][data-day="${currentDayNum}"]`,
     );
     if (btn) scrollPillIntoView(btn);
   }, [currentDayNum, scrollPillIntoView]);
@@ -123,7 +134,7 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
     // 全覽模式時，indicator 跟著「全覽」按鈕
     const nav = navRef.current;
     if (isTripMapMode) {
-      const overviewBtn = nav.querySelector<HTMLElement>('.dn-overview');
+      const overviewBtn = nav.querySelector<HTMLElement>('[data-testid="dn-overview-btn"]');
       if (!overviewBtn) {
         setIndicatorStyle(null);
         return;
@@ -131,7 +142,7 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
       setIndicatorStyle({ left: overviewBtn.offsetLeft, width: overviewBtn.offsetWidth });
       return;
     }
-    const activeBtn = nav.querySelector<HTMLElement>(`.dn[data-day="${currentDayNum}"]`);
+    const activeBtn = nav.querySelector<HTMLElement>(`[data-dn][data-day="${currentDayNum}"]`);
     if (!activeBtn) {
       setIndicatorStyle(null);
       return;
@@ -184,92 +195,136 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
     setTimeout(() => setTooltipDay(null), 2000);
   }, []);
 
-  /* --- Build wrap class names --- */
-  const wrapClassName = clsx(
-    'dh-nav-wrap',
-    canScrollLeft && 'can-scroll-left',
-    canScrollRight && 'can-scroll-right',
-  );
-
   return (
-    <div className={wrapClassName} ref={wrapRef}>
-      <button
-        className="dh-nav-arrow"
-        aria-label="向左捲動"
-        aria-hidden={!canScrollLeft}
-        tabIndex={canScrollLeft ? 0 : -1}
-        disabled={!canScrollLeft}
-        onClick={handleArrowLeft}
-      >
-        &#8249;
-      </button>
-      <div className="dh-nav" id="navPills" ref={navRef}>
-        {indicatorStyle && (
-          <div
-            className="dn-indicator"
-            aria-hidden="true"
-            style={{
-              transform: `translateX(${indicatorStyle.left}px)`,
-              width: indicatorStyle.width,
-            }}
-          />
-        )}
-        {days.map((d) => {
-          const dayNum = d.day_num;
-          const isActive = !isTripMapMode && dayNum === currentDayNum;
-          const isToday = dayNum === todayDayNum;
-          const showTooltip = tooltipDay === dayNum;
+    <>
+      <style>{SCOPED_STYLES}</style>
+      <div className="relative flex items-center min-w-0 ml-auto" ref={wrapRef}>
+        {/* Left gradient fade mask */}
+        <div
+          className={clsx(
+            'absolute left-0 top-0 bottom-0 w-8 pointer-events-none z-1 bg-linear-to-r from-secondary to-transparent transition-opacity duration-fast ease-apple',
+            canScrollLeft ? 'opacity-100' : 'opacity-0',
+          )}
+          aria-hidden="true"
+        />
+        {/* Right gradient fade mask */}
+        <div
+          className={clsx(
+            'absolute right-0 top-0 bottom-0 w-8 pointer-events-none z-1 bg-linear-to-l from-secondary to-transparent transition-opacity duration-fast ease-apple',
+            canScrollRight ? 'opacity-100' : 'opacity-0',
+          )}
+          aria-hidden="true"
+        />
 
-          const tooltipId = `dn-tooltip-${dayNum}`;
-          return (
+        <button
+          className="hidden md:flex items-center bg-transparent border-none text-accent text-title3 cursor-pointer p-2 min-w-tap-min focus-visible:outline-none focus-visible:shadow-ring focus-visible:rounded-xs aria-hidden:invisible"
+          aria-label="向左捲動"
+          aria-hidden={!canScrollLeft}
+          tabIndex={canScrollLeft ? 0 : -1}
+          disabled={!canScrollLeft}
+          onClick={handleArrowLeft}
+        >
+          &#8249;
+        </button>
+        <div
+          className="relative flex gap-2 flex-1 overflow-x-auto overflow-y-visible scroll-smooth py-1 md:justify-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          id="navPills"
+          ref={navRef}
+        >
+          {indicatorStyle && (
+            <div
+              className="absolute top-0 h-full bg-accent rounded-md opacity-15 pointer-events-none will-change-[transform,width]"
+              aria-hidden="true"
+              style={{
+                transition: `transform var(--duration-indicator) var(--ease-spring, cubic-bezier(0.32, 1.28, 0.60, 1.00)), width var(--duration-indicator) var(--ease-spring, cubic-bezier(0.32, 1.28, 0.60, 1.00))`,
+                transform: `translateX(${indicatorStyle.left}px)`,
+                width: indicatorStyle.width,
+              }}
+            />
+          )}
+          {days.map((d) => {
+            const dayNum = d.day_num;
+            const isActive = !isTripMapMode && dayNum === currentDayNum;
+            const isToday = dayNum === todayDayNum;
+            const showTooltip = tooltipDay === dayNum;
+
+            const tooltipId = `dn-tooltip-${dayNum}`;
+            return (
+              <button
+                key={dayNum}
+                className={clsx(
+                  'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote md:text-title3 font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
+                  isActive
+                    ? 'active bg-accent text-accent-foreground'
+                    : 'bg-accent-bg text-accent hover:bg-accent hover:text-accent-foreground',
+                )}
+                data-dn=""
+                data-day={dayNum}
+                data-action="switch-day"
+                data-target={`day${dayNum}`}
+                aria-label={d.label ? `${formatPillLabel(d)} ${d.label}` : formatPillLabel(d)}
+                aria-describedby={showTooltip ? tooltipId : undefined}
+                onClick={() => handleDayClick(dayNum)}
+                onMouseEnter={() => handleMouseEnter(dayNum)}
+                onMouseLeave={handleMouseLeave}
+                onTouchStart={() => handleTouchStart(dayNum)}
+                onTouchEnd={handleTouchEnd}
+              >
+                {formatPillLabel(d)}
+                {/* Today marker dot */}
+                {isToday && (
+                  <span
+                    className={clsx(
+                      'dn-today-dot absolute bottom-1 left-1/2 -translate-x-1/2 rounded-full',
+                      isActive ? 'bg-accent-foreground' : 'bg-accent',
+                    )}
+                    aria-hidden="true"
+                  />
+                )}
+                {showTooltip && (
+                  <span
+                    id={tooltipId}
+                    className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 bg-secondary text-foreground text-caption font-medium py-2 px-3 rounded-sm shadow-md whitespace-nowrap z-10 pointer-events-none [animation:dn-tooltip-in_var(--transition-duration-fast)_var(--transition-timing-function-apple)]"
+                    role="tooltip"
+                  >
+                    {formatTooltip(d)}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+
+          {/* 全覽按鈕（F006.5）：只在有切換 callback 時顯示 */}
+          {onToggleTripMap && (
             <button
-              key={dayNum}
-              className={clsx('dn', isActive && 'active', isToday && 'dn-today')}
-              data-day={dayNum}
-              data-action="switch-day"
-              data-target={`day${dayNum}`}
-              aria-label={d.label ? `${formatPillLabel(d)} ${d.label}` : formatPillLabel(d)}
-              aria-describedby={showTooltip ? tooltipId : undefined}
-              onClick={() => handleDayClick(dayNum)}
-              onMouseEnter={() => handleMouseEnter(dayNum)}
-              onMouseLeave={handleMouseLeave}
-              onTouchStart={() => handleTouchStart(dayNum)}
-              onTouchEnd={handleTouchEnd}
-            >
-              {formatPillLabel(d)}
-              {showTooltip && (
-                <span id={tooltipId} className="dn-tooltip" role="tooltip">
-                  {formatTooltip(d)}
-                </span>
+              className={clsx(
+                'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote md:text-title3 font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
+                isTripMapMode
+                  ? 'active bg-accent text-accent-foreground'
+                  : 'bg-accent-bg text-accent hover:bg-accent hover:text-accent-foreground',
               )}
+              data-dn=""
+              aria-label="全覽地圖"
+              aria-pressed={isTripMapMode}
+              onClick={onToggleTripMap}
+              data-testid="dn-overview-btn"
+              type="button"
+            >
+              全覽
             </button>
-          );
-        })}
-
-        {/* 全覽按鈕（F006.5）：只在有切換 callback 時顯示 */}
-        {onToggleTripMap && (
-          <button
-            className={clsx('dn', 'dn-overview', isTripMapMode && 'active')}
-            aria-label="全覽地圖"
-            aria-pressed={isTripMapMode}
-            onClick={onToggleTripMap}
-            data-testid="dn-overview-btn"
-            type="button"
-          >
-            全覽
-          </button>
-        )}
+          )}
+        </div>
+        <button
+          className="hidden md:flex items-center bg-transparent border-none text-accent text-title3 cursor-pointer p-2 min-w-tap-min focus-visible:outline-none focus-visible:shadow-ring focus-visible:rounded-xs aria-hidden:invisible"
+          aria-label="向右捲動"
+          aria-hidden={!canScrollRight}
+          tabIndex={canScrollRight ? 0 : -1}
+          disabled={!canScrollRight}
+          onClick={handleArrowRight}
+        >
+          &#8250;
+        </button>
       </div>
-      <button
-        className="dh-nav-arrow"
-        aria-label="向右捲動"
-        aria-hidden={!canScrollRight}
-        tabIndex={canScrollRight ? 0 : -1}
-        disabled={!canScrollRight}
-        onClick={handleArrowRight}
-      >
-        &#8250;
-      </button>
-    </div>
+    </>
   );
 }

--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -7,6 +7,7 @@ import type { DaySummary } from '../../types/trip';
 const SCOPED_STYLES = `
 .dn-today-dot { width: 6px; height: 6px; }
 body.dark [data-dn]:not(.active) { background: transparent; border: 1.5px solid var(--color-accent); }
+@media (min-width: 1280px) { [data-dn] { font-size: var(--font-size-title3); } }
 @keyframes dn-tooltip-in {
   from { opacity: 0; transform: translateX(-50%) translateY(4px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
@@ -253,7 +254,7 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
               <button
                 key={dayNum}
                 className={clsx(
-                  'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote md:text-title3 font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
+                  'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
                   isActive
                     ? 'active bg-accent text-accent-foreground'
                     : 'bg-accent-bg text-accent hover:bg-accent hover:text-accent-foreground',
@@ -298,7 +299,7 @@ export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, 
           {onToggleTripMap && (
             <button
               className={clsx(
-                'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote md:text-title3 font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
+                'dn relative z-1 flex items-center justify-center border-none py-2 px-3 rounded-md text-footnote font-semibold font-inherit min-w-tap-min min-h-tap-min text-center whitespace-nowrap transition-[background,color] duration-fast ease-apple',
                 isTripMapMode
                   ? 'active bg-accent text-accent-foreground'
                   : 'bg-accent-bg text-accent hover:bg-accent hover:text-accent-foreground',

--- a/src/components/trip/DaySkeleton.tsx
+++ b/src/components/trip/DaySkeleton.tsx
@@ -2,21 +2,21 @@ import { memo } from 'react';
 
 const DaySkeleton = memo(function DaySkeleton() {
   return (
-    <div className="day-skeleton" role="status" aria-label="行程載入中" aria-busy="true">
+    <div className="px-padding-h" role="status" aria-label="行程載入中" aria-busy="true">
       {/* Day header */}
-      <div className="skeleton-header">
+      <div className="py-3 pb-4">
         <div className="skeleton-bone" style={{ width: '40%', height: 24 }} />
         <div className="skeleton-bone" style={{ width: '30%', height: 16, marginTop: 4 }} />
       </div>
       {/* Weather bar */}
-      <div className="skeleton-bone skeleton-weather" />
+      <div className="skeleton-bone w-full h-14 mb-4" />
       {/* Timeline events — 2 items closer to median, reduces layout shift */}
       {[1, 2].map(i => (
-        <div key={i} className="skeleton-event">
-          <div className="skeleton-flag">
-            <div className="skeleton-bone skeleton-dot" />
+        <div key={i} className="flex gap-3 mb-4">
+          <div className="w-6 shrink-0 flex justify-center">
+            <div className="skeleton-bone w-5 h-5 rounded-full" />
           </div>
-          <div className="skeleton-card">
+          <div className="flex-1 bg-secondary rounded-md p-4">
             <div className="skeleton-bone" style={{ width: '60%', height: 18 }} />
             <div className="skeleton-bone" style={{ width: '80%', height: 14, marginTop: 8 }} />
             <div className="skeleton-bone" style={{ width: '45%', height: 14, marginTop: 4 }} />

--- a/src/components/trip/DestinationArt.tsx
+++ b/src/components/trip/DestinationArt.tsx
@@ -303,7 +303,7 @@ export const DestinationArt = memo(function DestinationArt({ tripId, dark }: Des
   const mode = dark ? 'dark' : 'light';
 
   return (
-    <div className="destination-art" aria-hidden="true">
+    <div className="absolute inset-0 z-0 pointer-events-none overflow-hidden" aria-hidden="true">
       <svg
         viewBox="0 0 480 48"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/trip/DrivingStats.tsx
+++ b/src/components/trip/DrivingStats.tsx
@@ -24,14 +24,14 @@ function TransportTypeGroups({ byType }: { byType: Record<string, TypeGroup> }) 
         const group = byType[key];
         if (!group) return null;
         return (
-          <div key={key} className="transport-type-group">
-            <div className="transport-type-label">
+          <div key={key} className="mb-1">
+            <div className="font-semibold mb-1">
               <Icon name={group.icon} /> {group.label}：
               {formatMinutes(group.totalMinutes)}
             </div>
-            <div className="driving-stats-detail">
+            <div className="flex flex-wrap gap-1 gap-x-3 text-muted text-callout">
               {group.segments.map((seg, i) => (
-                <span key={i} className="driving-stats-seg">
+                <span key={i}>
                   <Icon name={group.icon} />{' '}
                   {seg.from && (
                     <>{seg.from}{seg.to ? ` → ${seg.to}` : ''} </>
@@ -60,16 +60,15 @@ interface DayDrivingStatsProps {
 export function DayDrivingStatsCard({ stats }: DayDrivingStatsProps) {
   const [isOpen, setIsOpen] = useState(false);
   const isWarning = isDrivingWarning(stats.drivingMinutes);
-  const cls = clsx('driving-stats', isWarning && 'driving-stats-warning');
 
   const handleToggle = useCallback(() => {
     setIsOpen((prev) => !prev);
   }, []);
 
   return (
-    <div className={cls}>
+    <div className="my-3 py-3 rounded-sm bg-transparent text-callout">
       <div
-        className={clsx('col-row', isOpen && 'open')}
+        className="flex items-center gap-2 py-2 px-3 -mx-3 select-none cursor-pointer rounded-sm transition-colors duration-fast ease-apple hover:bg-accent-bg"
         role="button"
         tabIndex={0}
         aria-expanded={isOpen}
@@ -80,11 +79,11 @@ export function DayDrivingStatsCard({ stats }: DayDrivingStatsProps) {
         {isWarning ? <Icon name="warning" /> : <Icon name="bus" />} 當日交通：
         {formatMinutes(stats.totalMinutes)}
         {isWarning && (
-          <span className="driving-stats-badge">{DRIVING_WARN_LABEL}</span>
+          <span className="inline-block bg-destructive text-accent-foreground text-footnote py-1 px-2 rounded-sm font-semibold ml-2">{DRIVING_WARN_LABEL}</span>
         )}
-        <span className="arrow">{isOpen ? ARROW_COLLAPSE : ARROW_EXPAND}</span>
+        <span className="ml-auto text-muted text-subheadline">{isOpen ? ARROW_COLLAPSE : ARROW_EXPAND}</span>
       </div>
-      <div className={clsx('col-detail', isOpen && 'open')}>
+      <div className={clsx('hidden print:block py-3 text-body leading-relaxed', isOpen && '!block')}>
         <TransportTypeGroups byType={stats.byType} />
       </div>
     </div>
@@ -106,7 +105,7 @@ function getTypeMinutes(stats: DayDrivingStats, type: string): number {
 function StatCell({ minutes, type }: { minutes: number; type: string }) {
   const warn = type === 'car' && isDrivingWarning(minutes);
   return (
-    <span className={clsx('ds-cell-value', warn && 'ds-cell-warn')}>
+    <span className={clsx('font-semibold ml-auto flex items-center gap-1', warn && 'text-warning')}>
       {warn && <Icon name="warning" />}
       {formatMinutes(minutes)}
     </span>
@@ -122,26 +121,26 @@ export function TripDrivingStatsCard({ tripStats }: TripDrivingStatsProps) {
   const activeTypes = TRANSPORT_TYPE_ORDER.filter((k) => tripStats.grandByType[k]);
 
   return (
-    <div className="driving-summary">
-      <div className="driving-summary-header">
+    <div className="my-2">
+      <div className="flex items-center gap-2 py-3 font-semibold text-headline">
         <Icon name="bus" /> 交通統計
       </div>
 
       {/* Mobile: card layout */}
-      <div className="ds-cards">
+      <div className="flex flex-col gap-2 md:hidden">
         {tripStats.days.map((d) => {
           const isWarning = isDrivingWarning(d.stats.drivingMinutes);
           return (
-            <div key={d.dayId} className={clsx('ds-card', isWarning && 'ds-card-warn')}>
-              <div className="ds-card-label">{d.label} {d.date}</div>
+            <div key={d.dayId} className={clsx('bg-secondary rounded-sm p-3', isWarning && 'bg-warning-bg')}>
+              <div className="font-semibold text-callout mb-2">{d.label} {d.date}</div>
               {activeTypes.map((type) => {
                 const g = d.stats.byType[type];
                 if (!g) return null;
                 const mins = g.totalMinutes;
                 return (
-                  <div key={type} className="ds-card-row">
+                  <div key={type} className="flex items-center gap-2 py-1 text-callout">
                     <Icon name={g.icon} />
-                    <span className="ds-card-type">{g.label}</span>
+                    <span className="text-muted min-w-8">{g.label}</span>
                     <StatCell minutes={mins} type={type} />
                   </div>
                 );
@@ -152,25 +151,25 @@ export function TripDrivingStatsCard({ tripStats }: TripDrivingStatsProps) {
       </div>
 
       {/* Desktop: table layout */}
-      <div className="ds-table-wrap">
-        <table className="ds-table">
+      <div className="hidden md:block">
+        <table className="w-full border-collapse text-callout">
           <thead>
             <tr>
               <th></th>
               {activeTypes.map((type) => {
                 const g = tripStats.grandByType[type];
                 return (
-                  <th key={type}><Icon name={g.icon} /> {g.label}</th>
+                  <th key={type} className="text-center p-2 font-semibold text-muted whitespace-nowrap"><Icon name={g.icon} /> {g.label}</th>
                 );
               })}
             </tr>
           </thead>
           <tbody>
             {tripStats.days.map((d) => (
-              <tr key={d.dayId}>
-                <td className="ds-table-label">{d.label} {d.date}</td>
+              <tr key={d.dayId} className="border-t border-border">
+                <td className="text-left font-semibold whitespace-nowrap p-2">{d.label} {d.date}</td>
                 {activeTypes.map((type) => (
-                  <td key={type}>
+                  <td key={type} className="text-center p-2">
                     <StatCell minutes={getTypeMinutes(d.stats, type)} type={type} />
                   </td>
                 ))}
@@ -178,10 +177,10 @@ export function TripDrivingStatsCard({ tripStats }: TripDrivingStatsProps) {
             ))}
           </tbody>
           <tfoot>
-            <tr className={clsx(isDrivingWarning(tripStats.grandByType['car']?.totalMinutes ?? 0) && 'ds-row-warn')}>
-              <td className="ds-table-label">合計</td>
+            <tr className={clsx('border-t-2 border-border font-bold', isDrivingWarning(tripStats.grandByType['car']?.totalMinutes ?? 0) && 'bg-warning-bg')}>
+              <td className="text-left font-semibold whitespace-nowrap p-2">合計</td>
               {activeTypes.map((type) => (
-                <td key={type}>
+                <td key={type} className="text-center p-2">
                   <StatCell minutes={tripStats.grandByType[type]?.totalMinutes ?? 0} type={type} />
                 </td>
               ))}

--- a/src/components/trip/Emergency.tsx
+++ b/src/components/trip/Emergency.tsx
@@ -36,10 +36,10 @@ export default function Emergency({ data }: EmergencyProps) {
   if (!data.cards || !data.cards.length) return null;
 
   return (
-    <div className="ov-grid">
+    <div className="grid grid-cols-3 gap-3 max-sm:grid-cols-1">
       {data.cards.map((card, i) => (
-        <div key={i} className="ov-card">
-          {card.title && <h4>{card.title}</h4>}
+        <div key={i} className="bg-accent-bg rounded-sm p-4">
+          {card.title && <h4 className="relative pl-4 mt-0"><span className="absolute left-0 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full bg-accent" />{card.title}</h4>}
           {card.contacts &&
             card.contacts.map((c, j) => {
               const cUrl = escUrl(c.url || (c.phone ? 'tel:' + c.phone : ''));

--- a/src/components/trip/Flights.tsx
+++ b/src/components/trip/Flights.tsx
@@ -36,36 +36,36 @@ export default function Flights({ data }: FlightsProps) {
         data.segments.map((seg, i) => {
           const isReturn = seg.label && seg.label.indexOf('回') >= 0;
           return (
-            <div key={i} className="flight-row">
-              <span className="flight-icon">
+            <div key={i} className="flex items-center p-3 rounded-md gap-2">
+              <span className="text-title3 shrink-0 flex items-center">
                 {isReturn ? <Icon name="landing" /> : <Icon name="takeoff" />}
               </span>
-              <div className="flight-info">
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 flex-1 min-w-0">
                 {seg.label && (
-                  <span className="flight-label">{seg.label}</span>
+                  <span className="font-bold text-headline whitespace-nowrap">{seg.label}</span>
                 )}
                 {seg.flightNo && (
-                  <span className="flight-route">{seg.flightNo}</span>
+                  <span className="font-semibold text-title3 whitespace-nowrap">{seg.flightNo}</span>
                 )}
                 {seg.route && (
-                  <span className="flight-route">{seg.route}</span>
+                  <span className="font-semibold text-title3 whitespace-nowrap">{seg.route}</span>
                 )}
                 {seg.time && (
-                  <span className="flight-time">{seg.time}</span>
+                  <span className="text-callout text-muted whitespace-nowrap">{seg.time}</span>
                 )}
               </div>
             </div>
           );
         })}
       {data.airline && (
-        <div className="flight-row">
-          <span className="flight-icon">
+        <div className="flex items-center p-3 rounded-md gap-2">
+          <span className="text-title3 shrink-0 flex items-center">
             <Icon name="building" />
           </span>
-          <div className="flight-info">
-            <span className="flight-label">{data.airline.name || ''}</span>
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 flex-1 min-w-0">
+            <span className="font-bold text-headline whitespace-nowrap">{data.airline.name || ''}</span>
             {data.airline.note && (
-              <span className="flight-time">{data.airline.note}</span>
+              <span className="text-callout text-muted whitespace-nowrap">{data.airline.note}</span>
             )}
           </div>
         </div>

--- a/src/components/trip/Footer.tsx
+++ b/src/components/trip/Footer.tsx
@@ -16,7 +16,7 @@ interface FooterProps {
 
 export default function Footer({ footer }: FooterProps) {
   return (
-    <div className="trip-footer" id="footer-slot">
+    <div id="footer-slot">
       <footer>
         {footer.title && <h3>{footer.title}</h3>}
         {footer.dates && <p>{footer.dates}</p>}

--- a/src/components/trip/Hotel.tsx
+++ b/src/components/trip/Hotel.tsx
@@ -33,20 +33,20 @@ export const Hotel = memo(function Hotel({ hotel }: HotelProps) {
 
   return (
     <>
-      <div className="col-row cursor-pointer" onClick={toggle} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }} aria-expanded={open} aria-label={open ? '收合飯店詳情' : '展開飯店詳情'} role="button" tabIndex={0}>
+      <div className="flex items-center gap-2 py-2 px-3 -mx-3 select-none cursor-pointer rounded-sm transition-colors duration-fast ease-apple hover:bg-accent-bg" onClick={toggle} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }} aria-expanded={open} aria-label={open ? '收合飯店詳情' : '展開飯店詳情'} role="button" tabIndex={0}>
         <Icon name="hotel" /> {hotel.name}{' '}
-        <span className="arrow">{open ? ARROW_COLLAPSE : ARROW_EXPAND}</span>
+        <span className="ml-auto text-muted text-subheadline">{open ? ARROW_COLLAPSE : ARROW_EXPAND}</span>
       </div>
-      <div className={clsx('col-detail', open && 'open')}>
+      <div className={clsx('hidden print:block py-3 text-body leading-relaxed', open && '!block')}>
         {hotel.details && hotel.details.length > 0 && (
-          <div className="hotel-detail-grid">
+          <div className="flex flex-wrap gap-2 gap-x-4 mb-2">
             {hotel.details.map((d, i) => (
               <span key={i}>{d}</span>
             ))}
           </div>
         )}
         {hotel.breakfast && (
-          <div className="hotel-sub">
+          <div className="mt-2 py-1 pl-4">
             <Icon name="utensils" />{' '}
             {hotel.breakfast.included === true ? (
               <>
@@ -61,7 +61,7 @@ export const Hotel = memo(function Hotel({ hotel }: HotelProps) {
           </div>
         )}
         {hotel.checkout && (
-          <div className="hotel-sub">
+          <div className="mt-2 py-1 pl-4">
             <Icon name="clock" /> 退房 {hotel.checkout}
           </div>
         )}

--- a/src/components/trip/HourlyWeather.tsx
+++ b/src/components/trip/HourlyWeather.tsx
@@ -117,8 +117,8 @@ export default function HourlyWeather({
   /* ===== State A: more than 16 days away — no API call ===== */
   if (tooFarAway) {
     return (
-      <div className="hourly-weather" id={`hourly-${dayId}`}>
-        <div className="hw-summary">
+      <div className="py-3 overflow-hidden" id={`hourly-${dayId}`}>
+        <div className="flex justify-start items-center gap-2 py-2 px-3 -mx-3 text-subheadline text-muted select-none cursor-pointer rounded-sm transition-colors duration-fast ease-apple hover:text-accent hover:bg-hover">
           ☀️ 天氣預報將於出發前 16 天開放 &nbsp;&middot;&nbsp; {locs}
         </div>
       </div>
@@ -128,8 +128,8 @@ export default function HourlyWeather({
   /* --- Loading state --- */
   if (loading) {
     return (
-      <div className="hourly-weather" id={`hourly-${dayId}`}>
-        <div className="hw-loading">
+      <div className="py-3 overflow-hidden" id={`hourly-${dayId}`}>
+        <div className="text-center py-3 text-muted text-callout">
           <Icon name="hourglass" /> 正在載入逐時天氣預報...
         </div>
       </div>
@@ -139,8 +139,8 @@ export default function HourlyWeather({
   /* --- Error state --- */
   if (error) {
     return (
-      <div className="hourly-weather" id={`hourly-${dayId}`}>
-        <div className="hw-error">天氣資料載入失敗：{error}</div>
+      <div className="py-3 overflow-hidden" id={`hourly-${dayId}`}>
+        <div className="text-center py-3 text-foreground text-callout bg-accent-bg rounded-sm">天氣資料載入失敗：{error}</div>
       </div>
     );
   }
@@ -154,8 +154,8 @@ export default function HourlyWeather({
   /* ===== State B: within 16 days but API returned all-zero data ===== */
   if (!hasData) {
     return (
-      <div className="hourly-weather" id={`hourly-${dayId}`}>
-        <div className="hw-summary">
+      <div className="py-3 overflow-hidden" id={`hourly-${dayId}`}>
+        <div className="flex justify-start items-center gap-2 py-2 px-3 -mx-3 text-subheadline text-muted select-none cursor-pointer rounded-sm transition-colors duration-fast ease-apple hover:text-accent hover:bg-hover">
           ☁️ 超出預報範圍，暫無資料 &nbsp;&middot;&nbsp; {locs}
         </div>
       </div>
@@ -195,12 +195,12 @@ export default function HourlyWeather({
   /* --- Render State C --- */
   return (
     <div
-      className={clsx('hourly-weather', isOpen && 'hw-open')}
+      className="py-3 overflow-hidden"
       id={`hourly-${dayId}`}
     >
       {/* Summary row (clickable) */}
       <div
-        className="hw-summary"
+        className="flex justify-start items-center gap-2 py-2 px-3 -mx-3 text-subheadline text-muted select-none cursor-pointer rounded-sm transition-colors duration-fast ease-apple hover:text-accent hover:bg-hover focus-visible:outline-none focus-visible:shadow-ring focus-visible:rounded-xs"
         data-action="toggle-hw"
         role="button"
         tabIndex={0}
@@ -215,22 +215,22 @@ export default function HourlyWeather({
         <Icon name="raindrop" />
         {minR}~{maxR}%{' '}
         &nbsp;&middot;&nbsp; {locs}
-        <span className="hw-summary-arrow">
+        <span className="ml-auto shrink-0 font-bold text-subheadline text-muted">
           {isOpen ? ARROW_COLLAPSE : ARROW_EXPAND}
         </span>
       </div>
 
       {/* Detail panel */}
-      <div className="hw-detail">
-        <div className="hourly-weather-header">
-          <span className="hourly-weather-title">
+      <div className={isOpen ? 'block' : 'hidden'}>
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-subheadline font-semibold text-muted">
             <Icon name="timer" /> 7日內預報 &mdash; {weatherDay.label}
           </span>
-          <span className="hw-update-time">
+          <span className="text-subheadline text-muted">
             {currentHour}:{String(now.getMinutes()).padStart(2, '0')}
           </span>
         </div>
-        <div className="hw-grid" ref={gridRef}>
+        <div className="flex gap-2 overflow-x-auto pt-1 pb-1 scroll-smooth" ref={gridRef}>
           {Array.from({ length: 24 }, (_, h) => {
             const wIcon = WMO[data.codes[h]] || 'question';
             const temp = Math.round(data.temps[h]);
@@ -240,19 +240,25 @@ export default function HourlyWeather({
             return (
               <div
                 key={h}
-                className={clsx('hw-block', isNow && 'hw-now')}
+                className={clsx(
+                  'bg-background rounded-sm py-2 px-1 text-center min-w-[52px] shrink-0',
+                  isNow && 'bg-accent-bg shadow-ring',
+                )}
                 data-hour={h}
               >
-                <div className="hw-block-time">
+                <div className="text-subheadline font-semibold text-muted mb-1">
                   {isNow ? '\u25B6 ' : ''}
                   {h}:00
                 </div>
-                <div className="hw-block-icon-temp">
+                <div className="flex items-center justify-center gap-1 text-callout font-bold text-foreground leading-tight">
                   <Icon name={wIcon} />
                   <span>{temp}&deg;</span>
                 </div>
                 <div
-                  className={clsx('hw-block-rain', rain >= 50 && 'hw-rain-high')}
+                  className={clsx(
+                    'text-callout text-accent',
+                    rain >= 50 && 'text-foreground font-bold bg-info-bg rounded-xs px-1',
+                  )}
                 >
                   {rain}%
                 </div>

--- a/src/components/trip/InfoBox.tsx
+++ b/src/components/trip/InfoBox.tsx
@@ -72,8 +72,8 @@ export interface InfoBoxData {
 // ---------------------------------------------------------------------------
 
 function gridClass(count: number): string {
-  if (count === 1) return 'info-box-grid grid-1';
-  return count % 2 === 0 ? 'info-box-grid grid-even' : 'info-box-grid grid-odd';
+  if (count === 1) return 'flex flex-col md:grid md:grid-cols-1 md:gap-2';
+  return count % 2 === 0 ? 'flex flex-col md:grid md:grid-cols-2 md:gap-2' : 'flex flex-col md:grid md:grid-cols-3 md:gap-2';
 }
 
 // ---------------------------------------------------------------------------
@@ -82,8 +82,8 @@ function gridClass(count: number): string {
 
 function ReservationBox({ box }: { box: InfoBoxData }) {
   return (
-    <div className="info-box reservation">
-      {box.title && <><strong>{box.title}</strong><br /></>}
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
+      {box.title && <><strong className="font-semibold">{box.title}</strong><br /></>}
       {box.items && box.items.length > 0 &&
         box.items.filter((item): item is string => typeof item === 'string').map((item, i) => (
           <span key={i}>{item}<br /></span>
@@ -96,16 +96,16 @@ function ReservationBox({ box }: { box: InfoBoxData }) {
 
 function ParkingBox({ box }: { box: InfoBoxData }) {
   return (
-    <div className="info-box parking">
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
       <div>
         {box.title && (
-          <><Icon name="parking" /> <strong>{box.title}</strong></>
+          <><Icon name="parking" /> <strong className="font-semibold">{box.title}</strong></>
         )}
         {box.price && <>：{box.price}</>}
         {box.location && <>{' '}<MapLinks location={box.location} inline /></>}
       </div>
       {box.note && (
-        <div className="parking-note">{box.note}</div>
+        <div className="mt-2 text-footnote text-muted leading-relaxed">{box.note}</div>
       )}
     </div>
   );
@@ -115,15 +115,15 @@ function SouvenirBox({ box }: { box: InfoBoxData }) {
   // items here are SouvenirItem objects (not strings)
   const items = (box.items ?? []).filter((item): item is SouvenirItem => typeof item === 'object' && item !== null);
   return (
-    <div className="info-box souvenir">
-      {box.title && <><Icon name="gift" /> <strong>{box.title}</strong><br /></>}
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
+      {box.title && <><Icon name="gift" /> <strong className="font-semibold">{box.title}</strong><br /></>}
       {items.map((item, i) => {
         const itemUrl = escUrl(item.url);
         return (
           <span key={i}>
             <Icon name="gift" />{' '}
             {itemUrl ? (
-              <a href={itemUrl} target="_blank" rel="noopener noreferrer">{item.name}</a>
+              <a href={itemUrl} target="_blank" rel="noopener noreferrer" className="text-foreground font-semibold underline">{item.name}</a>
             ) : (
               item.name
             )}
@@ -141,8 +141,8 @@ function RestaurantsBox({ box }: { box: InfoBoxData }) {
   const rItems = box.restaurants ?? [];
   const rTitle = box.title || (rItems.length > 1 ? `${rItems.length}選一` : '推薦餐廳');
   return (
-    <div className="info-box restaurants">
-      <Icon name="utensils" /> <strong>{rTitle}：</strong>
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
+      <Icon name="utensils" /> <strong className="font-semibold">{rTitle}：</strong>
       <div className={gridClass(rItems.length)}>
         {rItems.map((r, i) => (
           <Restaurant key={i} restaurant={r} />
@@ -156,8 +156,8 @@ function ShoppingBox({ box }: { box: InfoBoxData }) {
   const sItems = box.shops ?? [];
   const sTitle = box.title || (sItems.length > 1 ? '推薦購物' : '附近購物');
   return (
-    <div className="info-box shopping">
-      <Icon name="shopping" /> <strong>{sTitle}：</strong>
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
+      <Icon name="shopping" /> <strong className="font-semibold">{sTitle}：</strong>
       <div className={gridClass(sItems.length)}>
         {sItems.map((s, i) => (
           <Shop key={i} shop={s} />
@@ -171,14 +171,14 @@ function GasStationBox({ box }: { box: InfoBoxData }) {
   const gsTitle = box.title || '加油站';
   const st = box.station;
   return (
-    <div className="info-box gas-station">
-      <Icon name="gas-station" /> <strong>{gsTitle}</strong>
+    <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
+      <Icon name="gas-station" /> <strong className="font-semibold">{gsTitle}</strong>
       {typeof box.googleRating === 'number' && (
-        <>{' '}<span className="rating">★ {box.googleRating.toFixed(1)}</span></>
+        <>{' '}<span className="text-accent text-caption shrink-0">★ {box.googleRating.toFixed(1)}</span></>
       )}
       {st && (
-        <div className="gas-station-detail">
-          <strong>{st.name}</strong><br />
+        <div className="mt-2">
+          <strong className="font-semibold">{st.name}</strong><br />
           {st.address && <>{st.address}<br /></>}
           {st.hours && <><Icon name="clock" /> {st.hours}<br /></>}
           {st.service && <>{st.service}<br /></>}
@@ -214,7 +214,7 @@ export const InfoBox = memo(function InfoBox({ box }: InfoBoxProps) {
       return <GasStationBox box={box} />;
     default:
       if (box.content) {
-        return <div className="info-box">{box.content}</div>;
+        return <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed">{box.content}</div>;
       }
       return null;
   }

--- a/src/components/trip/InfoPanel.tsx
+++ b/src/components/trip/InfoPanel.tsx
@@ -34,8 +34,8 @@ export default function InfoPanel({
       )}
       {/* Hotel info card */}
       {currentDay?.hotel && (
-        <div className="info-card hotel-summary-card">
-          <div className="info-label"><Icon name="hotel" /> 今日住宿</div>
+        <div className="hotel-summary-card bg-secondary rounded-md p-4 mb-3">
+          <div className="font-bold text-title3 mb-3"><Icon name="hotel" /> 今日住宿</div>
           <div className="hotel-summary-name">{currentDay.hotel.name}</div>
           {currentDay.hotel.checkout && (
             <div className="hotel-summary-checkout">
@@ -46,8 +46,8 @@ export default function InfoPanel({
       )}
       {/* Day transport summary card */}
       {dayTransport && (
-        <div className="info-card transport-summary-card">
-          <div className="info-label"><Icon name="bus" /> 當日交通</div>
+        <div className="transport-summary-card bg-secondary rounded-md p-4 mb-3">
+          <div className="font-bold text-title3 mb-3"><Icon name="bus" /> 當日交通</div>
           {TRANSPORT_TYPE_ORDER.map((key) => {
             const g = dayTransport.byType[key];
             if (!g) return null;

--- a/src/components/trip/InfoSheet.tsx
+++ b/src/components/trip/InfoSheet.tsx
@@ -292,8 +292,8 @@ export default function InfoSheet({
       <style>{SCOPED_STYLES}</style>
       <div
         className={clsx(
-          'fixed inset-0 bg-overlay opacity-0 pointer-events-none transition-opacity',
-          open && 'opacity-100 pointer-events-auto',
+          'fixed inset-0 bg-overlay transition-opacity',
+          open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
         )}
         style={{ zIndex: 'var(--z-info-sheet-backdrop)', transitionDuration: 'var(--transition-duration-slow)', transitionTimingFunction: 'var(--transition-timing-function-apple)' }}
         id="infoBottomSheet"

--- a/src/components/trip/InfoSheet.tsx
+++ b/src/components/trip/InfoSheet.tsx
@@ -335,8 +335,7 @@ export default function InfoSheet({
           {/* Drag handle (decorative only) */}
           <div
             data-sheet-handle
-            className="w-10 rounded-sm mx-auto mt-3 mb-1"
-            style={{ height: 0, paddingTop: '8px', paddingBottom: '8px', borderTop: '4px solid var(--color-muted)' }}
+            className="w-10 h-1 rounded-full bg-muted mx-auto mt-3 mb-1"
           />
 
           {/* Header */}

--- a/src/components/trip/InfoSheet.tsx
+++ b/src/components/trip/InfoSheet.tsx
@@ -3,6 +3,38 @@ import clsx from 'clsx';
 import Icon from '../shared/Icon';
 import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 
+/* ===== Scoped styles (dark mode + focus management) ===== */
+
+const SCOPED_STYLES = `
+body.dark [data-info-sheet-panel] {
+  background: color-mix(in srgb, var(--color-secondary) 95%, var(--color-accent) 5%);
+  box-shadow: 0 -1px 0 rgba(255,255,255,0.06), 0 -8px 30px rgba(0,0,0,0.5);
+}
+[data-info-sheet-panel] :focus:not(:focus-visible) { outline: none; box-shadow: none; }
+[data-info-sheet-panel]:focus { outline: none; box-shadow: none; }
+@media (max-width: 767px) {
+  [data-info-sheet-panel] { height: 50vh; min-height: 280px; }
+  @supports (height: 1dvh) { [data-info-sheet-panel] { height: 50dvh; } }
+  [data-info-sheet-panel].detent-full { height: 100vh; }
+  @supports (height: 1dvh) { [data-info-sheet-panel].detent-full { height: 100dvh; } }
+  [data-info-sheet-panel] {
+    transition: transform var(--transition-duration-slow) var(--transition-timing-function-apple),
+                height var(--transition-duration-slow) var(--transition-timing-function-apple);
+  }
+  [data-info-sheet-panel] [data-sheet-close-btn] {
+    position: absolute;
+    width: 1px; height: 1px; overflow: hidden;
+    clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; padding: 0;
+  }
+  [data-info-sheet-panel]:not(.detent-full) [data-info-sheet-body]::after {
+    content: '';
+    position: sticky; bottom: 0; display: block; height: 24px;
+    background: linear-gradient(transparent, var(--color-secondary));
+    pointer-events: none;
+  }
+}
+`;
+
 /* ===== Props ===== */
 
 interface InfoSheetProps {
@@ -18,7 +50,7 @@ interface InfoSheetProps {
 
 /* ===== Constants ===== */
 
-/** Mobile breakpoint — keep in sync with @media (max-width: 767px) in css/style.css */
+/** Mobile breakpoint — keep in sync with @media (max-width: 767px) in SCOPED_STYLES */
 const MOBILE_BREAKPOINT = 768;
 
 /** Selectors for focusable elements inside the panel. */
@@ -118,7 +150,7 @@ export default function InfoSheet({
 
     // 8-3: passive: false so subsequent touchmove preventDefault works in Chrome
     const onTouchStart = (e: TouchEvent) => {
-      const handle = panel.querySelector('.sheet-handle');
+      const handle = panel.querySelector('[data-sheet-handle]');
       const isOnHandle = handle?.contains(e.target as Node);
       const isAtTop = body.scrollTop <= 0;
       const d = detentRef.current;
@@ -256,54 +288,94 @@ export default function InfoSheet({
   }, []);
 
   return (
-    <div
-      className={clsx('info-sheet-backdrop', open && 'open')}
-      id="infoBottomSheet"
-      ref={backdropRef}
-      onClick={handleClose}
-      style={{ overscrollBehavior: 'contain' }}
-    >
+    <>
+      <style>{SCOPED_STYLES}</style>
       <div
-        className={clsx('info-sheet-panel', detent === 'full' && 'detent-full')}
-        id="infoSheet"
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="sheet-title"
-        tabIndex={-1}
-        onClick={handlePanelClick}
-        onKeyDown={handlePanelKeyDown}
+        className={clsx(
+          'fixed inset-0 bg-overlay opacity-0 pointer-events-none transition-opacity',
+          open && 'opacity-100 pointer-events-auto',
+        )}
+        style={{ zIndex: 'var(--z-info-sheet-backdrop)', transitionDuration: 'var(--transition-duration-slow)', transitionTimingFunction: 'var(--transition-timing-function-apple)' }}
+        id="infoBottomSheet"
+        ref={backdropRef}
+        onClick={handleClose}
       >
-        {/* Drag handle (decorative only) */}
-        <div className="sheet-handle" />
-
-        {/* Header */}
-        <div className="sheet-header">
-          <div className="sheet-header-spacer" />
-          <span className="sheet-title" id="sheet-title">
-            {title}
-          </span>
-          <button
-            className="sheet-close-btn"
-            id="sheetCloseBtn"
-            aria-label="關閉"
-            ref={closeBtnRef}
-            onClick={handleClose}
-          >
-            <Icon name="x-mark" />
-          </button>
-        </div>
-
-        {/* Body */}
         <div
-          className="info-sheet-body"
-          id="bottomSheetBody"
-          ref={bodyRef}
-          onWheel={handleBodyWheel}
+          className={clsx(detent === 'full' && 'detent-full')}
+          data-info-sheet-panel
+          id="infoSheet"
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="sheet-title"
+          tabIndex={-1}
+          onClick={handlePanelClick}
+          onKeyDown={handlePanelKeyDown}
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '92vh',
+            background: 'color-mix(in srgb, var(--color-secondary) 88%, transparent)',
+            WebkitBackdropFilter: 'saturate(180%) blur(28px)',
+            backdropFilter: 'saturate(180%) blur(28px)',
+            borderRadius: 'var(--radius-lg) var(--radius-lg) 0 0',
+            zIndex: 'var(--z-info-sheet)',
+            transform: open ? 'translateY(0)' : 'translateY(100%)',
+            transition: open
+              ? 'transform var(--duration-sheet-open) var(--ease-spring)'
+              : 'transform var(--duration-sheet-close) var(--ease-sheet-close)',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '12px var(--spacing-padding-h) max(24px, env(safe-area-inset-bottom))',
+            overscrollBehavior: 'contain',
+          }}
         >
-          {children}
+          {/* Drag handle (decorative only) */}
+          <div
+            data-sheet-handle
+            className="w-10 rounded-sm mx-auto mt-3 mb-1"
+            style={{ height: 0, paddingTop: '8px', paddingBottom: '8px', borderTop: '4px solid var(--color-muted)' }}
+          />
+
+          {/* Header */}
+          <div
+            className="grid items-center mb-2"
+            style={{ gridTemplateColumns: 'var(--spacing-tap-min) 1fr var(--spacing-tap-min)' }}
+          >
+            <div className="w-tap-min shrink-0" />
+            <span
+              className="flex-1 min-w-0 text-title3 font-bold text-foreground text-center overflow-hidden text-ellipsis whitespace-nowrap"
+              id="sheet-title"
+            >
+              {title}
+            </span>
+            <button
+              data-sheet-close-btn
+              className="flex items-center justify-center w-tap-min h-tap-min border-none rounded-full bg-transparent text-foreground shrink-0 transition-colors duration-fast hover:text-accent hover:bg-accent-bg focus:outline-none"
+              id="sheetCloseBtn"
+              aria-label="關閉"
+              ref={closeBtnRef}
+              onClick={handleClose}
+            >
+              <Icon name="x-mark" />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div
+            data-info-sheet-body
+            className="overflow-y-auto text-body flex-1 min-h-0"
+            style={{ overscrollBehavior: 'contain', touchAction: 'pan-y' }}
+            id="bottomSheetBody"
+            ref={bodyRef}
+            onWheel={handleBodyWheel}
+          >
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/trip/MapLinks.tsx
+++ b/src/components/trip/MapLinks.tsx
@@ -52,31 +52,38 @@ function resolveAppleUrl(loc: MapLocation): string {
 }
 
 export const MapLinks = memo(function MapLinks({ location: loc, inline = false }: MapLinksProps) {
-  const cls = clsx('map-link', inline && 'map-link-inline');
+  const baseCls = clsx(
+    'inline-flex items-center gap-1 bg-transparent text-accent py-2 px-3 rounded-sm text-callout no-underline mr-1 mb-1 min-h-tap-min align-middle transition-colors duration-fast ease-apple hover:bg-hover hover:text-foreground',
+    inline && 'text-callout py-2 px-2 min-h-tap-min',
+  );
   const googleUrl = resolveGoogleUrl(loc);
   const appleUrl = resolveAppleUrl(loc);
   const naverUrl = escUrl(loc.naverQuery || '');
   const showNaver = naverUrl && /^https?:/i.test(naverUrl);
 
+  const iconSizeCls = inline ? 'w-4 h-4' : 'w-5 h-5';
+  const appleIconSizeCls = inline ? 'w-3 h-3' : 'w-4 h-4';
+
   return (
     <>
-      <a href={googleUrl} target="_blank" rel="noopener noreferrer" className={cls}>
-        <span className="g-icon">G</span> Map
+      <a href={googleUrl} target="_blank" rel="noopener noreferrer" className={baseCls}>
+        <span className={clsx('inline-flex items-center justify-center rounded-full bg-[var(--color-google-maps)] text-accent-foreground text-footnote font-bold leading-none shrink-0', iconSizeCls)} style={{ fontFamily: "'Google Sans', Arial, sans-serif" }}>G</span> Map
       </a>
-      <a href={appleUrl} target="_blank" rel="noopener noreferrer" className={clsx(cls, 'apple')}>
+      <a href={appleUrl} target="_blank" rel="noopener noreferrer" className={clsx(baseCls, 'text-foreground hover:bg-hover hover:text-foreground')}>
         <span
-          className="apple-icon"
+          className={clsx('inline-flex items-center shrink-0', appleIconSizeCls)}
           dangerouslySetInnerHTML={{ __html: APPLE_SVG }}
+          style={{ width: inline ? 12 : 16, height: inline ? 12 : 16 }}
         />
         {' '}Map
       </a>
       {showNaver && (
-        <a href={naverUrl} target="_blank" rel="noopener noreferrer" className={clsx(cls, 'naver')}>
-          <span className="n-icon">N</span> N Map
+        <a href={naverUrl} target="_blank" rel="noopener noreferrer" className={clsx(baseCls, 'text-foreground hover:bg-hover hover:text-foreground')}>
+          <span className={clsx('inline-flex items-center justify-center rounded-full bg-[var(--color-naver-maps)] text-accent-foreground text-footnote font-bold leading-none shrink-0', iconSizeCls)} style={{ fontFamily: "'Google Sans', Arial, sans-serif" }}>N</span> N Map
         </a>
       )}
       {loc.mapcode && (
-        <span className={clsx(cls, 'mapcode')}>
+        <span className={clsx(baseCls, 'text-accent hover:bg-hover hover:text-foreground')}>
           <Icon name="device" /> {loc.mapcode}
         </span>
       )}
@@ -99,7 +106,7 @@ interface NavLinksProps {
 export const NavLinks = memo(function NavLinks({ locations }: NavLinksProps) {
   if (!locations || locations.length === 0) return null;
   return (
-    <div className="nav-links">
+    <div className="my-2">
       {locations.map((loc, i) => (
         <span key={i}>
           {loc.label && <strong>{loc.label}：</strong>}

--- a/src/components/trip/MapMarker.tsx
+++ b/src/components/trip/MapMarker.tsx
@@ -38,13 +38,13 @@ function InfoWindowCard({ pin, onScrollToEntry, onClose }: InfoWindowCardProps) 
 
   return (
     <div
-      className="map-info-window"
+      className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 w-[200px] bg-secondary rounded-sm shadow-md p-3 z-10"
       role="dialog"
       aria-label={`${label}：${pin.title ?? ''}`}
     >
       {/* 關閉按鈕 */}
       <button
-        className="map-info-close"
+        className="absolute top-2 right-2 bg-transparent text-muted text-caption cursor-pointer w-6 h-6 flex items-center justify-center rounded-full transition-colors duration-fast ease-apple hover:bg-tertiary hover:text-foreground"
         type="button"
         aria-label="關閉"
         onClick={onClose}
@@ -53,23 +53,23 @@ function InfoWindowCard({ pin, onScrollToEntry, onClose }: InfoWindowCardProps) 
       </button>
 
       {/* 編號 + 名稱 */}
-      <div className="map-info-label">{label}</div>
-      <div className="map-info-title">{pin.title}</div>
+      <div className="text-caption text-muted mb-1 pr-6">{label}</div>
+      <div className="text-headline font-semibold text-foreground mb-1 break-words">{pin.title}</div>
 
       {/* 時間（entry only）*/}
       {!isHotel && pin.time && (
-        <div className="map-info-time">{pin.time}</div>
+        <div className="text-footnote text-muted mb-1">{pin.time}</div>
       )}
 
       {/* 評分（entry only）*/}
       {!isHotel && typeof pin.googleRating === 'number' && (
-        <div className="map-info-rating">★ {pin.googleRating.toFixed(1)}</div>
+        <div className="text-footnote text-muted mb-2">★ {pin.googleRating.toFixed(1)}</div>
       )}
 
       {/* 滾到此處按鈕（entry only）*/}
       {!isHotel && (
         <button
-          className="map-info-scroll-btn"
+          className="flex items-center justify-center w-full min-h-tap-min py-2 px-3 bg-accent text-accent-foreground rounded-sm text-footnote font-semibold cursor-pointer transition-opacity duration-fast ease-apple hover:opacity-85"
           type="button"
           aria-label={`在時間軸中查看 ${pin.title ?? ''}`}
           onClick={onScrollToEntry}
@@ -110,7 +110,7 @@ function MarkerDot({ pin, isSelected, onClick, onScrollToEntry, onCloseInfo, sho
   }, [onClick, onCloseInfo, showInfo]);
 
   return (
-    <div className="map-marker-wrap">
+    <div className="relative inline-block">
       {/* Marker circle */}
       <div
         role="button"
@@ -118,11 +118,11 @@ function MarkerDot({ pin, isSelected, onClick, onScrollToEntry, onCloseInfo, sho
         aria-label={ariaLabel}
         aria-expanded={showInfo}
         aria-haspopup="dialog"
-        className={`map-marker-dot${isSelected ? ' map-marker-dot--selected' : ''}`}
+        className={`flex items-center justify-center rounded-full bg-accent text-accent-foreground text-caption font-bold cursor-pointer select-none transition-[width,height,box-shadow] duration-fast ease-apple min-w-[var(--spacing-tap-min)] min-h-[var(--spacing-tap-min)] focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[3px] ${isSelected ? 'w-10 h-10 shadow-lg outline-2 outline-accent-foreground outline-offset-0' : 'w-8 h-8'}`}
         onClick={onClick}
         onKeyDown={handleKeyDown}
       >
-        {isHotel ? '🏨' : <span className="map-marker-num">{pin.index}</span>}
+        {isHotel ? '🏨' : <span className="text-caption font-bold leading-none text-accent-foreground pointer-events-none">{pin.index}</span>}
       </div>
 
       {/* InfoWindow */}

--- a/src/components/trip/MapRoute.tsx
+++ b/src/components/trip/MapRoute.tsx
@@ -127,7 +127,7 @@ export function createTravelLabelOverlay(
 
     override onAdd() {
       this.div = document.createElement('div');
-      this.div.className = 'map-route-label';
+      this.div.className = 'absolute -translate-x-1/2 -translate-y-1/2 bg-secondary text-muted text-caption py-1 px-2 rounded-xs shadow-sm whitespace-nowrap pointer-events-none select-none';
       this.div.textContent = this.labelText;
       this.div.setAttribute('aria-hidden', 'true');
 

--- a/src/components/trip/QuickPanel.tsx
+++ b/src/components/trip/QuickPanel.tsx
@@ -212,8 +212,8 @@ export default function QuickPanel({
         {/* Backdrop */}
         <div
           className={clsx(
-            'fixed inset-0 bg-overlay opacity-0 pointer-events-none transition-opacity',
-            isOpen && 'opacity-100 pointer-events-auto',
+            'fixed inset-0 bg-overlay transition-opacity',
+            isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
           )}
           style={{
             zIndex: 'calc(var(--z-quick-panel) - 1)',

--- a/src/components/trip/QuickPanel.tsx
+++ b/src/components/trip/QuickPanel.tsx
@@ -254,8 +254,7 @@ export default function QuickPanel({
         >
           {/* Drag handle — swipe-up affordance */}
           <div
-            className="w-10 rounded-sm mx-auto mt-3"
-            style={{ height: '4px', background: 'var(--color-muted)' }}
+            className="w-10 h-1 rounded-full bg-muted mx-auto mt-3"
             aria-hidden="true"
           />
           {/* X close button (same style as InfoSheet) */}

--- a/src/components/trip/QuickPanel.tsx
+++ b/src/components/trip/QuickPanel.tsx
@@ -3,6 +3,33 @@ import clsx from 'clsx';
 import Icon from '../shared/Icon';
 import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 
+/* ===== Scoped styles (dark mode + focus management + print) ===== */
+
+const SCOPED_STYLES = `
+body.dark [data-qp-item] {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 1px 0 rgba(255,255,255,0.04) inset;
+}
+body.dark [data-qp-trigger] {
+  box-shadow: 0 0 20px color-mix(in srgb, var(--color-accent) 30%, transparent),
+              0 2px 8px rgba(0,0,0,0.4);
+}
+body.dark [data-qp-sheet] {
+  box-shadow: 0 -1px 0 rgba(255,255,255,0.06),
+              0 -8px 30px rgba(0,0,0,0.5);
+}
+[data-qp-sheet] :focus:not(:focus-visible) { outline: none; box-shadow: none; }
+[data-qp-sheet]:focus { outline: none; box-shadow: none; }
+.print-mode [data-qp-root], .print-mode [data-qp-trigger] { display: none !important; }
+@media print { [data-qp-root], [data-qp-trigger] { display: none !important; } }
+@media (max-width: 390px) {
+  [data-qp-item-bottom] { padding: var(--spacing-1) var(--spacing-half); font-size: var(--font-size-caption2); }
+}
+@media (max-width: 350px) {
+  [data-qp-grid] { grid-template-columns: repeat(2, 1fr); }
+  [data-qp-grid-bottom] { grid-template-columns: repeat(3, 1fr); }
+}
+`;
+
 /* ===== Panel item config ===== */
 
 type PanelAction = 'sheet' | 'print' | 'download';
@@ -179,108 +206,185 @@ export default function QuickPanel({
   const sectionC = PANEL_ITEMS.filter((i) => i.section === 'C');
 
   return (
-    <div className={clsx('quick-panel', isOpen && 'open')} id="quickPanel">
-      {/* Backdrop */}
-      <div
-        className="quick-panel-backdrop"
-        role="presentation"
-        aria-hidden="true"
-        ref={backdropRef}
-        onClick={handleClose}
-        style={{ touchAction: 'none', overscrollBehavior: 'contain' }}
-      />
+    <>
+      <style>{SCOPED_STYLES}</style>
+      <div data-qp-root id="quickPanel">
+        {/* Backdrop */}
+        <div
+          className={clsx(
+            'fixed inset-0 bg-overlay opacity-0 pointer-events-none transition-opacity',
+            isOpen && 'opacity-100 pointer-events-auto',
+          )}
+          style={{
+            zIndex: 'calc(var(--z-quick-panel) - 1)',
+            overscrollBehavior: 'none',
+            transitionDuration: 'var(--transition-duration-normal)',
+            transitionTimingFunction: 'var(--transition-timing-function-apple)',
+          }}
+          role="presentation"
+          aria-hidden="true"
+          ref={backdropRef}
+          onClick={handleClose}
+        />
 
-      {/* Sheet */}
-      <div
-        className="quick-panel-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label="快速選單"
-        ref={sheetRef}
-        tabIndex={-1}
-        onKeyDown={handleSheetKeyDown}
-      >
-        {/* Drag handle — swipe-up affordance */}
-        <div className="quick-panel-handle" aria-hidden="true" />
-        {/* X close button (same style as InfoSheet) */}
-        <div className="quick-panel-header">
-          <div className="quick-panel-header-spacer" />
-          <button
-            className="sheet-close-btn"
-            aria-label="關閉"
-            ref={closeBtnRef}
-            onClick={handleClose}
+        {/* Sheet */}
+        <div
+          data-qp-sheet
+          className="fixed bottom-0 left-0 right-0 overflow-y-auto"
+          style={{
+            background: 'color-mix(in srgb, var(--color-secondary) 88%, transparent)',
+            WebkitBackdropFilter: 'saturate(180%) blur(28px)',
+            backdropFilter: 'saturate(180%) blur(28px)',
+            borderRadius: 'var(--radius-lg) var(--radius-lg) 0 0',
+            padding: 'var(--spacing-3) var(--spacing-4) calc(var(--spacing-4) + env(safe-area-inset-bottom))',
+            transform: isOpen ? 'translateY(0)' : 'translateY(100%)',
+            transition: isOpen
+              ? 'transform var(--duration-sheet-open) var(--ease-spring)'
+              : 'transform var(--duration-sheet-close) var(--ease-sheet-close)',
+            zIndex: 'var(--z-quick-panel)',
+            maxHeight: '85vh',
+            touchAction: 'none',
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="快速選單"
+          ref={sheetRef}
+          tabIndex={-1}
+          onKeyDown={handleSheetKeyDown}
+        >
+          {/* Drag handle — swipe-up affordance */}
+          <div
+            className="w-10 rounded-sm mx-auto mt-3"
+            style={{ height: '4px', background: 'var(--color-muted)' }}
+            aria-hidden="true"
+          />
+          {/* X close button (same style as InfoSheet) */}
+          <div className="flex items-center justify-end mb-1">
+            <div className="flex-1" />
+            <button
+              className="flex items-center justify-center w-tap-min h-tap-min border-none rounded-full bg-transparent text-foreground shrink-0 transition-colors duration-fast hover:text-accent hover:bg-accent-bg focus:outline-none"
+              aria-label="關閉"
+              ref={closeBtnRef}
+              onClick={handleClose}
+            >
+              <Icon name="x-mark" />
+            </button>
+          </div>
+          <div>
+            <div
+              data-qp-grid
+              className="grid gap-2"
+              style={{ gridTemplateColumns: 'repeat(3, 1fr)' }}
+            >
+              {sectionA.map((item) => {
+                const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
+                return (
+                  <button
+                    key={item.key}
+                    data-qp-item
+                    className={clsx(
+                      'flex flex-col items-center justify-center gap-1 min-h-tap-min border-none bg-background text-foreground cursor-pointer rounded-sm shadow-md p-3 font-inherit text-footnote transition-colors duration-fast',
+                      'active:bg-hover',
+                      isDisabled && 'opacity-50 cursor-not-allowed',
+                    )}
+                    data-content={item.key}
+                    disabled={isDisabled}
+                    onClick={() => handleItemClick(item)}
+                  >
+                    <Icon name={item.icon} />
+                    <span className="text-footnote text-foreground leading-none">{item.label}</span>
+                  </button>
+                );
+              })}
+              {sectionB.map((item) => {
+                const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
+                return (
+                  <button
+                    key={item.key}
+                    data-qp-item
+                    className={clsx(
+                      'flex flex-col items-center justify-center gap-1 min-h-tap-min border-none bg-background text-foreground cursor-pointer rounded-sm shadow-md p-3 font-inherit text-footnote transition-colors duration-fast',
+                      'active:bg-hover',
+                      isDisabled && 'opacity-50 cursor-not-allowed',
+                    )}
+                    data-content={item.key}
+                    disabled={isDisabled}
+                    onClick={() => handleItemClick(item)}
+                  >
+                    <Icon name={item.icon} />
+                    <span className="text-footnote text-foreground leading-none">{item.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <div className="my-3" />
+            <div
+              data-qp-grid-bottom
+              className="grid gap-2"
+              style={{ gridTemplateColumns: 'repeat(5, 1fr)' }}
+            >
+              {sectionC.map((item) => {
+                const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
+                return (
+                  <button
+                    key={item.key}
+                    data-qp-item
+                    data-qp-item-bottom
+                    className={clsx(
+                      'flex flex-col items-center justify-center gap-1 min-h-tap-min border-none bg-tertiary text-muted cursor-pointer rounded-sm shadow-md p-3 font-inherit text-footnote transition-colors duration-fast',
+                      'active:bg-hover',
+                      isDisabled && 'opacity-50 cursor-not-allowed',
+                    )}
+                    data-content={item.key}
+                    disabled={isDisabled}
+                    onClick={() => handleItemClick(item)}
+                  >
+                    <Icon name={item.icon} />
+                    <span className="text-footnote text-muted leading-none">{item.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* FAB trigger */}
+        <button
+          data-qp-trigger
+          className={clsx(
+            'fixed flex items-center justify-center rounded-full bg-accent text-accent-foreground border-none shadow-md',
+            isOpen && 'opacity-0 pointer-events-none scale-80',
+          )}
+          style={{
+            bottom: 'max(88px, calc(68px + env(safe-area-inset-bottom)))',
+            right: 'var(--spacing-5)',
+            width: 'var(--fab-size)',
+            height: 'var(--fab-size)',
+            zIndex: 'var(--z-quick-panel)',
+            transition: isOpen
+              ? 'opacity var(--transition-duration-fast), transform var(--transition-duration-fast)'
+              : 'transform var(--transition-duration-normal) var(--transition-timing-function-apple)',
+          }}
+          aria-label="快速選單"
+          aria-expanded={isOpen}
+          ref={triggerRef}
+          onClick={handleToggle}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-7 h-7 transition-transform"
+            style={{
+              transitionDuration: 'var(--transition-duration-normal)',
+              transitionTimingFunction: 'var(--transition-timing-function-apple)',
+              transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+            }}
           >
-            <Icon name="x-mark" />
-          </button>
-        </div>
-        <div className="quick-panel-grid-container">
-          <div className="quick-panel-grid">
-            {sectionA.map((item) => {
-              const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
-              return (
-                <button
-                  key={item.key}
-                  className={clsx('quick-panel-item', isDisabled && 'disabled')}
-                  data-content={item.key}
-                  disabled={isDisabled}
-                  onClick={() => handleItemClick(item)}
-                >
-                  <Icon name={item.icon} />
-                  <span className="quick-panel-label">{item.label}</span>
-                </button>
-              );
-            })}
-            {sectionB.map((item) => {
-              const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
-              return (
-                <button
-                  key={item.key}
-                  className={clsx('quick-panel-item', isDisabled && 'disabled')}
-                  data-content={item.key}
-                  disabled={isDisabled}
-                  onClick={() => handleItemClick(item)}
-                >
-                  <Icon name={item.icon} />
-                  <span className="quick-panel-label">{item.label}</span>
-                </button>
-              );
-            })}
-          </div>
-          <div className="quick-panel-divider" />
-          <div className="quick-panel-grid-bottom">
-            {sectionC.map((item) => {
-              const isDisabled = !isOnline && WRITE_KEYS.has(item.key);
-              return (
-                <button
-                  key={item.key}
-                  className={clsx('quick-panel-item quick-panel-item-bottom', isDisabled && 'disabled')}
-                  data-content={item.key}
-                  disabled={isDisabled}
-                  onClick={() => handleItemClick(item)}
-                >
-                  <Icon name={item.icon} />
-                  <span className="quick-panel-label">{item.label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
+            <path d="M12 8l-6 6h12z" />
+          </svg>
+        </button>
       </div>
-
-      {/* FAB trigger */}
-      <button
-        className="quick-panel-trigger"
-        aria-label="快速選單"
-        aria-expanded={isOpen}
-        ref={triggerRef}
-        onClick={handleToggle}
-      >
-        <svg viewBox="0 0 24 24" fill="currentColor" className="quick-panel-arrow">
-          <path d="M12 8l-6 6h12z" />
-        </svg>
-      </button>
-    </div>
+    </>
   );
 }
 

--- a/src/components/trip/Restaurant.tsx
+++ b/src/components/trip/Restaurant.tsx
@@ -100,22 +100,22 @@ export const Restaurant = memo(function Restaurant({ restaurant: r }: Restaurant
   if (r.hours) metaParts.push(r.hours);
 
   return (
-    <div className="restaurant-choice">
-      <div className="restaurant-header">
-        <span className="restaurant-name">
+    <div className="p-3 px-4 leading-normal bg-accent-subtle rounded-sm my-2 last:mb-0">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-semibold text-accent text-headline">
           {r.name}
         </span>
-        {r.category && <span className="restaurant-category">{r.category}</span>}
+        {r.category && <span className="text-footnote text-muted bg-secondary py-1 px-2 rounded-full">{r.category}</span>}
         {r.location && <MapLinks location={r.location} inline />}
       </div>
       {metaParts.length > 0 && (
-        <div className="restaurant-meta-row">
+        <div className="text-footnote text-muted mt-1">
           {metaParts.join(' · ')}
         </div>
       )}
-      {r.description && <MarkdownText text={r.description} as="div" className="restaurant-desc" />}
+      {r.description && <MarkdownText text={r.description} as="div" className="text-callout text-muted mt-1 line-clamp-2" />}
       {reservationEl && (
-        <span className="restaurant-meta">
+        <span className="block mt-1 text-callout text-muted">
           {reservationEl}
         </span>
       )}

--- a/src/components/trip/Shop.tsx
+++ b/src/components/trip/Shop.tsx
@@ -21,21 +21,21 @@ interface ShopProps {
 
 export default function Shop({ shop }: ShopProps) {
   return (
-    <div className="restaurant-choice">
+    <div className="p-3 px-4 leading-normal bg-accent-subtle rounded-sm my-2 last:mb-0">
       {shop.category && <strong>{shop.category}：</strong>}
       {shop.name}
       {typeof shop.googleRating === 'number' && (
-        <>{' '}<span className="rating">★ {shop.googleRating.toFixed(1)}</span></>
+        <>{' '}<span className="text-accent text-caption shrink-0">★ {shop.googleRating.toFixed(1)}</span></>
       )}
       <br />
       {shop.location && <MapLinks location={shop.location} inline />}
       {shop.hours && (
-        <span className="restaurant-meta">
+        <span className="block mt-1 text-callout text-muted">
           <Icon name="clock" /> {shop.hours}
         </span>
       )}
       {shop.mustBuy && shop.mustBuy.length > 0 && (
-        <div className="shop-must-buy">
+        <div className="mt-1 text-callout">
           <Icon name="gift" /> 必買：{shop.mustBuy.join('、')}
         </div>
       )}

--- a/src/components/trip/Suggestions.tsx
+++ b/src/components/trip/Suggestions.tsx
@@ -29,14 +29,20 @@ export default function Suggestions({ data }: SuggestionsProps) {
     return (
       <>
         {data.cards.map((card, i) => {
-          const priorityClass = card.priority
-            ? ` sg-priority-${card.priority}`
-            : '';
+          const priorityStyles: Record<string, string> = {
+            high: 'bg-priority-high-bg rounded-sm p-3',
+            medium: 'bg-priority-medium-bg rounded-sm p-3',
+            low: 'bg-priority-low-bg rounded-sm p-3',
+          };
+          const base = 'py-2';
+          const cls = card.priority && priorityStyles[card.priority]
+            ? priorityStyles[card.priority]
+            : base;
           return (
-            <div key={i} className={`suggestion-card${priorityClass}`}>
-              {card.title && <h4>{card.title}</h4>}
+            <div key={i} className={cls}>
+              {card.title && <h4 className="m-0 mb-2 flex items-center">{card.title}</h4>}
               {card.items &&
-                card.items.map((item, j) => <p key={j}>{item}</p>)}
+                card.items.map((item, j) => <p key={j} className="text-body my-1 leading-relaxed">{item}</p>)}
             </div>
           );
         })}
@@ -48,7 +54,7 @@ export default function Suggestions({ data }: SuggestionsProps) {
   if (data.content) {
     return (
       <div
-        className="suggestions-markdown"
+        className="text-body leading-relaxed"
         dangerouslySetInnerHTML={{ __html: renderMarkdown(data.content) }}
       />
     );

--- a/src/components/trip/Timeline.tsx
+++ b/src/components/trip/Timeline.tsx
@@ -70,7 +70,7 @@ export default function Timeline({ events, dayDate, localToday }: TimelineProps)
   if (!events || events.length === 0) return null;
 
   return (
-    <div className="timeline">
+    <div className="relative mt-3">
       {events.map((ev, i) => (
         <TimelineEvent
           key={ev.id ?? i}

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -148,10 +148,10 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
           )}
         >
           <div
+            data-tl-card
             className={clsx(
-              'bg-(--color-background) rounded-(--radius-sm) px-4 py-3',
+              'rounded-(--radius-sm) px-4 py-3',
               'shadow-[0_1px_3px_rgba(0,0,0,0.06),0_1px_2px_rgba(0,0,0,0.04)]',
-              'dark:shadow-[0_1px_0_rgba(255,255,255,0.04)]',
               isNow && 'shadow-(--shadow-md) ring-[1.5px] ring-(--color-accent) scale-[1.01]',
               isPast && 'shadow-none opacity-75',
             )}

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -194,8 +194,8 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
 
       {/* ---- Travel segment to next entry ---- */}
       {travel && travelText && (
-        <div className="ml-3 py-2 pl-4 border-l-2 border-dashed border-(--color-border)">
-          <div className="flex items-center gap-2 py-2 px-4 text-(length:--font-size-footnote) text-(--color-muted) bg-(--color-accent-bg) rounded-(--radius-sm) cursor-default">
+        <div className="ml-3 py-2 pl-4 border-0 border-l-2 border-dashed border-(--color-border)">
+          <div className="flex items-center gap-2 py-2 px-4 text-footnote text-muted bg-accent-bg rounded-sm cursor-default">
             {travelType && (
               <span className="inline-flex items-center [&_.svg-icon]:w-[1.1em] [&_.svg-icon]:h-[1.1em]">
                 <Icon name={travelType} />

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -144,7 +144,7 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
         <div
           data-tl-segment
           className={clsx(
-            'ml-3 py-2 pl-4 border-l-2 border-dashed border-(--color-border)',
+            'ml-3 py-2 pl-4 border-0 border-l-2 border-dashed border-(--color-border)',
             isNow && 'border-solid! border-(--color-accent)!',
           )}
         >

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -152,9 +152,8 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
             data-tl-card
             className={clsx(
               'rounded-(--radius-sm) px-4 py-3',
-              'shadow-[0_1px_3px_rgba(0,0,0,0.06),0_1px_2px_rgba(0,0,0,0.04)]',
               isNow && 'shadow-(--shadow-md) ring-[1.5px] ring-(--color-accent) scale-[1.01]',
-              isPast && 'shadow-none opacity-75',
+              isPast && '!shadow-none opacity-75',
             )}
           >
             {/* Card header */}

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -110,41 +110,74 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
     <>
       {/* ---- Main event ---- */}
       <div
-        className={clsx('tl-event', 'expanded', isNow && 'tl-now', isPast && 'tl-past')}
+        className={clsx(
+          'relative',
+          isPast && 'opacity-55',
+        )}
         data-entry-id={entry.id ?? undefined}
+        data-now={isNow || undefined}
       >
         {/* Arrival flag */}
-        <div className="tl-flag tl-flag-arrive">
-          <span className="tl-flag-num">{index}</span>
-          <span className="tl-time-start">
+        <div
+          className="inline-flex items-center gap-2 py-1 pr-5 pl-3 font-bold text-(length:--font-size-footnote) leading-tight bg-(--color-accent) text-(--color-accent-foreground) rounded-l-(--radius-xs)"
+          style={{ clipPath: 'polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)' }}
+        >
+          <span
+            className={clsx(
+              'relative text-[0.8em] bg-white/25 w-5 h-5 rounded-full inline-flex items-center justify-center shrink-0',
+              isNow && 'shadow-[0_0_8px_color-mix(in_srgb,var(--color-accent)_50%,transparent)]',
+            )}
+          >
+            {index}
+            {/* Pulse dot for "now" indicator — replaces ::after pseudo-element */}
+            {isNow && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-(--color-accent) animate-[tl-pulse_2s_infinite]" />
+            )}
+          </span>
+          <span>
             {parsed.start}
             {parsed.end ? `-${parsed.end}` : ''}
           </span>
         </div>
 
         {/* Segment: dashed line + card */}
-        <div className="tl-segment">
-          <div className="tl-card">
+        <div
+          className={clsx(
+            'ml-3 py-2 pl-4 border-l-2 border-dashed border-(--color-border)',
+            isNow && 'border-solid! border-(--color-accent)!',
+          )}
+        >
+          <div
+            className={clsx(
+              'bg-(--color-background) rounded-(--radius-sm) px-4 py-3',
+              'shadow-[0_1px_3px_rgba(0,0,0,0.06),0_1px_2px_rgba(0,0,0,0.04)]',
+              'dark:shadow-[0_1px_0_rgba(255,255,255,0.04)]',
+              isNow && 'shadow-(--shadow-md) ring-[1.5px] ring-(--color-accent) scale-[1.01]',
+              isPast && 'shadow-none opacity-75',
+            )}
+          >
             {/* Card header */}
-            <div className="tl-card-header">
-              <span className="tl-title">{entry.title ?? ''}</span>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-semibold text-(length:--font-size-title3) leading-tight text-(--color-accent) flex-1 min-w-0">
+                {entry.title ?? ''}
+              </span>
               {typeof entry.googleRating === 'number' && (
-                <>{' '}<span className="rating">★ {entry.googleRating.toFixed(1)}</span></>
+                <>{' '}<span className="text-(--color-accent) text-(length:--font-size-caption) shrink-0">★ {entry.googleRating.toFixed(1)}</span></>
               )}
               {durationText && (
-                <span className="tl-duration">
+                <span className="text-(length:--font-size-footnote) text-(--color-muted) whitespace-nowrap shrink-0 inline-flex items-center gap-1">
                   <Icon name="clock" /> {durationText}
                 </span>
               )}
             </div>
 
             {/* Note */}
-            {entry.note && <MarkdownText text={entry.note} as="div" className="tl-desc" />}
+            {entry.note && <MarkdownText text={entry.note} as="div" className="text-(--color-muted) my-1 text-(length:--font-size-callout)" />}
 
             {/* Body: description + locations + info boxes */}
             {hasBody && (
-              <div className="tl-body">
-                {entry.description && <MarkdownText text={entry.description} as="div" className="tl-desc" />}
+              <div className="grid grid-rows-[1fr] py-1 text-(length:--font-size-body) leading-relaxed transition-[grid-template-rows] duration-(--transition-duration-normal) ease-(--transition-timing-function-apple) [&>*]:overflow-hidden">
+                {entry.description && <MarkdownText text={entry.description} as="div" className="text-(--color-muted) my-1 text-(length:--font-size-callout)" />}
                 {entry.locations && entry.locations.length > 0 && (
                   <NavLinks locations={entry.locations} />
                 )}
@@ -155,20 +188,20 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
                 }
               </div>
             )}
-          </div>{/* end tl-card */}
-        </div>{/* end tl-segment */}
-      </div>{/* end tl-event */}
+          </div>{/* end card */}
+        </div>{/* end segment */}
+      </div>{/* end event */}
 
       {/* ---- Travel segment to next entry ---- */}
       {travel && travelText && (
-        <div className="tl-segment tl-segment-travel">
-          <div className="tl-travel-content">
+        <div className="ml-3 py-2 pl-4 border-l-2 border-dashed border-(--color-border)">
+          <div className="flex items-center gap-2 py-2 px-4 text-(length:--font-size-footnote) text-(--color-muted) bg-(--color-accent-bg) rounded-(--radius-sm) cursor-default">
             {travelType && (
-              <span className="tl-travel-icon">
+              <span className="inline-flex items-center [&_.svg-icon]:w-[1.1em] [&_.svg-icon]:h-[1.1em]">
                 <Icon name={travelType} />
               </span>
             )}
-            <span className="tl-travel-text">{travelText}</span>
+            <span className="flex-1">{travelText}</span>
           </div>
         </div>
       )}

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -142,6 +142,7 @@ export const TimelineEvent = memo(function TimelineEvent({ entry, index, isNow, 
 
         {/* Segment: dashed line + card */}
         <div
+          data-tl-segment
           className={clsx(
             'ml-3 py-2 pl-4 border-l-2 border-dashed border-(--color-border)',
             isNow && 'border-solid! border-(--color-accent)!',

--- a/src/components/trip/TodayRouteSheet.tsx
+++ b/src/components/trip/TodayRouteSheet.tsx
@@ -15,18 +15,18 @@ export const TodayRouteSheet = memo(function TodayRouteSheet({ events }: TodayRo
   );
 
   if (routeEvents.length === 0) {
-    return <p className="text-[var(--color-muted)]">今日行程沒有地圖連結</p>;
+    return <p className="text-muted">今日行程沒有地圖連結</p>;
   }
 
   return (
-    <div className="today-route-list">
+    <div className="flex flex-col gap-2">
       {routeEvents.map((ev, i) => (
-        <div key={ev.id ?? i} className="today-route-item">
-          <div className="today-route-header">
-            <span className="today-route-time">{ev.time?.split('-')[0]?.trim() || ''}</span>
-            <span className="today-route-title">{ev.title || ''}</span>
+        <div key={ev.id ?? i} className="flex flex-col gap-1 p-3 bg-accent-subtle rounded-sm">
+          <div className="flex items-baseline gap-2">
+            <span className="font-semibold text-footnote text-accent whitespace-nowrap min-w-[40px]">{ev.time?.split('-')[0]?.trim() || ''}</span>
+            <span className="text-callout font-semibold text-foreground">{ev.title || ''}</span>
           </div>
-          <div className="today-route-links">
+          <div className="flex gap-2 pl-[calc(40px+var(--spacing-2))]">
             <NavLinks locations={ev.locations as NavLocation[]} />
           </div>
         </div>

--- a/src/components/trip/TodaySummary.tsx
+++ b/src/components/trip/TodaySummary.tsx
@@ -13,15 +13,15 @@ export const TodaySummary = memo(function TodaySummary({ entries }: TodaySummary
   if (entries.length === 0) return null;
 
   return (
-    <div className="info-card today-summary">
-      <div className="info-label"><Icon name="timer" /> 今日行程</div>
-      <ul className="today-summary-list">
+    <div className="bg-secondary rounded-md p-4 mb-3">
+      <div className="font-bold text-title3 mb-3"><Icon name="timer" /> 今日行程</div>
+      <ul className="list-none p-0 m-0">
         {entries.map((e, i) => {
           const timeStr = e.time?.split('-')[0]?.trim() || '';
           return (
-            <li key={e.id ?? i} className="today-summary-item">
-              <span className="today-summary-time">{timeStr}</span>
-              <span className="today-summary-title">{e.title}</span>
+            <li key={e.id ?? i} className="flex gap-2 py-2 px-3 -mx-3 text-callout rounded-sm items-center">
+              <span className="font-semibold text-accent whitespace-nowrap min-w-[40px]">{timeStr}</span>
+              <span className="text-foreground overflow-hidden text-ellipsis whitespace-nowrap flex-1 min-w-0">{e.title}</span>
             </li>
           );
         })}

--- a/src/components/trip/TripMap.tsx
+++ b/src/components/trip/TripMap.tsx
@@ -235,15 +235,15 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
   /* ===== Render ===== */
 
   return (
-    <div className="day-map-section" data-testid="trip-map-section">
+    <div data-testid="trip-map-section">
       {/* Header：標籤 + 收合按鈕 */}
-      <div className="day-map-header">
-        <span className="day-map-header-label">
+      <div className="flex items-center justify-between p-2 px-1 mb-2">
+        <span className="text-footnote font-semibold text-muted uppercase tracking-[0.04em]">
           <Icon name="map" />
           全覽地圖
         </span>
         <button
-          className="day-map-toggle-btn"
+          className="flex items-center gap-2 py-2 px-4 bg-transparent rounded-sm text-muted text-footnote font-medium cursor-pointer min-h-tap-min min-w-[var(--spacing-tap-min)] transition-colors duration-fast ease-apple hover:text-foreground hover:bg-tertiary"
           aria-expanded={!collapsed}
           aria-controls="trip-map"
           onClick={handleToggle}
@@ -260,15 +260,15 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
         role="region"
         aria-label="全行程總覽地圖"
         className={clsx(
-          'day-map-wrap',
-          collapsed ? 'day-map-wrap--collapsed' : 'day-map-wrap--expanded',
+          'overflow-hidden transition-[max-height] duration-normal ease-apple',
+          collapsed ? 'max-h-0' : 'max-h-[420px] md:max-h-[460px] lg:max-h-[520px]',
         )}
         aria-hidden={collapsed}
       >
         {/* Case 1：SDK 載入中 → skeleton */}
         {status === 'loading' || status === 'idle' ? (
           <div
-            className="day-map-skeleton"
+            className="h-[250px] md:h-[300px] lg:h-[350px] bg-tertiary rounded-md animate-pulse"
             role="status"
             aria-label="地圖載入中"
             data-testid="trip-map-skeleton"
@@ -278,17 +278,17 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
         {/* Case 2：SDK 載入失敗 → error fallback */}
         {status === 'error' ? (
           <div
-            className="day-map-error"
+            className="flex flex-col items-center justify-center gap-3 p-8 bg-secondary rounded-md h-[250px] md:h-[300px] lg:h-[350px] text-center"
             role="alert"
             data-testid="trip-map-error"
           >
             <Icon name="warning" />
-            <p className="day-map-error-title">地圖無法載入</p>
-            <p className="day-map-error-desc">
+            <p className="text-subheadline font-semibold text-foreground">地圖無法載入</p>
+            <p className="text-footnote text-muted">
               {error ?? 'Google Maps SDK 無法載入，請確認網路連線。'}
             </p>
             <a
-              className="day-map-error-link"
+              className="inline-flex items-center gap-2 py-2 px-4 bg-accent text-accent-foreground rounded-sm text-footnote font-semibold no-underline min-h-tap-min min-w-[var(--spacing-tap-min)] justify-center"
               href={buildFallbackUrl()}
               target="_blank"
               rel="noopener noreferrer"
@@ -303,7 +303,7 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
         {/* Case 3：SDK ready + 無資料 → empty state */}
         {status === 'ready' && !hasData ? (
           <div
-            className="day-map-empty"
+            className="flex items-center justify-center h-[250px] md:h-[300px] lg:h-[350px] bg-secondary rounded-md text-footnote text-muted text-center p-4"
             data-testid="trip-map-empty"
           >
             尚無地點資料
@@ -312,17 +312,17 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
 
         {/* Case 4：SDK ready + 有資料 → 地圖容器 */}
         {status === 'ready' && hasData ? (
-          <div className="day-map-container" data-testid="trip-map-container">
+          <div className="relative touch-none bg-secondary rounded-md overflow-hidden" data-testid="trip-map-container">
             <div
               ref={mapRef}
-              className="day-map"
+              className="h-[250px] md:h-[300px] lg:h-[350px] w-full rounded-md"
               aria-label="全行程互動地圖"
               data-testid="trip-map-canvas"
             />
 
             {/* 日期圖例（左下角，F006.3）*/}
             <div
-              className="trip-map-legend"
+              className="absolute bottom-3 left-3 flex flex-wrap gap-1 p-0 max-w-[calc(100%-var(--spacing-6))] z-[5]"
               role="list"
               aria-label="天數圖例"
               data-testid="trip-map-legend"
@@ -338,9 +338,9 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
                     key={dayNum}
                     role="listitem"
                     className={clsx(
-                      'trip-map-legend-pill',
-                      isDimmed && 'trip-map-legend-pill--dimmed',
-                      isHighlighted && 'trip-map-legend-pill--active',
+                      'inline-flex items-center gap-1 py-1 px-2 rounded-full text-caption font-medium cursor-pointer min-h-tap-min min-w-[var(--spacing-tap-min)] bg-secondary shadow-sm text-foreground transition-[opacity,background] duration-fast ease-apple hover:shadow-md',
+                      isDimmed && 'opacity-40',
+                      isHighlighted && 'font-semibold shadow-md',
                     )}
                     style={{ background: isHighlighted ? color + '22' : 'var(--color-secondary)' }}
                     onClick={() => handleLegendPillClick(dayNum)}
@@ -350,7 +350,7 @@ export default function TripMap({ allDays, dayNums }: TripMapProps) {
                     type="button"
                   >
                     <span
-                      className="trip-map-legend-dot"
+                      className="w-2 h-2 rounded-full shrink-0"
                       style={{ background: color }}
                       aria-hidden="true"
                     />

--- a/src/components/trip/TripStatsCard.tsx
+++ b/src/components/trip/TripStatsCard.tsx
@@ -54,19 +54,19 @@ export default function TripStatsCard({ days }: TripStatsCardProps) {
   });
 
   return (
-    <div className="info-card stats-card">
-      <div className="stats-card-title">行程統計</div>
+    <div className="bg-secondary rounded-md p-4 mb-3">
+      <div className="font-bold text-title3 mb-3">行程統計</div>
 
       {/* Total days */}
-      <div className="stats-row">
-        <span className="stats-label">天數</span>
-        <span className="stats-value">{days.length} 天</span>
+      <div className="flex justify-between items-center py-1 text-callout">
+        <span className="text-muted">天數</span>
+        <span className="font-semibold">{days.length} 天</span>
       </div>
 
       {/* Total spots */}
-      <div className="stats-row">
-        <span className="stats-label">景點數</span>
-        <span className="stats-value">{spots} 個</span>
+      <div className="flex justify-between items-center py-1 text-callout">
+        <span className="text-muted">景點數</span>
+        <span className="font-semibold">{spots} 個</span>
       </div>
 
       {/* Transport summary by type */}
@@ -76,11 +76,11 @@ export default function TripStatsCard({ days }: TripStatsCardProps) {
           const g = tripStats.grandByType[key];
           if (!g) return null;
           return (
-            <div key={key} className="stats-row">
-              <span className="stats-label">
+            <div key={key} className="flex justify-between items-center py-1 text-callout">
+              <span className="text-muted">
                 <Icon name={g.icon} /> {g.label}
               </span>
-              <span className="stats-value">
+              <span className="font-semibold">
                 {formatMinutes(g.totalMinutes)}
               </span>
             </div>
@@ -89,9 +89,9 @@ export default function TripStatsCard({ days }: TripStatsCardProps) {
 
       {/* Total budget */}
       {totalBudget > 0 && (
-        <div className="stats-row">
-          <span className="stats-label">預估預算</span>
-          <span className="stats-value">
+        <div className="flex justify-between items-center py-1 text-callout">
+          <span className="text-muted">預估預算</span>
+          <span className="font-semibold">
             {currency} {totalBudget.toLocaleString()}
           </span>
         </div>

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -23,7 +23,7 @@ const V2_CUTOVER_PATHS = ['/admin', '/manage'];
 const isCutover = V2_CUTOVER_PATHS.some(p => window.location.pathname === p || window.location.pathname.startsWith(p + '/'));
 
 /* V2-ready 但尚未 cutover 的路由（未來 ManagePage 等加入此列） */
-const V2_READY_PATHS: string[] = [];
+const V2_READY_PATHS: string[] = ['/trip'];
 const isV2Ready = V2_READY_PATHS.some(p => window.location.pathname === p || window.location.pathname.startsWith(p + '/'));
 
 if (isCutover || (useV2 && isV2Ready)) {

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -26,8 +26,10 @@ const isCutover = V2_CUTOVER_PATHS.some(p => window.location.pathname === p || w
 const V2_READY_PATHS: string[] = ['/trip'];
 const isV2Ready = V2_READY_PATHS.some(p => window.location.pathname === p || window.location.pathname.startsWith(p + '/'));
 
+/* 分離 import 避免 Vite preload-helper 合併兩個分支的 CSS deps */
 if (isCutover || (useV2 && isV2Ready)) {
   import('./mainV2');
-} else {
+}
+if (!isCutover && !(useV2 && isV2Ready)) {
   import('./mainV1');
 }

--- a/src/entries/mainV2.tsx
+++ b/src/entries/mainV2.tsx
@@ -10,6 +10,7 @@ import '../../css/tokens.css';
 
 const AdminPage = lazy(() => import('../pages/AdminPage'));
 const ManagePage = lazy(() => import('../pages/ManagePageV2'));
+const TripPageV2 = lazy(() => import('../pages/TripPageV2'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
 const FALLBACK_STYLE = { padding: '2rem', textAlign: 'center' as const };
@@ -32,6 +33,7 @@ if (el) {
             <Route path="/admin/" element={<AdminPage />} />
             <Route path="/manage" element={<ManagePage />} />
             <Route path="/manage/" element={<ManagePage />} />
+            <Route path="/trip/:tripId" element={<TripPageV2 />} />
             <Route path="*" element={<LegacyRedirect />} />
           </Routes>
         </Suspense>

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -111,6 +111,16 @@ body.dark .day-header-v2 {
   animation: shimmer 1.5s infinite;
   border-radius: var(--radius-sm);
 }
+/* Timeline card glass effect (V1: body[class*="theme-"] .tl-card) */
+[data-tl-card] {
+  background: color-mix(in srgb, var(--color-background) 92%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+body.dark [data-tl-card] {
+  background: color-mix(in srgb, var(--color-tertiary) 88%, transparent);
+  box-shadow: 0 1px 0 rgba(255,255,255,0.04);
+}
 /* tripContent-v2 link styles */
 #tripContent-v2 a:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); text-decoration: underline; }
 #tripContent-v2 a:visited:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); }
@@ -1184,7 +1194,7 @@ export default function TripPageV2() {
       <style>{SCOPED_STYLES}</style>
 
       {/* Sticky Nav */}
-      <div className="sticky-nav-v2 sticky top-0 z-(--z-sticky-nav) border-b border-border bg-(--color-glass-nav) backdrop-blur-xl backdrop-saturate-200 text-foreground py-3 px-padding-h flex items-center gap-3 overflow-x-hidden overflow-y-visible" id="stickyNav">
+      <div className="sticky-nav-v2 sticky top-0 z-(--z-sticky-nav) bg-[color-mix(in_srgb,var(--color-background)_92%,transparent)] backdrop-blur-xl backdrop-saturate-200 shadow-[0_1px_0_var(--color-border)] text-foreground py-3 px-padding-h md:px-6 flex items-center gap-3 overflow-x-hidden overflow-y-visible" id="stickyNav">
         {activeTripId && <DestinationArt tripId={activeTripId} dark={isDark} />}
         <TriplineLogo isOnline={isOnline} />
         <span className={clsx('nav-inline-title-v2 text-subheadline font-semibold text-foreground whitespace-nowrap overflow-hidden text-ellipsis max-w-[160px] md:hidden', showNavTitle && 'visible')}>
@@ -1219,7 +1229,7 @@ export default function TripPageV2() {
 
       {/* Page Layout */}
       <div className="page-layout-v2 flex min-h-dvh">
-        <div className="container-v2 flex-1 min-w-0 max-w-full mx-auto">
+        <div className="container-v2 flex-1 min-w-0 max-w-full">
           <div id="tripContent-v2" className="pt-3">
             {/* Large Title (mobile only) */}
             {!loading && trip && (

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -1185,7 +1185,7 @@ export default function TripPageV2() {
       <style>{SCOPED_STYLES}</style>
 
       {/* Sticky Nav */}
-      <div className="sticky-nav-v2 sticky top-0 z-sticky-nav border-b border-border bg-(--color-glass-nav) backdrop-blur-xl backdrop-saturate-200 text-foreground py-3 px-padding-h flex items-center gap-3 overflow-x-hidden overflow-y-visible" id="stickyNav">
+      <div className="sticky-nav-v2 sticky top-0 z-(--z-sticky-nav) border-b border-border bg-(--color-glass-nav) backdrop-blur-xl backdrop-saturate-200 text-foreground py-3 px-padding-h flex items-center gap-3 overflow-x-hidden overflow-y-visible" id="stickyNav">
         {activeTripId && <DestinationArt tripId={activeTripId} dark={isDark} />}
         <TriplineLogo isOnline={isOnline} />
         <span className={clsx('nav-inline-title-v2 text-subheadline font-semibold text-foreground whitespace-nowrap overflow-hidden text-ellipsis max-w-[160px] md:hidden', showNavTitle && 'visible')}>
@@ -1295,7 +1295,7 @@ export default function TripPageV2() {
       {!loading && trip && (
         <a
           className={clsx(
-            'edit-fab-v2 fixed right-5 w-(--fab-size) h-(--fab-size) rounded-full bg-accent text-accent-foreground border-none text-large-title font-light no-underline flex items-center justify-center z-fab shadow-md transition-[transform,box-shadow] duration-normal ease-apple',
+            'edit-fab-v2 fixed right-5 w-(--fab-size) h-(--fab-size) rounded-full bg-accent text-accent-foreground border-none text-large-title font-light no-underline flex items-center justify-center z-(--z-fab) shadow-md transition-[transform,box-shadow] duration-normal ease-apple',
             'bottom-[max(20px,env(safe-area-inset-bottom))]',
             !isOnline && 'opacity-40 pointer-events-none',
           )}

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -87,7 +87,7 @@ body.dark .day-header-v2 {
   animation: fadeIn 300ms var(--transition-timing-function-apple) both;
 }
 /* sticky-nav children z-index layering above DestinationArt */
-.sticky-nav-v2 > :not(.destination-art):not(.manage-trip-select--center) { position: relative; z-index: 1; }
+.sticky-nav-v2 > :not([aria-hidden="true"]) { position: relative; z-index: 1; }
 /* nav-inline-title fade */
 .nav-inline-title-v2 { opacity: 0; transition: opacity var(--duration-nav-fade, 250ms) ease; }
 .nav-inline-title-v2.visible { opacity: 1; }
@@ -133,7 +133,7 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 .print-mode .day-header-v2 { background: var(--color-background); position: relative !important; flex-wrap: wrap; padding: 8px 12px; }
 .print-mode .container-v2 { max-width: 210mm; margin: 0 auto; box-shadow: var(--shadow-lg); }
 /* Info panel: hidden by default, visible on desktop */
-.info-panel { display: none; }
+.info-panel { display: none; background: var(--color-secondary); border-radius: var(--radius-lg); }
 @media (min-width: 1200px) {
   .info-panel {
     display: block; position: fixed; right: 0; top: var(--spacing-nav-h);
@@ -296,7 +296,7 @@ const DaySection = React.memo(function DaySection({
   return (
     <section className="day-section" data-day={dayNum}>
       <div className="day-header-v2 relative z-(--z-day-header) py-2 px-4 flex items-center gap-2 min-h-[100px] rounded-t-md" id={`day${dayNum}`}>
-        <h2 className="text-title2 font-bold whitespace-nowrap overflow-hidden text-ellipsis">Day {dayNum}</h2>
+        <h2 className="text-title2 font-bold whitespace-nowrap overflow-hidden text-ellipsis m-0">Day {dayNum}</h2>
         {daySummary?.label && (
           <span>{daySummary.label}</span>
         )}

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -1235,7 +1235,7 @@ export default function TripPageV2() {
           <div id="tripContent-v2" className="pt-3">
             {/* Large Title (mobile only) */}
             {!loading && trip && (
-              <div className="py-2 px-padding-h pb-4 block md:hidden" ref={largeTitleRef}>
+              <div className="py-2 px-padding-h pb-4" ref={largeTitleRef}>
                 <h1 className="text-large-title font-bold leading-tight text-foreground">{trip.title || trip.name}</h1>
                 {dateRange && <p className="text-subheadline text-muted mt-1">{dateRange}</p>}
               </div>

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -61,12 +61,15 @@ const UNPUBLISHED_CLASS = 'text-muted mt-2';
 
 /* ===== Scoped styles for classes that need CSS-level selectors (animations, print, dark overrides) ===== */
 const SCOPED_STYLES = `
-/* day-header gradient overlays — require body.dark / body:not(.dark) context */
+/* day-header — match V1: subtle background + optional theme gradient overlay */
 body:not(.dark) .day-header-v2 {
-  background: linear-gradient(135deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
+  background: var(--color-accent-subtle);
+  background-image: var(--theme-header-gradient);
+  color: var(--color-foreground);
 }
 body.dark .day-header-v2 {
-  background: linear-gradient(135deg, var(--color-hover) 0%, color-mix(in srgb, var(--color-hover) 85%, #000) 100%);
+  background: var(--color-accent-bg);
+  background-image: var(--theme-header-gradient);
 }
 /* day-content enter animation */
 @keyframes fadeSlideIn {
@@ -284,7 +287,7 @@ const DaySection = React.memo(function DaySection({
 
   return (
     <section className="day-section" data-day={dayNum}>
-      <div className="day-header-v2 relative sticky z-(--z-day-header) bg-accent text-accent-foreground py-2 px-4 flex items-center gap-2 min-h-[100px] rounded-t-md" id={`day${dayNum}`}>
+      <div className="day-header-v2 relative z-(--z-day-header) py-2 px-4 flex items-center gap-2 min-h-[100px] rounded-t-md" id={`day${dayNum}`}>
         <h2 className="text-title2 font-bold whitespace-nowrap overflow-hidden text-ellipsis">Day {dayNum}</h2>
         {daySummary?.label && (
           <span>{daySummary.label}</span>

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -136,8 +136,8 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 .info-panel { display: none; background: var(--color-secondary); border-radius: var(--radius-lg); }
 @media (min-width: 1200px) {
   .info-panel {
-    display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-8));
-    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-8));
+    display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-10));
+    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-10));
     overflow-y: auto; padding: var(--spacing-4) var(--spacing-3);
   }
 }

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -121,6 +121,8 @@ body.dark [data-tl-card] {
   background: color-mix(in srgb, var(--color-tertiary) 88%, transparent);
   box-shadow: 0 1px 0 rgba(255,255,255,0.04);
 }
+/* Timeline segment dashed line — dark mode uses subtle white instead of solid border token */
+body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 /* tripContent-v2 link styles */
 #tripContent-v2 a:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); text-decoration: underline; }
 #tripContent-v2 a:visited:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); }

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -1235,7 +1235,7 @@ export default function TripPageV2() {
           <div id="tripContent-v2" className="pt-3">
             {/* Large Title (mobile only) */}
             {!loading && trip && (
-              <div className="py-2 px-padding-h pb-4" ref={largeTitleRef}>
+              <div className="py-2 px-padding-h pb-4 block md:hidden" ref={largeTitleRef}>
                 <h1 className="text-large-title font-bold leading-tight text-foreground">{trip.title || trip.name}</h1>
                 {dateRange && <p className="text-subheadline text-muted mt-1">{dateRange}</p>}
               </div>

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -127,7 +127,7 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 #tripContent-v2 a:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); text-decoration: underline; }
 #tripContent-v2 a:visited:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); }
 /* tripContent-v2 section cards */
-#tripContent-v2 section { background: var(--color-secondary); border-radius: var(--radius-md); margin-bottom: var(--spacing-3); overflow: hidden; }
+#tripContent-v2 section { background: var(--color-secondary); border-radius: var(--radius-md); margin-bottom: var(--spacing-3); overflow: clip; }
 /* print-mode overrides */
 .print-mode #tripContent-v2 section { background: var(--color-background) !important; }
 .print-mode .day-header-v2 { background: var(--color-background); position: relative !important; flex-wrap: wrap; padding: 8px 12px; }
@@ -136,8 +136,8 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 .info-panel { display: none; background: var(--color-secondary); border-radius: var(--radius-lg); }
 @media (min-width: 1200px) {
   .info-panel {
-    display: block; position: fixed; right: 0; top: var(--spacing-nav-h);
-    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h));
+    display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-6));
+    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-6));
     overflow-y: auto; padding: var(--spacing-3);
   }
 }

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -47,6 +47,8 @@ import type { BackupData } from '../components/trip/Backup';
 import type { EmergencyData } from '../components/trip/Emergency';
 import type { SuggestionsData } from '../components/trip/Suggestions';
 
+import '../../css/tokens.css';
+
 /* ===== Feature flags ===== */
 
 /** 地圖功能預設隱藏，URL 加 ?showmap=1 顯示 */
@@ -54,17 +56,151 @@ const ENABLE_DAY_MAP = new URLSearchParams(window.location.search).get('showmap'
 
 /* ===== Module-level constants (#14: hoist inline styles) ===== */
 
-const LOADING_CLASS = 'text-center p-10 text-[var(--color-muted)]';
-const UNPUBLISHED_CLASS = 'text-[var(--color-muted)] mt-2';
+const LOADING_CLASS = 'text-center p-10 text-muted';
+const UNPUBLISHED_CLASS = 'text-muted mt-2';
+
+/* ===== Scoped styles for classes that need CSS-level selectors (animations, print, dark overrides) ===== */
+const SCOPED_STYLES = `
+/* day-header gradient overlays — require body.dark / body:not(.dark) context */
+body:not(.dark) .day-header-v2 {
+  background: linear-gradient(135deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
+}
+body.dark .day-header-v2 {
+  background: linear-gradient(135deg, var(--color-hover) 0%, color-mix(in srgb, var(--color-hover) 85%, #000) 100%);
+}
+/* day-content enter animation */
+@keyframes fadeSlideIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.day-content-enter-v2 {
+  animation: fadeSlideIn var(--transition-duration-normal) var(--transition-timing-function-apple) both;
+}
+.day-content-loaded-v2 {
+  animation: fadeIn 300ms var(--transition-timing-function-apple) both;
+}
+/* sticky-nav children z-index layering above DestinationArt */
+.sticky-nav-v2 > :not(.destination-art):not(.manage-trip-select--center) { position: relative; z-index: 1; }
+/* nav-inline-title fade */
+.nav-inline-title-v2 { opacity: 0; transition: opacity var(--duration-nav-fade, 250ms) ease; }
+.nav-inline-title-v2.visible { opacity: 1; }
+/* edit-fab hover */
+.edit-fab-v2:hover { transform: scale(1.1); box-shadow: var(--shadow-lg); }
+/* print mode */
+.print-mode .sticky-nav-v2 { display: none; }
+.print-mode .edit-fab-v2 { display: none !important; }
+.print-mode .print-exit-btn-v2 { display: block; }
+@media print {
+  .sticky-nav-v2, .edit-fab-v2, .print-exit-btn-v2 { display: none !important; }
+}
+/* skeleton-bone shimmer (not in tokens.css — needs keyframe + gradient) */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.skeleton-bone {
+  background: linear-gradient(90deg, var(--color-tertiary) 25%, var(--color-secondary) 50%, var(--color-tertiary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: var(--radius-sm);
+}
+/* tripContent-v2 link styles */
+#tripContent-v2 a:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); text-decoration: underline; }
+#tripContent-v2 a:visited:not(.map-link):not(.map-link-inline) { color: var(--color-foreground); }
+/* tripContent-v2 section cards */
+#tripContent-v2 section { background: var(--color-secondary); border-radius: var(--radius-md); margin-bottom: var(--spacing-3); overflow: hidden; }
+/* print-mode overrides */
+.print-mode #tripContent-v2 section { background: var(--color-background) !important; }
+.print-mode .day-header-v2 { background: var(--color-background); position: relative !important; flex-wrap: wrap; padding: 8px 12px; }
+.print-mode .container-v2 { max-width: 210mm; margin: 0 auto; box-shadow: var(--shadow-lg); }
+/* Info panel: hidden by default, visible on desktop */
+.info-panel { display: none; }
+@media (min-width: 1200px) {
+  .info-panel {
+    display: block; position: fixed; right: 0; top: var(--spacing-nav-h);
+    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h));
+    overflow-y: auto; padding: var(--spacing-3);
+  }
+}
+/* Desktop layout: info-panel offset */
+@media (min-width: 1024px) {
+  #tripContent-v2 { max-width: var(--content-max-w); margin: 0 auto; }
+  .page-layout-v2:has(.info-panel) { padding-right: calc(var(--info-panel-w) + var(--spacing-3)); }
+}
+@media (min-width: 1024px) and (max-width: 1279px) {
+  #tripContent-v2 { max-width: none; }
+}
+/* day-header sticky on desktop */
+@media (min-width: 768px) {
+  .day-header-v2 {
+    position: sticky;
+    top: calc(var(--spacing-nav-h) + var(--spacing-3));
+    z-index: var(--z-day-header);
+  }
+}
+/* Appearance settings cards */
+.color-mode-card-v2,
+.color-theme-card-v2 {
+  appearance: none; border: 2px solid var(--color-border); border-radius: var(--radius-sm);
+  background: var(--color-secondary); padding: 8px; text-align: center; cursor: pointer;
+  transition: border-color var(--transition-duration-fast) var(--transition-timing-function-apple);
+}
+.color-mode-card-v2:hover,
+.color-theme-card-v2:hover { border-color: color-mix(in srgb, var(--color-accent) 40%, transparent); }
+.color-mode-card-v2.active,
+.color-theme-card-v2.active { border-color: var(--color-accent); }
+.color-mode-card-v2:focus-visible,
+.color-theme-card-v2:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
+/* Color mode preview mini UI */
+.color-mode-preview-v2 {
+  width: 80px; height: 52px; border-radius: var(--radius-xs); overflow: hidden; margin: 0 auto 4px;
+  display: flex; flex-direction: column;
+}
+.color-mode-preview-v2 .cmp-top { flex: 1; }
+.color-mode-preview-v2 .cmp-bottom { flex: 1; display: flex; align-items: center; gap: 4px; padding: 0 6px; }
+.color-mode-preview-v2 .cmp-input { flex: 1; height: 8px; border-radius: 4px; }
+.color-mode-preview-v2 .cmp-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--color-accent); }
+.color-mode-light .cmp-top { background: var(--cmp-light-bg); }
+.color-mode-light .cmp-bottom { background: var(--cmp-light-surface); }
+.color-mode-light .cmp-input { background: var(--cmp-light-input); }
+.color-mode-dark .cmp-top { background: var(--cmp-dark-bg); }
+.color-mode-dark .cmp-bottom { background: var(--cmp-dark-surface); }
+.color-mode-dark .cmp-input { background: var(--cmp-dark-input); }
+.color-mode-auto .cmp-top { background: linear-gradient(135deg, var(--cmp-light-bg) 50%, var(--cmp-dark-bg) 50%); }
+.color-mode-auto .cmp-bottom { background: linear-gradient(135deg, var(--cmp-light-surface) 50%, var(--cmp-dark-surface) 50%); }
+.color-mode-auto .cmp-input { background: linear-gradient(135deg, var(--cmp-light-input) 50%, var(--cmp-dark-input) 50%); }
+/* color-theme-swatch */
+.color-theme-swatch-v2 {
+  width: 80px; height: 28px; border-radius: var(--radius-xs); margin: 0 auto 4px;
+}
+@media (min-width: 768px) {
+  .color-mode-preview-v2 { width: 100px; height: 66px; }
+  .color-theme-swatch-v2 { width: 100px; height: 34px; }
+}
+/* trip-btn in info sheet */
+.trip-btn-v2 {
+  display: block; width: 100%; text-align: left; padding: 16px; border-radius: var(--radius-sm);
+  border: 2px solid transparent; background: var(--color-accent-bg); font-family: inherit;
+  font-size: var(--font-size-body); color: var(--color-foreground); text-decoration: none; cursor: pointer;
+}
+.trip-btn-v2:hover { background: var(--color-secondary); }
+.trip-btn-v2.active { border-color: var(--color-accent); }
+body.dark .trip-btn-v2 { background: var(--color-hover); }
+body.dark .trip-btn-v2:hover { background: var(--color-tertiary); }
+`;
 
 /* ===== Static early-return views (#13: hoist to module level) ===== */
 
 const UNPUBLISHED_VIEW = (
-  <div className="page-layout">
-    <div className="container">
-      <div id="tripContent">
-        <div className="trip-error">
-          <p>此行程已下架</p>
+  <div className="flex min-h-dvh">
+    <div className="flex-1 min-w-0 max-w-full mx-auto">
+      <div id="tripContent-v2">
+        <div className="text-center p-10 text-foreground">
+          <p className="mb-4 text-title2">此行程已下架</p>
           <p className={UNPUBLISHED_CLASS}>2 秒後跳轉至設定頁…</p>
         </div>
       </div>
@@ -73,10 +209,10 @@ const UNPUBLISHED_VIEW = (
 );
 
 const LOADING_VIEW = (
-  <div className="page-layout">
-    <div className="container">
-      <div id="tripContent">
-        <div className="trip-loading">
+  <div className="flex min-h-dvh">
+    <div className="flex-1 min-w-0 max-w-full mx-auto">
+      <div id="tripContent-v2">
+        <div className="px-padding-h">
           <DaySkeleton />
           <DaySkeleton />
         </div>
@@ -148,28 +284,28 @@ const DaySection = React.memo(function DaySection({
 
   return (
     <section className="day-section" data-day={dayNum}>
-      <div className="day-header info-header relative" id={`day${dayNum}`}>
-        <h2>Day {dayNum}</h2>
+      <div className="day-header-v2 relative sticky z-(--z-day-header) bg-accent text-accent-foreground py-2 px-4 flex items-center gap-2 min-h-[100px] rounded-t-md" id={`day${dayNum}`}>
+        <h2 className="text-title2 font-bold whitespace-nowrap overflow-hidden text-ellipsis">Day {dayNum}</h2>
         {daySummary?.label && (
-          <span className="day-label">{daySummary.label}</span>
+          <span>{daySummary.label}</span>
         )}
         {daySummary?.date && (
-          <span className="dh-date">
+          <span className="text-subheadline text-muted ml-auto whitespace-nowrap">
             {daySummary.date}
             {daySummary.day_of_week && `（${daySummary.day_of_week}）`}
           </span>
         )}
         {themeArt && <DayArt entries={timeline} dark={themeArt.dark} />}
       </div>
-      <div key={animKey} className={clsx('day-content', animKey > 0 && 'day-content-enter', day && 'day-content-loaded')} id={`day-slot-${dayNum}`}>
+      <div key={animKey} className={clsx('px-padding-h pb-4', animKey > 0 && 'day-content-enter-v2', day && 'day-content-loaded-v2')} id={`day-slot-${dayNum}`}>
         {!day ? (
           <DaySkeleton />
         ) : (
           <>
             {warnings.length > 0 && (
-              <div className="trip-warnings">
+              <div className="bg-destructive-bg py-3 px-4 my-2 rounded-sm text-callout text-destructive">
                 <strong><Icon name="warning" /> 注意事項：</strong>
-                <ul>
+                <ul className="mt-1 ml-4">
                   {warnings.map((w) => <li key={w}>{w}</li>)}
                 </ul>
               </div>
@@ -185,7 +321,7 @@ const DaySection = React.memo(function DaySection({
               />
             )}
 
-            <div className="day-overview">
+            <div className="bg-accent-subtle rounded-sm p-3 mb-3">
               {hotel && typeof hotel === 'object' && <Hotel hotel={toHotelData(hotel as unknown as Record<string, unknown>)} />}
               {dayDrivingStats && (
                 <DayDrivingStatsCard stats={dayDrivingStats} />
@@ -196,7 +332,7 @@ const DaySection = React.memo(function DaySection({
                 全覽模式（hideDayMap=true）時隱藏，由 TripMap 取代
                 ENABLE_DAY_MAP=false 時完全隱藏（feature flag）*/}
             {ENABLE_DAY_MAP && !hideDayMap && (
-              <Suspense fallback={<div className="day-map-skeleton" aria-label="地圖載入中" />}>
+              <Suspense fallback={<div className="h-[200px] rounded-sm bg-secondary animate-pulse" aria-label="地圖載入中" />}>
                 <DayMap day={day} dayNum={dayNum} />
               </Suspense>
             )}
@@ -286,7 +422,7 @@ type ResolveState =
 
 /* ===== Component ===== */
 
-export default function TripPage() {
+export default function TripPageV2() {
   const { tripId: urlTripId } = useParams<{ tripId: string }>();
   const navigate = useNavigate();
   const [resolveState, setResolveState] = useState<ResolveState>({ status: 'loading' });
@@ -800,9 +936,9 @@ export default function TripPage() {
       requestAnimationFrame(() => {
         switchDay(dayNums[idx]);
         scrollToDay(dayNums[idx]);
-        // Scroll to [data-now] if it exists (delayed for DOM update)
+        // Scroll to .tl-now if it exists (delayed for DOM update)
         setTimeout(() => {
-          const nowEl = document.querySelector('[data-now]');
+          const nowEl = document.querySelector('.tl-now');
           if (nowEl) {
             nowEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
           }
@@ -817,7 +953,7 @@ export default function TripPage() {
       const nav = document.getElementById('stickyNav');
       if (!nav) return;
       const margin = (nav.offsetHeight + (parseFloat(getComputedStyle(nav).top) || 0) + 4) + 'px';
-      document.querySelectorAll('.day-header, .info-header').forEach((h) => {
+      document.querySelectorAll('.day-header-v2').forEach((h) => {
         (h as HTMLElement).style.scrollMarginTop = margin;
       });
     }
@@ -936,41 +1072,41 @@ export default function TripPage() {
       case 'prep':
         return (
           <>
-            <div className="info-card">{flightsData ? <Flights data={flightsData} /> : <p>無航班資料</p>}</div>
-            <div className="info-card">{checklistData ? <Checklist data={checklistData} /> : <p>無確認清單</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{flightsData ? <Flights data={flightsData} /> : <p>無航班資料</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{checklistData ? <Checklist data={checklistData} /> : <p>無確認清單</p>}</div>
           </>
         );
       case 'emergency-group':
         return (
           <>
-            <div className="info-card">{emergencyData ? <Emergency data={emergencyData} /> : <p>無緊急聯絡資料</p>}</div>
-            <div className="info-card">{backupData ? <Backup data={backupData} /> : <p>無備案資料</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{emergencyData ? <Emergency data={emergencyData} /> : <p>無緊急聯絡資料</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{backupData ? <Backup data={backupData} /> : <p>無備案資料</p>}</div>
           </>
         );
       case 'ai-group':
         return (
           <>
-            <div className="info-card">{suggestionsData ? <Suggestions data={suggestionsData} /> : <p>AI 沒意見喔</p>}</div>
-            <div className="info-card">{tripDrivingStats ? <TripDrivingStatsCard tripStats={tripDrivingStats} /> : <p>無交通資料</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{suggestionsData ? <Suggestions data={suggestionsData} /> : <p>AI 沒意見喔</p>}</div>
+            <div className="bg-secondary rounded-md p-4 mb-3">{tripDrivingStats ? <TripDrivingStatsCard tripStats={tripDrivingStats} /> : <p>無交通資料</p>}</div>
           </>
         );
       /* Settings sheets */
       case 'trip-select':
         return (
-          <div className="setting-page">
-            <div className="setting-section">
-              <div className="setting-trip-list">
+          <div className="max-w-[520px] mx-auto p-padding-h">
+            <div className="mb-3">
+              <div className="flex flex-col gap-2">
                 {sheetTripsLoading && (
                   <div className={LOADING_CLASS}>載入中...</div>
                 )}
                 {!sheetTripsLoading && sheetTrips.map((t) => (
                   <button
                     key={t.tripId}
-                    className={clsx('trip-btn', t.tripId === activeTripId && 'active')}
+                    className={clsx('trip-btn-v2', t.tripId === activeTripId && 'active')}
                     onClick={() => handleTripChange(t.tripId)}
                   >
-                    <strong>{t.name}</strong>
-                    {t.title && <span className="trip-sub">{t.title}</span>}
+                    <strong className="block text-title3">{t.name}</strong>
+                    {t.title && <span className="text-caption text-muted mt-1 block">{t.title}</span>}
                   </button>
                 ))}
               </div>
@@ -979,41 +1115,41 @@ export default function TripPage() {
         );
       case 'appearance':
         return (
-          <div className="setting-page">
-            <div className="setting-section">
-              <div className="setting-section-title">色彩模式</div>
-              <div className="color-mode-grid">
+          <div className="max-w-[520px] mx-auto p-padding-h">
+            <div className="mb-3">
+              <div className="text-footnote font-semibold text-muted uppercase tracking-wider mb-3 pb-2 border-b border-border">色彩模式</div>
+              <div className="grid grid-cols-3 gap-3">
                 {COLOR_MODE_OPTIONS.map((m) => (
                   <button
                     key={m.key}
-                    className={clsx('color-mode-card', m.key === colorMode && 'active')}
+                    className={clsx('color-mode-card-v2', m.key === colorMode && 'active')}
                     onClick={() => setColorMode(m.key)}
                   >
-                    <div className={`color-mode-preview color-mode-${m.key}`}>
+                    <div className={`color-mode-preview-v2 color-mode-${m.key}`}>
                       <div className="cmp-top"></div>
                       <div className="cmp-bottom">
                         <div className="cmp-input"></div>
                         <div className="cmp-dot"></div>
                       </div>
                     </div>
-                    <div className="color-mode-label">{m.label}</div>
+                    <div className="text-caption text-muted mt-1">{m.label}</div>
                   </button>
                 ))}
               </div>
-              <div className="setting-subsection-title">色彩主題</div>
-              <div className="color-theme-grid">
+              <div className="text-caption font-semibold text-muted mt-4 mb-2">色彩主題</div>
+              <div className="grid grid-cols-4 gap-2">
                 {COLOR_THEMES.map((t) => (
                   <button
                     key={t.key}
-                    className={clsx('color-theme-card', t.key === colorTheme && 'active')}
+                    className={clsx('color-theme-card-v2', t.key === colorTheme && 'active')}
                     data-theme={t.key}
                     onClick={() => setTheme(t.key)}
                   >
                     <div
-                      className="color-theme-swatch"
+                      className="color-theme-swatch-v2"
                       style={{ background: isDark ? THEME_ACCENTS[t.key].dark : THEME_ACCENTS[t.key].light }}
                     />
-                    <div className="color-theme-label">{t.label}</div>
+                    <div className="text-caption text-muted mt-1">{t.label}</div>
                   </button>
                 ))}
               </div>
@@ -1031,12 +1167,12 @@ export default function TripPage() {
 
   if (error && !trip) {
     return (
-      <div className="page-layout">
-        <div className="container">
-          <div id="tripContent">
-            <div className="trip-error">
-              <p>行程不存在：{activeTripId}</p>
-              <a className="trip-error-link" href="/">選擇其他行程</a>
+      <div className="flex min-h-dvh">
+        <div className="flex-1 min-w-0 max-w-full mx-auto">
+          <div id="tripContent-v2">
+            <div className="text-center p-10 text-foreground">
+              <p className="mb-4 text-title2">行程不存在：{activeTripId}</p>
+              <a className="inline-block py-3 px-6 bg-accent text-accent-foreground rounded-md no-underline font-semibold text-callout transition-[filter] duration-fast ease-apple hover:brightness-110" href="/">選擇其他行程</a>
             </div>
           </div>
         </div>
@@ -1046,11 +1182,13 @@ export default function TripPage() {
 
   return (
     <>
+      <style>{SCOPED_STYLES}</style>
+
       {/* Sticky Nav */}
-      <div className="sticky-nav" id="stickyNav">
+      <div className="sticky-nav-v2 sticky top-0 z-sticky-nav border-b border-border bg-(--color-glass-nav) backdrop-blur-xl backdrop-saturate-200 text-foreground py-3 px-padding-h flex items-center gap-3 overflow-x-hidden overflow-y-visible" id="stickyNav">
         {activeTripId && <DestinationArt tripId={activeTripId} dark={isDark} />}
         <TriplineLogo isOnline={isOnline} />
-        <span className={clsx('nav-inline-title', showNavTitle && 'visible')}>
+        <span className={clsx('nav-inline-title-v2 text-subheadline font-semibold text-foreground whitespace-nowrap overflow-hidden text-ellipsis max-w-[160px] md:hidden', showNavTitle && 'visible')}>
           {trip?.title || trip?.name}
         </span>
         <DayNav
@@ -1081,19 +1219,19 @@ export default function TripPage() {
       )}
 
       {/* Page Layout */}
-      <div className="page-layout">
-        <div className="container">
-          <div id="tripContent">
+      <div className="page-layout-v2 flex min-h-dvh">
+        <div className="container-v2 flex-1 min-w-0 max-w-full mx-auto">
+          <div id="tripContent-v2" className="pt-3">
             {/* Large Title (mobile only) */}
             {!loading && trip && (
-              <div className="large-title-area" ref={largeTitleRef}>
-                <h1 className="large-title">{trip.title || trip.name}</h1>
-                {dateRange && <p className="large-subtitle">{dateRange}</p>}
+              <div className="py-2 px-padding-h pb-4 block md:hidden" ref={largeTitleRef}>
+                <h1 className="text-large-title font-bold leading-tight text-foreground">{trip.title || trip.name}</h1>
+                {dateRange && <p className="text-subheadline text-muted mt-1">{dateRange}</p>}
               </div>
             )}
 
             {loading && (
-              <div className="trip-loading">
+              <div className="px-padding-h">
                 <DaySkeleton />
                 <DaySkeleton />
               </div>
@@ -1102,7 +1240,7 @@ export default function TripPage() {
             {/* TripMap 全覽地圖（F006）：全覽模式時顯示於 DaySections 上方
                 ENABLE_DAY_MAP=false 時完全隱藏（feature flag）*/}
             {ENABLE_DAY_MAP && !loading && isTripMapMode && (
-              <Suspense fallback={<div className="day-map-skeleton" aria-label="地圖載入中" />}>
+              <Suspense fallback={<div className="h-[200px] rounded-sm bg-secondary animate-pulse" aria-label="地圖載入中" />}>
                 <TripMap allDays={allDays} dayNums={dayNums} />
               </Suspense>
             )}
@@ -1156,7 +1294,11 @@ export default function TripPage() {
       {/* Edit FAB */}
       {!loading && trip && (
         <a
-          className={clsx('edit-fab', !isOnline && 'disabled')}
+          className={clsx(
+            'edit-fab-v2 fixed right-5 w-(--fab-size) h-(--fab-size) rounded-full bg-accent text-accent-foreground border-none text-large-title font-light no-underline flex items-center justify-center z-fab shadow-md transition-[transform,box-shadow] duration-normal ease-apple',
+            'bottom-[max(20px,env(safe-area-inset-bottom))]',
+            !isOnline && 'opacity-40 pointer-events-none',
+          )}
           id="editFab"
           href="/manage/"
           aria-label="AI 修改行程"
@@ -1181,7 +1323,11 @@ export default function TripPage() {
 
       {/* Print exit button */}
       {isPrintMode && (
-        <button className="print-exit-btn" id="printExitBtn" onClick={togglePrint}>
+        <button
+          className="print-exit-btn-v2 hidden fixed top-[10px] left-1/2 -translate-x-1/2 z-(--z-print-exit) bg-destructive text-accent-foreground border-none py-3 px-6 rounded-sm text-callout font-system font-semibold hover:brightness-[0.85] focus-visible:outline-none focus-visible:shadow-ring"
+          id="printExitBtn"
+          onClick={togglePrint}
+        >
           退出列印模式
         </button>
       )}

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -138,7 +138,7 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
   .info-panel {
     display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-6));
     width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-6));
-    overflow-y: auto; padding: var(--spacing-3);
+    overflow-y: auto; padding: var(--spacing-4) var(--spacing-3);
   }
 }
 /* Desktop layout: info-panel offset (no content max-width — match V1 full-width) */
@@ -926,6 +926,10 @@ export default function TripPageV2() {
   useEffect(() => {
     if (loading || dayNums.length === 0 || initialScrollDone.current) return;
     initialScrollDone.current = true;
+
+    // Reset browser scroll restoration to prevent stale position
+    if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    window.scrollTo(0, 0);
 
     // URL hash takes priority over auto-locate
     const hash = window.location.hash;

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -129,13 +129,9 @@ body.dark .day-header-v2 {
     overflow-y: auto; padding: var(--spacing-3);
   }
 }
-/* Desktop layout: info-panel offset */
-@media (min-width: 1024px) {
-  #tripContent-v2 { max-width: var(--content-max-w); margin: 0 auto; }
+/* Desktop layout: info-panel offset (no content max-width — match V1 full-width) */
+@media (min-width: 1200px) {
   .page-layout-v2:has(.info-panel) { padding-right: calc(var(--info-panel-w) + var(--spacing-3)); }
-}
-@media (min-width: 1024px) and (max-width: 1279px) {
-  #tripContent-v2 { max-width: none; }
 }
 /* day-header sticky on desktop */
 @media (min-width: 768px) {

--- a/src/pages/TripPageV2.tsx
+++ b/src/pages/TripPageV2.tsx
@@ -136,8 +136,8 @@ body.dark [data-tl-segment] { border-left-color: rgba(255,255,255,0.12); }
 .info-panel { display: none; background: var(--color-secondary); border-radius: var(--radius-lg); }
 @media (min-width: 1200px) {
   .info-panel {
-    display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-6));
-    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-6));
+    display: block; position: fixed; right: 0; top: calc(var(--spacing-nav-h) + var(--spacing-8));
+    width: var(--info-panel-w); height: calc(100dvh - var(--spacing-nav-h) - var(--spacing-8));
     overflow-y: auto; padding: var(--spacing-4) var(--spacing-3);
   }
 }

--- a/tests/unit/quick-panel.test.js
+++ b/tests/unit/quick-panel.test.js
@@ -203,13 +203,10 @@ describe('DRY: 常數不重複定義', () => {
 
 describe('QuickPanel single label per item', () => {
   it('each quick-panel-item renders one Icon and one label span', () => {
-    // In the JSX, each button should have exactly one <Icon> and one <span className="quick-panel-label">
-    // The pattern for rendering items is: <Icon .../> then <span className="quick-panel-label">
-    // Count occurrences of quick-panel-label in the item rendering sections
-    const labelMatches = tsx.match(/className="quick-panel-label"/g);
+    // In V2, each button has data-qp-item and a label <span> with Tailwind classes
+    // Count occurrences of label spans in the item rendering sections
+    const labelMatches = tsx.match(/leading-none">{item\.label}<\/span>/g);
     // There are 3 grid rendering sections (sectionA, sectionB, sectionC), each with one label per item
-    // But labels appear in the map functions, so there should be exactly 3 occurrences
-    // (one per map: sectionA+B map and sectionC map) - actually it's 3 map calls
     expect(labelMatches).not.toBeNull();
     // Each map renders one label per item — 3 separate map() calls
     expect(labelMatches.length).toBe(3);
@@ -300,9 +297,10 @@ describe('QuickPanel 無障礙', () => {
   });
 
   it('has X close button with aria-label', () => {
-    expect(tsx).toContain('sheet-close-btn');
+    // V2: sheet-close-btn replaced by Tailwind inline classes
     expect(tsx).toContain('aria-label="關閉"');
     expect(tsx).toContain('closeBtnRef');
+    expect(tsx).toContain('rounded-full');
   });
 
   it('focuses sheet on open (not close button, to avoid focus ring)', () => {
@@ -317,8 +315,10 @@ describe('QuickPanel sheet-handle 移除', () => {
     expect(tsx).not.toContain('sheet-handle');
   });
 
-  it('has quick-panel-header with close button instead', () => {
-    expect(tsx).toContain('quick-panel-header');
+  it('has header with close button instead', () => {
+    // V2: quick-panel-header replaced by Tailwind flex layout
+    expect(tsx).toContain('flex items-center justify-end');
+    expect(tsx).toContain('aria-label="關閉"');
   });
 });
 

--- a/tests/unit/trip-map.test.tsx
+++ b/tests/unit/trip-map.test.tsx
@@ -263,12 +263,12 @@ describe('TripMap — 圖例 pill 互動', () => {
     // pill-2 和 pill-3 應有 dimmed
     const pill2 = screen.getByTestId('trip-map-legend-pill-2');
     const pill3 = screen.getByTestId('trip-map-legend-pill-3');
-    expect(pill2).toHaveClass('trip-map-legend-pill--dimmed');
-    expect(pill3).toHaveClass('trip-map-legend-pill--dimmed');
+    expect(pill2).toHaveClass('opacity-40');
+    expect(pill3).toHaveClass('opacity-40');
 
     // pill-1 不應有 dimmed
     const pill1 = screen.getByTestId('trip-map-legend-pill-1');
-    expect(pill1).not.toHaveClass('trip-map-legend-pill--dimmed');
+    expect(pill1).not.toHaveClass('opacity-40');
   });
 });
 


### PR DESCRIPTION
## Summary
- Trip Page 走 V2 entry（mainV2 + tokens.css）
- 14 個 QA issues 修復（travel segment、InfoPanel、body margin、pill font 等）
- 修復 Vite preload-helper 合併 V1/V2 CSS deps 問題

## Vite CSS Fix
Vite 的 preload-helper 把 if/else 兩個分支的 dynamic import deps 合併預載，
導致 V2 頁面也載入 mainV1.css 造成樣式衝突。改用兩個獨立 if block 分離 deps。

## Test plan
- [x] Local dev: ?v2=1 正確載入 V2 CSS
- [x] Staging: 只載入 tokens.css，無 mainV1.css
- [x] V1 頁面（無 ?v2=1）不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)