### PR TITLE
fix: daily-check autofix 2026-04-09 — sw.js routing + InfoBox safe render + SSE loop guard

### DIFF
--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "include": ["/api/*", "/trip/*"],
-  "exclude": ["/assets/*", "/icons/*", "/manifest.json"]
+  "exclude": ["/assets/*", "/icons/*", "/manifest.json", "/sw.js", "/registerSW.js"]
 }

--- a/src/components/trip/InfoBox.tsx
+++ b/src/components/trip/InfoBox.tsx
@@ -103,7 +103,7 @@ function ReservationBox({ box }: { box: InfoBoxData }) {
     <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
       {box.title && <><strong className="font-semibold">{safeText(box.title)}</strong><br /></>}
       {box.items && box.items.length > 0 &&
-        box.items.map((item, i) => (
+        box.items.filter((item): item is string => typeof item === 'string').map((item, i) => (
           <span key={i}>{safeText(item)}<br /></span>
         ))
       }
@@ -123,7 +123,7 @@ function ParkingBox({ box }: { box: InfoBoxData }) {
         {box.location && <>{' '}<MapLinks location={box.location} inline /></>}
       </div>
       {box.note && (
-        <MarkdownText text={box.note} as="div" className="mt-2 text-footnote text-muted leading-relaxed" inline />
+        <MarkdownText text={safeText(box.note)} as="div" className="mt-2 text-footnote text-muted leading-relaxed" inline />
       )}
     </div>
   );

--- a/src/components/trip/InfoBox.tsx
+++ b/src/components/trip/InfoBox.tsx
@@ -10,6 +10,23 @@ import Shop, { type ShopData } from './Shop';
 import { escUrl } from '../../lib/sanitize';
 
 // ---------------------------------------------------------------------------
+// Safe text extraction — API may return objects like {text, checked} or {label, text}
+// ---------------------------------------------------------------------------
+
+function safeText(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.text === 'string') return obj.text;
+    if (typeof obj.label === 'string' && typeof obj.text === 'string') return `${obj.label}: ${obj.text}`;
+    if (typeof obj.name === 'string') return obj.name;
+  }
+  return String(value);
+}
+
+// ---------------------------------------------------------------------------
 // Souvenir item shape
 // ---------------------------------------------------------------------------
 
@@ -84,13 +101,13 @@ function gridClass(count: number): string {
 function ReservationBox({ box }: { box: InfoBoxData }) {
   return (
     <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
-      {box.title && <><strong className="font-semibold">{box.title}</strong><br /></>}
+      {box.title && <><strong className="font-semibold">{safeText(box.title)}</strong><br /></>}
       {box.items && box.items.length > 0 &&
-        box.items.filter((item): item is string => typeof item === 'string').map((item, i) => (
-          <span key={i}>{item}<br /></span>
+        box.items.map((item, i) => (
+          <span key={i}>{safeText(item)}<br /></span>
         ))
       }
-      {box.notes && <MarkdownText text={box.notes} as="div" />}
+      {box.notes && <MarkdownText text={safeText(box.notes)} as="div" />}
     </div>
   );
 }
@@ -100,9 +117,9 @@ function ParkingBox({ box }: { box: InfoBoxData }) {
     <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
       <div>
         {box.title && (
-          <><Icon name="parking" /> <strong className="font-semibold">{box.title}</strong></>
+          <><Icon name="parking" /> <strong className="font-semibold">{safeText(box.title)}</strong></>
         )}
-        {box.price && <>：{box.price}</>}
+        {box.price && <>：{safeText(box.price)}</>}
         {box.location && <>{' '}<MapLinks location={box.location} inline /></>}
       </div>
       {box.note && (
@@ -117,7 +134,7 @@ function SouvenirBox({ box }: { box: InfoBoxData }) {
   const items = (box.items ?? []).filter((item): item is SouvenirItem => typeof item === 'object' && item !== null);
   return (
     <div className="my-2 py-2 px-3 rounded-sm text-body leading-relaxed bg-accent-bg">
-      {box.title && <><Icon name="gift" /> <strong className="font-semibold">{box.title}</strong><br /></>}
+      {box.title && <><Icon name="gift" /> <strong className="font-semibold">{safeText(box.title)}</strong><br /></>}
       {items.map((item, i) => {
         const itemUrl = escUrl(item.url);
         return (

--- a/src/components/trip/InfoBox.tsx
+++ b/src/components/trip/InfoBox.tsx
@@ -19,8 +19,8 @@ function safeText(value: unknown): string {
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   if (typeof value === 'object') {
     const obj = value as Record<string, unknown>;
-    if (typeof obj.text === 'string') return obj.text;
     if (typeof obj.label === 'string' && typeof obj.text === 'string') return `${obj.label}: ${obj.text}`;
+    if (typeof obj.text === 'string') return obj.text;
     if (typeof obj.name === 'string') return obj.name;
   }
   return String(value);

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -224,31 +224,24 @@ export default function ManagePage() {
 
   /* ----- SSE: track status of the latest non-terminal request ----- */
   const sse = useRequestSSE(sseRequestId);
-  // Update local request status optimistically on every SSE status change
+  // Ref guard: track last processed status+id to prevent re-processing
+  const lastProcessedRef = useRef<string | null>(null);
   useEffect(() => {
-    if (sse.status && sseRequestId) {
-      updateRequestStatus(sseRequestId, sse.status, sse.processedBy);
-      if (sse.status === 'completed') {
-        showToast('你的請求已處理完成！', 'success', 3000);
-        setSseRequestId(null);
-      } else if (sse.status === 'failed') {
-        showToast('處理失敗，請稍後重新提交', 'error', 5000);
-        setSseRequestId(null);
-      }
-    }
-  }, [sse.status, sse.processedBy, sseRequestId, updateRequestStatus]);
+    if (!sse.status || !sseRequestId) return;
+    const key = `${sseRequestId}:${sse.status}`;
+    if (key === lastProcessedRef.current) return;
+    lastProcessedRef.current = key;
 
-  // Fetch full request data from server only when status reaches 'completed'
-  // Separated from the above effect to avoid cascading setRequests() calls
-  const completedRequestIdRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (sse.status === 'completed' && sseRequestId && sseRequestId !== completedRequestIdRef.current) {
-      completedRequestIdRef.current = sseRequestId;
+    updateRequestStatus(sseRequestId, sse.status, sse.processedBy);
+    if (sse.status === 'completed') {
+      showToast('你的請求已處理完成！', 'success', 3000);
       refreshRequest(sseRequestId);
-    } else if (sse.status !== 'completed') {
-      completedRequestIdRef.current = null;
+      setSseRequestId(null);
+    } else if (sse.status === 'failed') {
+      showToast('處理失敗，請稍後重新提交', 'error', 5000);
+      setSseRequestId(null);
     }
-  }, [sse.status, sseRequestId, refreshRequest]);
+  }, [sse.status, sse.processedBy, sseRequestId, updateRequestStatus, refreshRequest]);
 
   /* ----- SSE disconnect warning ----- */
   const sseWasConnectedRef = useRef(false);


### PR DESCRIPTION
## Summary
- **sw.js routing**: 加入 `_routes.json` exclude，避免被 Cloudflare Functions 攔截返回 HTML（Sentry #7-10）
- **InfoBox safe render**: 新增 `safeText()` 防止 API 回傳 `{text, checked}` / `{label, text}` 物件被當 React child 渲染（Sentry #4-5）
- **ManagePage SSE loop guard**: 合併兩個 SSE effects + ref guard 防止 Maximum update depth exceeded（Sentry #1-2）

## Test plan
- [x] TypeScript 零錯誤
- [x] 434 unit/integration tests 全過
- [x] tp-code-verify 綠燈
- [x] /review 通過（adversarial review 修正 2 項）
- [x] /cso --diff 零 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)