### PR TITLE
fix(leaflet): cleanup 前呼叫 map.stop() — 修 iOS Chrome _leaflet_pos crash

### DIFF
--- a/src/hooks/useLeafletMap.ts
+++ b/src/hooks/useLeafletMap.ts
@@ -86,6 +86,11 @@ export function useLeafletMap(opts: UseLeafletMapOptions = {}): UseLeafletMap {
     setMap(instance);
 
     return () => {
+      // Stop any in-flight pan/zoom animation before teardown.
+      // Without this, a queued _onZoomTransitionEnd setTimeout can fire
+      // after map.remove() clears panes, throwing "_leaflet_pos" TypeError
+      // (seen on iOS Chrome when navigating away mid-animation).
+      instance.stop();
       instance.remove();
       setMap(null);
     };


### PR DESCRIPTION
## Summary
- Sentry issue [#7425167093](https://ray-team-gq.sentry.io/issues/7425167093/) — iOS Chrome 從 StopDetailPage 返回行程時 `TypeError: undefined is not an object (evaluating e._leaflet_pos)` 崩潰
- 根因：OceanMap (detail) unmount 時 `map.remove()` 被呼叫，但 `setView` 的 zoom 動畫 setTimeout 仍在 queue，callback 執行時 pane 已被清掉
- Fix：`map.remove()` 前先 `map.stop()`，取消所有 pan/zoom 動畫 + 相關 timers

## Test plan
- [x] tsc + vite build 通過
- [ ] prod 部署後觀察 Sentry 無新 event
- [ ] 手動測試：iOS Chrome / Safari 從 StopDetailPage 返回行程不崩潰

## Context
- Breadcrumbs 顯示 user 點「返回行程」按鈕後 2 秒內 crash
- mechanism: `auto.browser.browserapierrors.setTimeout` → 標準 Leaflet teardown race
- 由 `/tp-daily-check` 2026-04-20 自動檢測並修復

🤖 Generated with [Claude Code](https://claude.com/claude-code)