### PR TITLE
docs(todos): session 清倉 — 6 項完成、#6 標註 NEEDS /plan-eng-review

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -9,84 +9,60 @@
 - **P3** — 想做再做（nice-to-have）
 - **P4** — 可能不做（長期觀察）
 
-## DayNav / Scroll Spy
-
-### Mobile URL bar 收縮造成 active pill 抖動
-
-**Priority:** P2
-**Source:** PR #182 adversarial review finding #3（confidence 85%）
-
-在 mobile Chrome / Safari，使用者捲動時 URL bar 會收縮，`window.innerHeight` 從約 600 跳到約 660。`src/lib/scrollSpy.ts` 的 threshold 用了 `innerHeight`，邊界情境（day header top 剛好落在新舊 threshold 中間，約 20px 區間）active pill 可能 toggle 一次。
-
-**實務影響**：小。`TripPage.tsx` 的 `scrollDayRef.current !== activeDayNum` dedup guard 避免重複 `switchDay` call；CSS sliding indicator 的 spring transition 會平滑 absorb 短暫切換。但用嚴格標準仍是 bug。
-
-**修法選項**：
-- 改用 `document.documentElement.clientHeight`（layout viewport，mobile 穩定）
-- 或 cache `innerHeight` 一次，scroll 期間不重讀（resize 才更新）
-- 或加 hysteresis：active pill 「離開」門檻比「進入」大 ~50px
-
-### Print mode scroll listener 沒 teardown
-
-**Priority:** P3
-**Source:** PR #182 adversarial review finding #2
-
-`TripPage.tsx` 的 onScroll effect deps 為 `[loading, dayNums, switchDay]`，不含 `isPrintMode`。進入 print mode 後 scroll listener 繼續存活，仍會 `switchDay()` 觸發 state update。實際使用者不會在 print mode 捲太久，影響很小。
-
-**修法**：effect 加 `isPrintMode` 依賴，print mode 下 early return。
-
-### `scrollDayRef.current` 跨行程 stale
-
-**Priority:** P3
-**Source:** PR #182 adversarial review finding #6
-
-`scrollDayRef = useRef(0)` 在行程切換後（`handleTripChange`）不會 reset。若前後兩趟行程都在 Day 1 結束，`scrollDayRef.current === 1` 時不會呼叫 `switchDay(1)`，導致新行程載入後 hash 殘留舊值。active pill 視覺不受影響（由 `currentDayNum` 控制）。
-
-**修法**：`handleTripChange` 加 `scrollDayRef.current = 0`。
-
-### 單天行程 hash 永不更新
-
-**Priority:** P4
-**Source:** PR #182 adversarial review finding #5
-
-若行程只有一天且頁面內容短於 viewport 高度，使用者無法捲動，`onScroll` 不會觸發，URL hash 停在初始值或空。`currentDayNum` 由 `useTrip` 的 `first.dayNum` 初始化，所以 active pill 正確，純 URL hash 問題。
-
-**修法**：`TripPage` 初次 resolve 完 trip 後，同步 push `#day${firstDayNum}` 到 URL。
-
-## Documentation
-
-### 補 docs 資料夾截圖
-
-**Priority:** P3
-**Source:** README 引用 `docs/daily-report-flow.png` 但該資料夾可能不存在
-
-README.md 第 47 行 `![每日行程流程](docs/daily-report-flow.png)` 若 `docs/` 不存在或檔名錯，README 會顯示 broken image。待確認並補上或移除。
-
 ## Observability
 
 ### `api_logs` source 欄位的 scheduler / companion 仍是 self-reported
 
 **Priority:** P3
+**Status:** NEEDS /plan-eng-review（架構議題，非 quick fix）
 **Source:** `functions/api/_middleware.ts:35-36` 註解已標註
 **Context:** 見 [ARCHITECTURE.md](ARCHITECTURE.md) Auth 段落「信任邊界重點」
 
-`detectSource()` 是 self-reported telemetry，不是 auth decision。daily-check 做 escalation 時只看 source 會被繞過。目前靠 path + error code secondary signal，還算穩。長期若要收斂成單一驗證點，需重設計 header 簽章或換 Cloudflare Service Token 分流。
+`detectSource()` 是 self-reported telemetry，不是 auth decision。daily-check 做 escalation 時只看 source 會被繞過。目前靠 path + error code 等 secondary signal 做 defense in depth，還算穩。
 
-## Tests
+長期若要收斂成單一驗證點需重設計：
 
-### Regression test for request scheduler timezone bug
+**選項 A**：在 scheduler / companion 端加 HMAC 簽章 header，middleware 驗簽才接受 `X-Tripline-Source` 宣告。優點可驗證、缺點金鑰管理成本。
 
-**Priority:** P2
-**Source:** PR #171 commit `9f414da`（`fix: daily-check todayISO() 使用本地時區`）
+**選項 B**：改用 Cloudflare Service Token，不同 token 對應不同 source，`CF-Access-Client-Id` 直接是身份識別。優點 CF 原生支援、缺點綁 Cloudflare、Service Token 輪換有運維成本。
 
-舊 bug 是跨午夜區間用 UTC 判「今天」造成漏信。修復時沒加 regression test。補一個能模擬伺服器時區切換的測試。
+**選項 C**：接受現況，在 daily-check escalation 邏輯加更多 secondary signals（URL 路徑、error code 分布、IP reputation 等），不靠 source 單點。成本最低、防禦層次多。
+
+建議先跑 `/office-hours` 探索威脅模型與業務影響，再 `/plan-eng-review` 選方案。**不適合塞進小 PR 直接做**。
 
 ---
 
 ## Completed
 
