### PR TITLE
fix: RawRestaurant 移除多餘 sortOrder (#166)

### DIFF
--- a/src/lib/mapDay.ts
+++ b/src/lib/mapDay.ts
@@ -16,7 +16,6 @@ import type { HotelData } from '../components/trip/Hotel';
 interface RawRestaurant {
   name?: string | null;
   sort_order?: number | null;
-  sortOrder?: number | null;
   category?: string | null;
   hours?: string | null;
   price?: string | null;
@@ -135,7 +134,7 @@ function formatTravelText(travel: RawTravel): string {
 function toRestaurantData(r: RawRestaurant): RestaurantData {
   return {
     name: r.name || '',
-    sortOrder: (r.sort_order ?? r.sortOrder) ?? null,
+    sortOrder: r.sort_order ?? null,
     category: r.category ?? null,
     hours: r.hours ?? null,
     price: r.price ?? null,


### PR DESCRIPTION
## Summary
- `RawRestaurant` 移除多餘的 `sortOrder` 欄位，API 只回傳 `sort_order`（snake_case）
- `toRestaurantData` 簡化為 `r.sort_order ?? null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)