-<!-- 完成的項目搬到這裡，加 `**Completed:** vX.Y.Z (YYYY-MM-DD)` -->
+### TODOS #5 誤報：docs/daily-report-flow.png 存在
 
-### DayNav scroll spy 閾值標錯日
+**Priority:** P3（誤報）
+**Completed:** 2026-04-17（`docs/todos-cleanup` PR）
+
+原先註記 README.md:47 `docs/daily-report-flow.png` 可能缺失。實際檢查 `docs/` 目錄存在且 `daily-report-flow.png`（196KB）、`daily-report-flow-wide.png`、`daily-report-flow.html` 都在。此 TODO 為誤報，無需處理。
+
+### TODOS #2：daily-check todayISO timezone regression test
+
+**Priority:** P2
+**Completed:** v1.2.3.7 (2026-04-17)
+**PR:** [#185](https://github.com/raychiutw/trip-planner/pull/185)
+
+把 `daily-check.js` 內聯的 `todayISO()` 抽到 `scripts/lib/local-date.js` 共用模組（支援注入時間），補 6 條單元測試覆蓋 PR #171 的原 bug 現場（凌晨 06:13 本地時間屬「今天」而非 UTC 前一天）+ 月日邊界。時區無關，CI runner 任何 TZ 穩定。
+
+### TODOS #1 #3 #4 #7：scroll spy 4 個 follow-up
+
+**Priority:** P2 / P3 / P3 / P4
+**Completed:** v1.2.3.6 (2026-04-17)
+**PR:** [#184](https://github.com/raychiutw/trip-planner/pull/184)
+
+- **#1 Mobile URL bar 抖動**：新增 `getStableViewportH()` 用 `documentElement.clientHeight` (layout viewport)，mobile Chrome/Safari 捲動時 URL bar 收縮不再造成 active pill toggle
+- **#3 Print mode scroll listener**：onScroll effect 加 `isPrintMode` 依賴 + 進入 print mode early return
+- **#4 scrollDayRef 跨行程 stale**：`handleTripChange` reset ref
+- **#7 單天行程 hash**：新增 `computeInitialHash()` pure function，初次載入自動推 `#day{today}` 或 `#day{first}` fallback
+
+加 8 條單元測試覆蓋 pure function（viewport 穩定性、hash fallback 邊界）。
+
+### TODOS：DayNav scroll spy 閾值標錯日
 
 **Priority:** P1
 **Completed:** v1.2.3.5 (2026-04-17)
@@ -94,7 +70,7 @@ README.md 第 47 行 `![每日行程流程](docs/daily-report-flow.png)` 若 `do
 
 捲動到 Day N header 完整顯示在 sticky nav 下方時 active pill 仍停在 Day N−1。閾值從 `navH + 10` 改為 `navH + (innerHeight − navH) / 3`，並抽成 `src/lib/scrollSpy.ts` pure function + 10 條 regression test。
 
-### 防止 GET /days/undefined 404
+### TODOS：防止 GET /days/undefined 404
 
 **Priority:** P1
 **Completed:** v1.2.3.4 (2026-04-16)
@@ -102,7 +78,7 @@ README.md 第 47 行 `![每日行程流程](docs/daily-report-flow.png)` 若 `do
 
 `fetchDay` 加 `Number.isInteger` 守門避免 undefined/NaN 發出 API 請求。
 
-### CI 自動 apply D1 migrations
+### TODOS：CI 自動 apply D1 migrations
 
 **Priority:** P1
 **Completed:** v1.2.3.3 (2026-04-13)


### PR DESCRIPTION
## Summary

反映本次 session（PR #184 + #185）完成的進度，TODOS 從 **7 open** 收斂到 **1 open**。

## Open TODOs 剩下

| # | 項目 | Priority | Status |
|---|------|---------|--------|
| 1 | api_logs source 欄位簽章 | P3 | **NEEDS /plan-eng-review** |

註記擴充為 3 個架構選項：
- **A** HMAC 簽章 header（可驗證、金鑰管理成本）
- **B** Cloudflare Service Token（原生支援、綁 CF）
- **C** 多層 secondary signals（成本最低、防禦層次多）

建議先 `/office-hours` 探索威脅模型 + 業務影響再 `/plan-eng-review` 選方案。不適合塞進小 PR 直接做。

## 移到 Completed

| # | 項目 | PR | Version |
|---|------|----|---------|
| #1 Mobile URL bar 抖動 | P2 | #184 | v1.2.3.6 |
| #3 Print mode listener | P3 | #184 | v1.2.3.6 |
| #4 scrollDayRef stale | P3 | #184 | v1.2.3.6 |
| #7 單天行程 hash | P4 | #184 | v1.2.3.6 |
| #2 timezone regression test | P2 | #185 | v1.2.3.7 |
| #5 docs/ 截圖 | P3 | — | **誤報移除** — `docs/daily-report-flow.png` 實際存在（196KB） |

## Verification

- TODOS.md 結構符合原設計（priority 分組 + Completed section）
- 每個 Completed 項目含 PR 連結 + version tag 方便追溯
- 純文件變更，不 bump VERSION，不走 code pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)