### PR TITLE
docs(design-sessions): 11 mockup HTML + roadmap update + agent-skills cleanup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "hooks": {},
   "enabledPlugins": {
-    "oh-my-claudecode@omc": true,
-    "agent-skills@addy-agent-skills": true
+    "oh-my-claudecode@omc": true
   }
 }

--- a/docs/2026-04-24-saas-pivot-roadmap.md
+++ b/docs/2026-04-24-saas-pivot-roadmap.md
@@ -26,6 +26,24 @@ trip-planner 從 2-user 私人工具（Cloudflare Access + email 白名單）轉
 | `lean-master-design-20260424-190000-mindtrip-layout-reference.md` | Mindtrip 桌機 + 手機布局規格 | Layout refactor 的 px / grid / URL state / overlay rules 規格書 |
 | `terracotta-preview.html` | Terracotta palette 視覺預覽 | 設計色彩參考 |
 
+### Mockup HTML（`docs/design-sessions/`）
+
+B-P2 layout refactor 視覺參考集合 — 透過 `tp-claude-design` skill 產出，每個檔含桌機 1440 / 1100 / mobile 375 三組 viewport，可直接對照實作。
+
+| 檔案 | 對應 | 用途 |
+|------|------|------|
+| `mockup-index.html` | 入口 | 11 檔導覽頁（3 shell variant + 7 page route + task 對照表） |
+| `mockup-shell-v1-ocean.html` | Shell V1 | Ocean 保守路線（對齊 tokens.css 現狀，零 retheme） |
+| `mockup-shell-v2-terracotta.html` | Shell V2 ✓ locked | Terracotta filled dark active pill（2026-04-24 定案） |
+| `mockup-shell-v3-magazine.html` | Shell V3 | Terracotta + 雜誌 editorial typography 變體 |
+| `mockup-trip-v2.html` | `/manage` | 行程 list + sheet 內 day strip + ocean-rail itinerary + trip switcher dropdown（無 sheet tabs） |
+| `mockup-chat-v2.html` | `/chat` | 全站 AI discovery entry：empty hero / 對話中 / 聊出 trip → sheet 展開 |
+| `mockup-map-v2.html` | `/map` | cross-trip global map（view-only、不含 search、sheet 32vw） |
+| `mockup-explore-v2.html` | `/explore` | search/儲存池 2 tab + multi-select + 加入 trip dropdown |
+| `mockup-login-v2.html` | `/login` | 未登入（OAuth Google/Apple/LINE 真實 SVG logo + Email）/ 已登入 settings |
+| `mockup-signup-v2.html` | `/login/signup` | Step 1 OAuth + Email 三 field + password meter / Step 2 等 verification |
+| `mockup-forgot-v2.html` | `/login/forgot` | Step 1 寄連結 / Step 2 設新密碼（password rule meter） |
+
 ### OpenSpec Changes（`openspec/changes/`）
 
 全部 4/4 artifacts complete，`openspec status` 皆 apply-ready：
@@ -206,6 +224,7 @@ V2-P7 Launch + audit                         B-P6 Polish  ◄┘
 - [Mindtrip UX benchmark](design-sessions/lean-master-design-20260424-180000-mindtrip-benchmark.md)
 - [Mindtrip layout reference](design-sessions/lean-master-design-20260424-190000-mindtrip-layout-reference.md)
 - [Terracotta preview](design-sessions/terracotta-preview.html)
+- [Mockup HTML 集合（B-P2 視覺參考）](design-sessions/mockup-index.html)
 - [OpenSpec changes](../openspec/changes/)
 - [既有 DESIGN.md](../DESIGN.md)
 - [tp-claude-design skill](../.claude/skills/tp-claude-design/)
@@ -215,3 +234,4 @@ V2-P7 Launch + audit                         B-P6 Polish  ◄┘
 ## Changelog
 
 - **2026-04-24 session**：完成 autoplan + office-hours 4 輪 + opsx:propose 產 6 changes。User 主動 research Mindtrip 競品 UX（提供 12 張 screenshots）+ 把 Mindtrip + OpenAuth 方案兩 model 挑戰全納入但 override 後維持 plan。
+- **2026-04-24 mockup batch**：透過 `tp-claude-design` skill 產出 11 個 HTML mockup（3 shell variant + 7 page route + 1 index）放在 `docs/design-sessions/mockup-*.html`。Shell V2 Terracotta 為 locked palette。Sheet 結構優化：移除 sheet tabs（功能跟 sidebar nav 重複）、改 trip switcher dropdown。Provider button 用真實 OAuth logo SVG（Google/Apple/LINE）。

--- a/docs/design-sessions/mockup-chat-v2.html
+++ b/docs/design-sessions/mockup-chat-v2.html
@@ -1,0 +1,958 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Chat Page — /chat</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  --grid-3pane: 240px 1fr min(780px, 40vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+  --font-caption2: 0.6875rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+/* Chat history list inside sidebar (聊天頁特有) */
+.sidebar-section-label {
+  padding: 12px 14px 6px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+}
+.chat-history-item {
+  display: block;
+  padding: 8px 14px; border-radius: 8px;
+  color: var(--foreground); text-decoration: none;
+  font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  transition: background 0.15s;
+}
+.chat-history-item:hover { background: var(--hover); }
+.chat-history-item.active { background: var(--accent-subtle); color: var(--accent-deep); font-weight: 600; }
+.chat-history-item .ch-time {
+  display: block; font-size: 11px; color: var(--muted); margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Chat Main Area ========== */
+.chat-main {
+  display: flex; flex-direction: column;
+  background: var(--secondary);
+  overflow: hidden;
+  position: relative;
+}
+.chat-topbar {
+  height: 56px; padding: 0 24px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  flex-shrink: 0;
+}
+.chat-topbar .conv-title {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.005em;
+  display: flex; align-items: center; gap: 8px;
+}
+.chat-topbar .conv-title .conv-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.chat-topbar .topbar-actions { display: flex; gap: 6px; }
+.chat-topbar .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 13px;
+}
+.chat-topbar .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Conversation feed */
+.conv-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 0;
+}
+.conv-feed-inner {
+  max-width: 760px; margin: 0 auto; padding: 0 32px;
+  display: flex; flex-direction: column; gap: 20px;
+}
+
+.msg { display: flex; gap: 12px; }
+.msg.user { justify-content: flex-end; }
+.msg.user .bubble {
+  background: var(--accent); color: #fff;
+  border-bottom-right-radius: 4px;
+}
+.msg.ai .bubble {
+  background: var(--background); border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+.msg .avatar-sm {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center;
+  font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+.msg.ai .avatar-sm { background: var(--foreground); color: var(--background); }
+.msg .bubble {
+  padding: 12px 16px; border-radius: 16px;
+  font-size: 15px; line-height: 1.55;
+  max-width: 560px;
+}
+.msg .bubble strong { font-weight: 600; }
+.msg .bubble .bubble-meta {
+  display: flex; gap: 8px; align-items: center;
+  margin-top: 8px; padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-size: 11px; color: var(--muted);
+  letter-spacing: 0.08em; text-transform: uppercase; font-weight: 600;
+}
+.msg.user .bubble .bubble-meta { border-top-color: rgba(255,255,255,0.2); color: rgba(255,255,255,0.7); }
+
+/* AI 提案 trip card inside bubble */
+.proposal-card {
+  display: block; margin-top: 12px;
+  border: 1px solid var(--border); border-radius: 12px;
+  background: var(--secondary);
+  padding: 12px;
+  cursor: pointer;
+}
+.proposal-card:hover { border-color: var(--accent); }
+.proposal-card .pc-cover {
+  height: 90px; border-radius: 8px;
+  background: linear-gradient(135deg, #D97848 0%, #F0935E 100%);
+  margin-bottom: 8px;
+}
+.proposal-card .pc-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 4px;
+}
+.proposal-card .pc-title {
+  font-size: 15px; font-weight: 700; letter-spacing: -0.005em; color: var(--foreground);
+  margin-bottom: 4px;
+}
+.proposal-card .pc-meta {
+  font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+
+/* Empty hero (新對話開頭) */
+.empty-hero {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 32px;
+  text-align: center;
+}
+.empty-hero .hero-greeting {
+  font-size: 36px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.2;
+  margin-bottom: 12px;
+}
+.empty-hero .hero-greeting .accent-dot { color: var(--accent); }
+.empty-hero .hero-sub {
+  font-size: 16px; color: var(--muted); margin-bottom: 32px;
+  max-width: 480px;
+}
+.suggestion-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;
+  max-width: 640px; width: 100%;
+}
+.sug-chip {
+  padding: 14px 18px; border-radius: 14px;
+  border: 1px solid var(--border); background: var(--background);
+  text-align: left; cursor: pointer; font-family: inherit;
+  display: flex; flex-direction: column; gap: 4px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.sug-chip:hover { border-color: var(--accent); background: var(--hover); }
+.sug-chip .sug-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--accent-deep);
+}
+.sug-chip .sug-text {
+  font-size: 14px; font-weight: 600; color: var(--foreground); letter-spacing: -0.005em;
+}
+
+/* Chat input (sticky bottom) */
+.chat-input-wrap {
+  flex-shrink: 0; padding: 16px 24px 24px;
+  background: linear-gradient(to top, var(--secondary) 80%, transparent);
+}
+.chat-input {
+  max-width: 760px; margin: 0 auto;
+  display: flex; align-items: center; gap: 10px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 9999px;
+  padding: 8px 12px;
+  box-shadow: var(--shadow-sm);
+  min-height: 56px;
+}
+.chat-input:focus-within { border-color: var(--accent); }
+.chat-input .input-btn {
+  width: 36px; height: 36px; border-radius: 50%;
+  border: none; background: transparent;
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted);
+}
+.chat-input .input-btn:hover { background: var(--hover); color: var(--accent); }
+.chat-input .input-btn.send {
+  background: var(--accent); color: #fff;
+}
+.chat-input .input-btn.send:hover { background: var(--accent-deep); }
+.chat-input .input-field {
+  flex: 1; border: none; background: transparent;
+  font: inherit; font-size: 15px; color: var(--foreground);
+  outline: none; padding: 0 4px;
+}
+.chat-input .input-field::placeholder { color: var(--muted); }
+
+/* Quick action bubbles above input */
+.quick-actions {
+  max-width: 760px; margin: 0 auto 12px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+.qa-bubble {
+  padding: 6px 12px; border-radius: 9999px;
+  border: 1px solid var(--border); background: var(--background);
+  font: inherit; font-size: 12px; color: var(--muted);
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.qa-bubble:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ========== Right Sheet (聊天聊出來的 trip) ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+.sheet-header .save-btn {
+  padding: 6px 14px; border-radius: 9999px;
+  background: var(--accent); color: #fff; border: none;
+  font: inherit; font-size: 12px; font-weight: 600;
+  cursor: pointer;
+}
+.sheet-header .save-btn:hover { background: var(--accent-deep); }
+
+.sheet-title { padding: 16px 24px 8px; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+.sheet-meta {
+  padding: 0 24px 16px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+}
+.sheet-meta .chip { padding: 4px 10px; border-radius: 9999px; background: var(--tertiary); }
+.sheet-meta .chip.active { background: var(--accent-subtle); color: var(--accent-deep); font-weight: 600; }
+
+.sheet-tabs {
+  display: flex; gap: 0; padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+.sheet-tab {
+  padding: 12px 14px; font-size: 14px; font-weight: 500;
+  color: var(--muted); cursor: pointer;
+  border: none; background: transparent; font-family: inherit;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.sheet-tab.active { color: var(--foreground); font-weight: 600; border-bottom-color: var(--accent); }
+.sheet-tab:hover:not(.active) { color: var(--foreground); }
+
+.sheet-body { flex: 1; overflow-y: auto; }
+
+/* Day strip */
+.day-strip {
+  display: flex; gap: 4px;
+  overflow-x: auto;
+  padding: 0 24px;
+  position: sticky; top: 0;
+  background: color-mix(in srgb, var(--sheet-bg) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  z-index: 5;
+  scrollbar-width: none;
+}
+.day-strip::-webkit-scrollbar { display: none; }
+.day-strip-btn {
+  flex: 0 0 auto; padding: 10px 12px;
+  border: none; background: transparent;
+  border-bottom: 2px solid transparent;
+  cursor: pointer; font-family: inherit;
+  color: var(--muted);
+  display: inline-flex; flex-direction: column; gap: 2px;
+  min-height: 44px;
+}
+.day-strip-btn.active { color: var(--accent-deep); border-bottom-color: var(--accent); }
+.day-strip-btn .dn-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+.day-strip-btn.active .dn-eyebrow { opacity: 1; }
+.day-strip-btn .dn-date {
+  font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums;
+}
+
+/* Ocean rail */
+.rail { padding: 16px 20px 20px; }
+.rail-header {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 10px; padding: 0 4px;
+}
+.rail-eyebrow {
+  font-size: var(--font-caption2); letter-spacing: 0.2em; color: var(--muted);
+  text-transform: uppercase; font-weight: 600;
+}
+.rail-meta { font-size: var(--font-caption2); color: var(--muted); font-variant-numeric: tabular-nums; }
+.rail-body { position: relative; padding: 0; }
+.rail-line {
+  position: absolute; left: 66px; top: 12px; bottom: 12px;
+  width: 1px; background: var(--border);
+}
+.rail-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 44px 24px 22px 1fr 18px;
+  column-gap: 10px; align-items: center;
+  width: 100%; padding: 12px 4px;
+  border-bottom: 1px dashed var(--border);
+  cursor: pointer;
+}
+.rail-item:hover { background: var(--hover); }
+.rail-item[data-last="true"] { border-bottom: none; }
+.rail-time {
+  text-align: right;
+  font-size: 13px; font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.rail-dot {
+  justify-self: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--background); border: 1.5px solid var(--line-strong);
+  display: grid; place-items: center;
+  font-size: var(--font-caption2); font-weight: 700; color: var(--muted);
+  z-index: 1;
+}
+.rail-item[data-accent="true"] .rail-dot { border-color: var(--accent); color: var(--accent); }
+.rail-icon {
+  width: 22px; height: 22px;
+  display: grid; place-items: center; color: var(--muted);
+}
+.rail-icon svg { width: 18px; height: 18px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.rail-item[data-accent="true"] .rail-icon { color: var(--accent); }
+.rail-content { min-width: 0; overflow: hidden; }
+.rail-name {
+  display: block; font-size: 15px; font-weight: 600; letter-spacing: -0.01em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rail-sub {
+  display: flex; gap: 6px; align-items: center;
+  font-size: 12px; color: var(--muted); margin-top: 3px;
+}
+.rail-type {
+  font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+}
+.rail-item[data-accent="true"] .rail-type { color: var(--accent); }
+.rail-sep { opacity: 0.5; }
+.rail-caret {
+  font-size: 18px; color: var(--muted);
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  flex-shrink: 0;
+}
+.mobile-topbar .brand {
+  font-size: 14px; font-weight: 700; letter-spacing: -0.005em;
+  display: flex; align-items: center; gap: 8px;
+}
+.mobile-topbar .brand .conv-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+}
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-conv {
+  flex: 1; overflow-y: auto;
+  padding: 20px 16px;
+  background: var(--secondary);
+  display: flex; flex-direction: column; gap: 16px;
+}
+.mobile-conv .msg { max-width: 100%; }
+.mobile-conv .msg .bubble { font-size: 14px; max-width: 280px; }
+
+.mobile-input-wrap {
+  flex-shrink: 0; padding: 12px 16px;
+  background: linear-gradient(to top, var(--background) 80%, transparent);
+  border-top: 1px solid var(--border);
+}
+.mobile-input-wrap .chat-input { min-height: 48px; }
+.mobile-input-wrap .chat-input .input-field { font-size: 14px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Chat Page Mockup — /chat</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      Sidebar 5 nav 第 1 項「聊天」· 全站 AI discovery entry · 從聊出 trip 到展開右 sheet 的完整流
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Chat</span>
+    <span class="nav-links">
+      <a href="mockup-trip-v2.html">← V2 Final（行程）</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — 對話進行中 + 聊出 trip 後 sheet 展開 ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · 對話進行中 + AI 已提案 trip → 右 sheet 展開預覽</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+
+    <!-- Sidebar with chat history -->
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+
+      <div class="sidebar-section-label">最近對話</div>
+      <a class="chat-history-item active">
+        沖繩 5 日親子行
+        <span class="ch-time">剛才 · 7/26 trip</span>
+      </a>
+      <a class="chat-history-item">
+        首爾美食週末
+        <span class="ch-time">昨天</span>
+      </a>
+      <a class="chat-history-item">
+        台中咖啡廳推薦
+        <span class="ch-time">3 天前</span>
+      </a>
+
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新對話</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <!-- Chat main -->
+    <main class="chat-main">
+      <header class="chat-topbar">
+        <div class="conv-title">
+          <span class="conv-eyebrow">CONVERSATION 042</span>
+          沖繩 5 日親子行
+        </div>
+        <div class="topbar-actions">
+          <button class="icon-btn" title="重新命名">✎</button>
+          <button class="icon-btn" title="分享">↗</button>
+          <button class="icon-btn" title="更多">⋯</button>
+        </div>
+      </header>
+
+      <div class="conv-feed">
+        <div class="conv-feed-inner">
+
+          <div class="msg user">
+            <div class="bubble">
+              7/26-7/30 想帶兩個小朋友去沖繩，希望輕鬆一點，不用每天趕景點。預算每天大約 ¥30,000 左右。
+            </div>
+            <div class="avatar-sm">R</div>
+          </div>
+
+          <div class="msg ai">
+            <div class="avatar-sm">T</div>
+            <div class="bubble">
+              已幫你排了 <strong>5 天 4 夜</strong>的沖繩行程，<strong>Day 1 抵達後直接 check in 飯店</strong>，下午自由活動，後面 4 天每天平均 4-5 個 stop，午餐和晚餐都已選好。
+              <div class="bubble-meta">
+                <span>2 旅伴</span>
+                <span>·</span>
+                <span>7/26 – 7/30</span>
+                <span>·</span>
+                <span>已避開趕景點</span>
+              </div>
+              <a class="proposal-card">
+                <div class="pc-cover"></div>
+                <div class="pc-eyebrow">JAPAN · 5 DAYS · DRAFT</div>
+                <div class="pc-title">沖繩 5 日親子行</div>
+                <div class="pc-meta">7/26 – 7/30 · 7+8+5+6+4 stops · ¥148,000 預估</div>
+              </a>
+            </div>
+          </div>
+
+          <div class="msg user">
+            <div class="bubble">Day 2 的水族館想換成晚一點開始，小朋友早上會起不來</div>
+            <div class="avatar-sm">R</div>
+          </div>
+
+          <div class="msg ai">
+            <div class="avatar-sm">T</div>
+            <div class="bubble">
+              已調整：Day 2 美麗海水族館從 10:00 改到 <strong>11:30 開始</strong>，原本 13:00 的午餐順延到 14:30（水族館內咖啡廳），下午接著古宇利島就會避開人潮。右邊 sheet 已更新。
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="chat-input-wrap">
+        <div class="quick-actions">
+          <button class="qa-bubble">+ 加入景點</button>
+          <button class="qa-bubble">改交通方式</button>
+          <button class="qa-bubble">換餐廳推薦</button>
+          <button class="qa-bubble">調整時段</button>
+        </div>
+        <div class="chat-input">
+          <button class="input-btn" title="附加">＋</button>
+          <input class="input-field" placeholder="繼續調整這趟行程，例：「Day 3 想加海水浴場」">
+          <button class="input-btn" title="語音">🎙</button>
+          <button class="input-btn send" title="送出">↑</button>
+        </div>
+      </div>
+    </main>
+
+    <!-- Right Sheet with proposed trip -->
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="save-btn">儲存到行程</button>
+        <button class="icon-btn" title="更多">⋯</button>
+      </div>
+      <div class="sheet-title">沖繩 5 日親子行</div>
+      <div class="sheet-meta">
+        <span class="chip active">沖繩 · 那霸</span>
+        <span class="chip">7/26 – 7/30</span>
+        <span class="chip">2 旅伴</span>
+        <span class="chip" style="background: var(--accent-bg); color: var(--accent-deep);">DRAFT</span>
+      </div>
+      <div class="sheet-tabs">
+        <button class="sheet-tab active">行程</button>
+        <button class="sheet-tab">想法</button>
+        <button class="sheet-tab">地圖</button>
+        <button class="sheet-tab">摘要</button>
+      </div>
+
+      <div class="sheet-body">
+        <div class="day-strip" role="tablist">
+          <button class="day-strip-btn active"><span class="dn-eyebrow">DAY 01</span><span class="dn-date">7/26</span></button>
+          <button class="day-strip-btn"><span class="dn-eyebrow">DAY 02</span><span class="dn-date">7/27</span></button>
+          <button class="day-strip-btn"><span class="dn-eyebrow">DAY 03</span><span class="dn-date">7/28</span></button>
+          <button class="day-strip-btn"><span class="dn-eyebrow">DAY 04</span><span class="dn-date">7/29</span></button>
+          <button class="day-strip-btn"><span class="dn-eyebrow">DAY 05</span><span class="dn-date">7/30</span></button>
+        </div>
+
+        <div class="rail">
+          <div class="rail-header">
+            <span class="rail-eyebrow">Itinerary · Day 01</span>
+            <span class="rail-meta">7 stops · 10:45–21:00</span>
+          </div>
+          <div class="rail-body">
+            <div class="rail-line"></div>
+            <div class="rail-item">
+              <span class="rail-time">10:45</span>
+              <span class="rail-dot">1</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5z"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">抵達那霸機場</span>
+                <div class="rail-sub"><span class="rail-type">飛行</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+            <div class="rail-item">
+              <span class="rail-time">12:10</span>
+              <span class="rail-dot">2</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="6" rx="1.5"/><path d="M5 11l2-5h10l2 5"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">租車取車</span>
+                <div class="rail-sub"><span class="rail-type">移動</span><span class="rail-sep">·</span><span>30m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+            <div class="rail-item" data-accent="true">
+              <span class="rail-time">13:00</span>
+              <span class="rail-dot">3</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M5 3v8a3 3 0 0 0 6 0V3M8 11v10M16 3c-1.5 0-3 1.5-3 4v4h3v10"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">MEGA唐吉軻德 宜野灣店（含午餐）</span>
+                <div class="rail-sub"><span class="rail-type">用餐</span><span class="rail-sep">·</span><span>2h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+            <div class="rail-item">
+              <span class="rail-time">15:10</span>
+              <span class="rail-dot">4</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M3 18v-6h7a3 3 0 0 1 3 3v3M3 18h18M21 18v-3a4 4 0 0 0-4-4M5 12V8a2 2 0 0 1 2-2h6"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">Check in Vessel Hotel</span>
+                <div class="rail-sub"><span class="rail-type">住宿</span><span class="rail-sep">·</span><span>20m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+            <div class="rail-item" data-accent="true" data-last="true">
+              <span class="rail-time">16:00</span>
+              <span class="rail-dot">5</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">美國村 + Sunset Beach</span>
+                <div class="rail-sub"><span class="rail-type">景點</span><span class="rail-sep">·</span><span>3h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — Empty State 新對話 ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · 新對話 empty state（hero greeting + suggestion bubbles）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-section-label">最近對話</div>
+      <a class="chat-history-item">沖繩 5 日親子行<span class="ch-time">剛才</span></a>
+      <a class="chat-history-item">首爾美食週末<span class="ch-time">昨天</span></a>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新對話</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <main class="chat-main">
+      <header class="chat-topbar">
+        <div class="conv-title">
+          <span class="conv-eyebrow">NEW</span>
+          新對話
+        </div>
+        <div class="topbar-actions">
+          <button class="icon-btn" title="更多">⋯</button>
+        </div>
+      </header>
+
+      <div class="empty-hero">
+        <h2 class="hero-greeting">想去哪裡<span class="accent-dot">？</span></h2>
+        <p class="hero-sub">告訴我目的地、日期、想要的旅遊風格 — 我會幫你排一份可調整的行程草稿。</p>
+
+        <div class="suggestion-grid">
+          <button class="sug-chip">
+            <span class="sug-eyebrow">SUMMER · FAMILY</span>
+            <span class="sug-text">7 月帶小朋友去沖繩，5 天輕鬆行</span>
+          </button>
+          <button class="sug-chip">
+            <span class="sug-eyebrow">WEEKEND · FOOD</span>
+            <span class="sug-text">這週末首爾美食 3 天 2 夜</span>
+          </button>
+          <button class="sug-chip">
+            <span class="sug-eyebrow">SOLO · CITY</span>
+            <span class="sug-text">一個人去東京 4 天，想看美術館和獨立咖啡廳</span>
+          </button>
+          <button class="sug-chip">
+            <span class="sug-eyebrow">OUTDOOR</span>
+            <span class="sug-text">幫我規劃宜蘭兩天健行</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="chat-input-wrap">
+        <div class="chat-input">
+          <button class="input-btn" title="附加">＋</button>
+          <input class="input-field" placeholder="跟我說你想去哪裡，或選上面的範例">
+          <button class="input-btn" title="語音">🎙</button>
+          <button class="input-btn send" title="送出">↑</button>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Mobile 375 ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · 對話進行中（user/AI bubble + chat input + bottom nav 常駐）</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">
+        <span class="conv-eyebrow">CONV 042</span>
+        沖繩 5 日親子行
+      </div>
+      <button class="icon-btn" title="更多"><span>⋯</span></button>
+    </header>
+
+    <div class="mobile-conv">
+      <div class="msg user">
+        <div class="bubble">7/26-7/30 想帶小朋友去沖繩，希望輕鬆一點</div>
+        <div class="avatar-sm">R</div>
+      </div>
+      <div class="msg ai">
+        <div class="avatar-sm">T</div>
+        <div class="bubble">
+          已排好 5 天 4 夜，每天平均 4-5 個 stop。
+          <a class="proposal-card">
+            <div class="pc-cover"></div>
+            <div class="pc-eyebrow">JAPAN · 5 DAYS · DRAFT</div>
+            <div class="pc-title">沖繩 5 日親子行</div>
+            <div class="pc-meta">7/26 – 7/30 · 7+8+5+6+4 stops</div>
+          </a>
+        </div>
+      </div>
+      <div class="msg user">
+        <div class="bubble">水族館想晚一點開始</div>
+        <div class="avatar-sm">R</div>
+      </div>
+    </div>
+
+    <div class="mobile-input-wrap">
+      <div class="quick-actions" style="margin-bottom: 8px;">
+        <button class="qa-bubble">+ 景點</button>
+        <button class="qa-bubble">換餐廳</button>
+        <button class="qa-bubble">調時段</button>
+      </div>
+      <div class="chat-input">
+        <button class="input-btn" title="附加">＋</button>
+        <input class="input-field" placeholder="繼續調整...">
+        <button class="input-btn send" title="送出">↑</button>
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>聊天頁規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/chat</code>（新對話）/ <code>/chat/:id</code>（指定 conversation）</li>
+    <li><strong>Sidebar 加段</strong>：原 5 nav 下方新增「最近對話」list（chat history） + 「+ 新對話」CTA（覆蓋原本的「新增行程」CTA）</li>
+    <li><strong>Main 區結構</strong>：top bar（conv title + actions）→ conversation feed（max-width 760 居中）→ chat input wrap（sticky bottom）</li>
+    <li><strong>訊息 bubble</strong>：user 右靠齊 + accent bg；AI 左靠齊 + 白底 + border。AI bubble 內可嵌 proposal card（trip preview）+ bubble-meta footer</li>
+    <li><strong>Empty state</strong>：hero greeting「想去哪裡？」+ 4 個 suggestion chip（eyebrow + text 兩行）</li>
+    <li><strong>Chat input</strong>：rounded-full 56px height，左 + 附加 / 中 input / 右 mic + send（accent fill）</li>
+    <li><strong>Quick actions</strong>：input 上方 4 個 outline pill bubble（+加景點 / 改交通 / 換餐廳 / 調時段），對話進行中才顯示</li>
+    <li><strong>Right sheet</strong>：聊出 trip 後展開 — 跟 V2 Final 同 sheet 結構（tabs + day strip + ocean-rail），多一個「儲存到行程」按鈕（DRAFT → 正式 trip）</li>
+    <li><strong>Mobile 差異</strong>：sidebar 收起、改 bottom nav；conversation feed padding 16px；input 高度降至 48px；quick actions 縮成 3 個</li>
+    <li><strong>實作對應</strong>：新建 <code>src/pages/ChatPage.tsx</code> 是 task §6.1 的 placeholder — mockup 提供完整 UI 規格供日後 V2-P? 階段實作</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-explore-v2.html
+++ b/docs/design-sessions/mockup-explore-v2.html
@@ -1,0 +1,1009 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Explore Page — /explore</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  --grid-3pane: 240px 1fr min(420px, 32vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+  --font-caption2: 0.6875rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Explore main ========== */
+.explore-main {
+  display: flex; flex-direction: column;
+  background: var(--secondary);
+  overflow: hidden;
+}
+
+/* Top: tab toggle (搜尋 / 儲存池) + search bar */
+.explore-topbar {
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 32px 0;
+}
+
+.explore-tabs {
+  display: flex; gap: 0;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+  margin-left: -32px; margin-right: -32px;
+  padding-left: 32px; padding-right: 32px;
+}
+.explore-tab {
+  padding: 8px 16px 12px;
+  font-size: 14px; font-weight: 600;
+  color: var(--muted); cursor: pointer;
+  border: none; background: transparent; font-family: inherit;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.explore-tab.active { color: var(--foreground); border-bottom-color: var(--accent); }
+.explore-tab .tab-count {
+  display: inline-grid; place-items: center;
+  min-width: 22px; height: 22px; padding: 0 6px;
+  border-radius: 9999px; background: var(--tertiary);
+  font-size: 11px; color: var(--muted); font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.explore-tab.active .tab-count { background: var(--accent-subtle); color: var(--accent-deep); }
+
+/* Search bar */
+.search-bar {
+  display: flex; align-items: center; gap: 10px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 9999px;
+  padding: 8px 16px; margin-bottom: 12px;
+  min-height: 48px;
+  box-shadow: var(--shadow-sm);
+}
+.search-bar:focus-within { border-color: var(--accent); }
+.search-bar .search-icon { width: 18px; height: 18px; color: var(--muted); }
+.search-bar .search-icon svg { width: 100%; height: 100%; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.search-bar .search-input {
+  flex: 1; border: none; background: transparent;
+  font: inherit; font-size: 15px; color: var(--foreground);
+  outline: none;
+}
+.search-bar .search-input::placeholder { color: var(--muted); }
+.search-bar .search-region {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 10px; border-radius: 9999px;
+  background: var(--accent-subtle); color: var(--accent-deep);
+  font-size: 12px; font-weight: 600;
+  cursor: pointer;
+}
+
+/* Category chip filter */
+.category-chips {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  padding-bottom: 14px;
+}
+.cat-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border-radius: 9999px;
+  border: 1px solid var(--border); background: transparent;
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--foreground); cursor: pointer;
+}
+.cat-chip:hover { border-color: var(--accent); color: var(--accent); }
+.cat-chip.active { background: var(--foreground); color: var(--background); border-color: var(--foreground); }
+
+/* Result body */
+.explore-body {
+  flex: 1; overflow-y: auto;
+  padding: 20px 32px 32px;
+}
+
+.results-meta {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 16px;
+}
+.results-meta .results-count {
+  font-size: 13px; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.results-meta .results-sort {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 13px; color: var(--foreground); font-weight: 500;
+  background: transparent; border: none; cursor: pointer; font-family: inherit;
+}
+
+/* POI grid */
+.poi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+.poi-card {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+.poi-card:hover { border-color: var(--accent); box-shadow: var(--shadow-md); transform: translateY(-1px); }
+.poi-card.selected { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.poi-card .pc-cover {
+  aspect-ratio: 4/3; background: var(--tertiary);
+}
+.poi-card .pc-cover.cv-1 { background: linear-gradient(135deg, #D97848 0%, #F0935E 100%); }
+.poi-card .pc-cover.cv-2 { background: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%); }
+.poi-card .pc-cover.cv-3 { background: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%); }
+.poi-card .pc-cover.cv-4 { background: linear-gradient(135deg, #06A77D 0%, #FBEEE4 100%); }
+.poi-card .pc-cover.cv-5 { background: linear-gradient(135deg, #0EA5C7 0%, #F0EDE3 100%); }
+.poi-card .pc-cover.cv-6 { background: linear-gradient(135deg, #2A1F18 0%, #6F5A47 100%); }
+
+.poi-card .pc-body { padding: 12px 14px 14px; }
+.poi-card .pc-eyebrow {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 4px;
+}
+.poi-card .pc-eyebrow .pc-cat-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.poi-card .pc-title {
+  font-size: 15px; font-weight: 700; letter-spacing: -0.005em;
+  margin-bottom: 4px; line-height: 1.3;
+}
+.poi-card .pc-meta {
+  display: flex; gap: 6px; align-items: center;
+  font-size: 12px; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.poi-card .pc-rating { color: var(--foreground); font-weight: 700; }
+
+/* Save button (top-right corner of cover) */
+.poi-card .pc-actions {
+  position: absolute; top: 8px; right: 8px;
+  display: flex; gap: 6px;
+}
+.pc-save-btn {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--foreground); font: inherit; font-size: 14px;
+  transition: background 0.15s;
+}
+.pc-save-btn:hover { background: var(--accent); color: #fff; border-color: var(--accent); }
+.pc-save-btn.saved { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+/* Multi-select checkbox (儲存池 mode) */
+.pc-select-box {
+  position: absolute; top: 8px; left: 8px;
+  width: 22px; height: 22px; border-radius: 6px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1.5px solid var(--border);
+  display: grid; place-items: center; cursor: pointer;
+  color: transparent; font: inherit; font-size: 14px; font-weight: 700;
+}
+.poi-card.selected .pc-select-box { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+/* Bottom multi-select action bar (sticky) */
+.multi-action-bar {
+  position: sticky; bottom: 0;
+  background: var(--background);
+  border-top: 1px solid var(--border);
+  padding: 14px 32px;
+  display: flex; align-items: center; gap: 12px;
+  box-shadow: 0 -8px 24px rgba(42,31,24,0.06);
+}
+.multi-action-bar .ma-count {
+  font-size: 14px; font-weight: 600; color: var(--foreground);
+}
+.multi-action-bar .ma-count .accent { color: var(--accent-deep); font-weight: 800; }
+.multi-action-bar .ma-spacer { flex: 1; }
+.multi-action-bar .ma-btn {
+  padding: 10px 18px; border-radius: 9999px;
+  background: var(--accent); color: #fff; border: none;
+  font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.multi-action-bar .ma-btn:hover { background: var(--accent-deep); }
+.multi-action-bar .ma-btn.secondary {
+  background: transparent; color: var(--foreground);
+  border: 1px solid var(--border);
+}
+.multi-action-bar .ma-btn.secondary:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ========== Right Sheet (selected POI detail) ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+.sheet-header .save-btn {
+  padding: 6px 14px; border-radius: 9999px;
+  background: var(--accent); color: #fff; border: none;
+  font: inherit; font-size: 12px; font-weight: 600;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.sheet-header .save-btn:hover { background: var(--accent-deep); }
+
+.sheet-cover {
+  height: 200px;
+  background: linear-gradient(135deg, #06A77D 0%, #FBEEE4 100%);
+}
+
+.sheet-body { flex: 1; overflow-y: auto; padding: 20px; }
+
+.sheet-eyebrow {
+  display: flex; align-items: center; gap: 6px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 8px;
+}
+.sheet-eyebrow .cat-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); }
+.sheet-poi-title {
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+  line-height: 1.2; margin-bottom: 8px;
+}
+.sheet-poi-meta {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+  margin-bottom: 16px;
+}
+.sheet-poi-meta .chip {
+  padding: 3px 10px; border-radius: 9999px;
+  background: var(--tertiary); color: var(--muted);
+  font-weight: 600; letter-spacing: 0.05em;
+}
+.sheet-poi-meta .chip.accent { background: var(--accent-subtle); color: var(--accent-deep); }
+.sheet-poi-meta .rating { color: var(--foreground); font-weight: 700; }
+
+.sheet-section {
+  margin-top: 20px; padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.sheet-section h4 {
+  font-size: var(--font-caption2); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 10px;
+}
+.sheet-section p { font-size: 14px; line-height: 1.55; color: var(--foreground); }
+.sheet-section .info-row {
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 13px; padding: 6px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.sheet-section .info-row:last-child { border-bottom: none; }
+.sheet-section .info-row .info-label {
+  font-size: var(--font-caption2); font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+  width: 80px; flex-shrink: 0;
+}
+
+/* Add to trip dropdown */
+.add-trip-dropdown {
+  background: var(--background); border: 1px solid var(--border); border-radius: 12px;
+  padding: 6px;
+  display: flex; flex-direction: column; gap: 2px;
+  box-shadow: var(--shadow-md);
+}
+.atd-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: 8px;
+  cursor: pointer; text-decoration: none; color: var(--foreground);
+}
+.atd-item:hover { background: var(--hover); }
+.atd-item .atd-cover {
+  width: 32px; height: 32px; border-radius: 6px; flex-shrink: 0;
+}
+.atd-item .atd-cover.cv-okinawa { background: linear-gradient(135deg, #D97848, #F0935E); }
+.atd-item .atd-cover.cv-seoul { background: linear-gradient(135deg, #B85C2E, #EADFCF); }
+.atd-item .atd-cover.cv-taichung { background: linear-gradient(135deg, #C88500, #F7DFCB); }
+.atd-item .atd-body { flex: 1; min-width: 0; }
+.atd-item .atd-title { font-size: 13px; font-weight: 600; }
+.atd-item .atd-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  flex-shrink: 0; position: sticky; top: 0; z-index: 10;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-explore {
+  flex: 1; overflow-y: auto;
+  padding-bottom: calc(var(--nav-h-mobile) + 0px);
+}
+.mobile-search-section {
+  padding: 12px 16px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  position: sticky; top: 56px; z-index: 5;
+  border-bottom: 1px solid var(--border);
+}
+.mobile-search-section .search-bar { padding: 6px 12px; min-height: 42px; margin-bottom: 8px; }
+.mobile-search-section .search-bar .search-input { font-size: 14px; }
+.mobile-search-section .explore-tabs {
+  border: none; margin-bottom: 8px; padding: 0; margin-left: 0; margin-right: 0;
+}
+.mobile-search-section .explore-tab { padding: 6px 12px; font-size: 13px; }
+
+.mobile-cat-chips {
+  display: flex; gap: 6px; padding: 4px 0 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.mobile-cat-chips::-webkit-scrollbar { display: none; }
+.mobile-cat-chips .cat-chip { flex: 0 0 auto; }
+
+.mobile-poi-list {
+  padding: 16px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.mobile-poi-row {
+  display: flex; gap: 12px; padding: 10px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 12px;
+  cursor: pointer; position: relative;
+}
+.mobile-poi-row:hover { border-color: var(--accent); }
+.mobile-poi-row .row-cover {
+  width: 80px; height: 80px; border-radius: 8px; flex-shrink: 0;
+}
+.mobile-poi-row .row-body { flex: 1; min-width: 0; }
+.mobile-poi-row .row-eyebrow {
+  font-size: 9px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 2px;
+}
+.mobile-poi-row .row-title {
+  font-size: 14px; font-weight: 700; letter-spacing: -0.005em;
+  margin-bottom: 4px; line-height: 1.3;
+}
+.mobile-poi-row .row-meta {
+  font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.mobile-poi-row .row-meta .rating { color: var(--foreground); font-weight: 700; }
+.mobile-poi-row .row-save {
+  position: absolute; top: 10px; right: 10px;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--background); border: 1px solid var(--border);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--foreground); font-size: 13px;
+}
+.mobile-poi-row .row-save.saved { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Explore Page Mockup — /explore</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      Sidebar 第 4 項「探索」· 搜尋 POI + 儲存池（save → 一次加入 trip）· 區分跟 /map（純瀏覽）的職責
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Explore</span>
+    <span class="nav-links">
+      <a href="mockup-trip-v2.html">行程</a>
+      <a href="mockup-map-v2.html">地圖</a>
+      <a href="mockup-login-v2.html">登入</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — 搜尋 mode + sheet 展開選中 POI detail ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · 搜尋 tab + POI grid + sheet 展開選中 POI（含「加入行程」flow）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <main class="explore-main">
+      <div class="explore-topbar">
+        <div class="explore-tabs">
+          <button class="explore-tab active">
+            <span>搜尋</span>
+            <span class="tab-count">128</span>
+          </button>
+          <button class="explore-tab">
+            <span>儲存池</span>
+            <span class="tab-count">12</span>
+          </button>
+        </div>
+        <div class="search-bar">
+          <span class="search-icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+          <input class="search-input" value="炸豬排" placeholder="搜尋景點、餐廳、飯店...">
+          <span class="search-region">沖繩 · 那霸 ▾</span>
+        </div>
+        <div class="category-chips">
+          <button class="cat-chip active">全部</button>
+          <button class="cat-chip">🍜 餐廳</button>
+          <button class="cat-chip">📍 景點</button>
+          <button class="cat-chip">🏨 飯店</button>
+          <button class="cat-chip">🛍 購物</button>
+          <button class="cat-chip">⛩ 寺廟</button>
+        </div>
+      </div>
+
+      <div class="explore-body">
+        <div class="results-meta">
+          <span class="results-count">128 個結果 · 沖繩 · 那霸 半徑 5 km</span>
+          <button class="results-sort">排序：最相近 ▾</button>
+        </div>
+        <div class="poi-grid">
+          <div class="poi-card">
+            <div class="pc-cover cv-1"></div>
+            <div class="pc-actions"><button class="pc-save-btn" title="儲存">♡</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 豬排</div>
+              <div class="pc-title">豚正・那霸國際通本店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.6</span><span>·</span><span>312 reviews</span><span>·</span><span>0.4 km</span></div>
+            </div>
+          </div>
+          <div class="poi-card selected">
+            <div class="pc-cover cv-4"></div>
+            <div class="pc-actions"><button class="pc-save-btn saved" title="已儲存">♥</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 沖繩料理</div>
+              <div class="pc-title">きじむなぁ瀬長島ウミカジテラス店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.4</span><span>·</span><span>1,250 reviews</span><span>·</span><span>1.2 km</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-3"></div>
+            <div class="pc-actions"><button class="pc-save-btn" title="儲存">♡</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 拉麵</div>
+              <div class="pc-title">通堂拉麵 小祿本店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.5</span><span>·</span><span>980 reviews</span><span>·</span><span>2.1 km</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-2"></div>
+            <div class="pc-actions"><button class="pc-save-btn saved" title="已儲存">♥</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 燒肉</div>
+              <div class="pc-title">焼肉乃我那覇 新都心店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.7</span><span>·</span><span>540 reviews</span><span>·</span><span>3.0 km</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-5"></div>
+            <div class="pc-actions"><button class="pc-save-btn" title="儲存">♡</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 海鮮</div>
+              <div class="pc-title">泊いゆまち（魚市場）</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.3</span><span>·</span><span>2,100 reviews</span><span>·</span><span>2.8 km</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-6"></div>
+            <div class="pc-actions"><button class="pc-save-btn" title="儲存">♡</button></div>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 甜點</div>
+              <div class="pc-title">BLUE SEAL ICE CREAM 國際通店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.2</span><span>·</span><span>820 reviews</span><span>·</span><span>0.8 km</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Sheet — selected POI detail -->
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="save-btn">+ 加入行程 ▾</button>
+      </div>
+      <div class="sheet-cover"></div>
+      <div class="sheet-body">
+        <div class="sheet-eyebrow">
+          <span class="cat-dot"></span>
+          餐廳 · 沖繩料理
+        </div>
+        <h2 class="sheet-poi-title">きじむなぁ 瀬長島ウミカジテラス店</h2>
+        <div class="sheet-poi-meta">
+          <span class="chip rating">★ 4.4 · 1,250 reviews</span>
+          <span class="chip">$$ · 預算 ¥2,000</span>
+          <span class="chip accent">已儲存</span>
+        </div>
+
+        <div class="sheet-section">
+          <h4>位置 · Address</h4>
+          <p>沖縄県豊見城市瀬長174-6 ウミカジテラス24A</p>
+        </div>
+
+        <div class="sheet-section">
+          <div class="info-row">
+            <span class="info-label">Phone</span>
+            <span>+81 98-851-7077</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Hours</span>
+            <span>11:00 – 21:00（每日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Cuisine</span>
+            <span>沖繩鄉土料理 · 海鮮</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Notes</span>
+            <span>島嶼海景餐廳，建議預約</span>
+          </div>
+        </div>
+
+        <div class="sheet-section">
+          <h4>加入到 trip（顯示快速 dropdown）</h4>
+          <div class="add-trip-dropdown">
+            <a class="atd-item">
+              <div class="atd-cover cv-okinawa"></div>
+              <div class="atd-body">
+                <div class="atd-title">沖繩之旅</div>
+                <div class="atd-meta">7/26 – 7/30 · 進行中</div>
+              </div>
+            </a>
+            <a class="atd-item">
+              <div class="atd-cover cv-seoul"></div>
+              <div class="atd-body">
+                <div class="atd-title">首爾美食行</div>
+                <div class="atd-meta">8/15 – 8/18 · 草稿</div>
+              </div>
+            </a>
+            <a class="atd-item">
+              <div class="atd-cover cv-taichung"></div>
+              <div class="atd-body">
+                <div class="atd-title">台中週末小旅</div>
+                <div class="atd-meta">6/8 – 6/9 · 已結束</div>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — 儲存池 mode + 多選 + 底部 action bar ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · 儲存池 tab + 多選 mode + 底部「加入行程」action bar</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <main class="explore-main">
+      <div class="explore-topbar">
+        <div class="explore-tabs">
+          <button class="explore-tab">
+            <span>搜尋</span>
+            <span class="tab-count">128</span>
+          </button>
+          <button class="explore-tab active">
+            <span>儲存池</span>
+            <span class="tab-count">12</span>
+          </button>
+        </div>
+        <div class="category-chips">
+          <button class="cat-chip active">全部 12</button>
+          <button class="cat-chip">🍜 餐廳 5</button>
+          <button class="cat-chip">📍 景點 4</button>
+          <button class="cat-chip">🏨 飯店 2</button>
+          <button class="cat-chip">🛍 購物 1</button>
+        </div>
+      </div>
+
+      <div class="explore-body">
+        <div class="results-meta">
+          <span class="results-count">12 個已儲存 POI · 點 ☐ 多選</span>
+          <button class="results-sort">排序：最近儲存 ▾</button>
+        </div>
+        <div class="poi-grid">
+          <div class="poi-card selected">
+            <div class="pc-cover cv-4"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 沖繩料理</div>
+              <div class="pc-title">きじむなぁ 瀬長島</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.4</span><span>·</span><span>已存 2 天</span></div>
+            </div>
+          </div>
+          <div class="poi-card selected">
+            <div class="pc-cover cv-2"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>餐廳 · 燒肉</div>
+              <div class="pc-title">焼肉乃我那覇 新都心店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.7</span><span>·</span><span>已存 5 天</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-1"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>景點 · 海灘</div>
+              <div class="pc-title">古宇利島 心型岩</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.5</span><span>·</span><span>已存 3 天</span></div>
+            </div>
+          </div>
+          <div class="poi-card selected">
+            <div class="pc-cover cv-5"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>景點 · 水族館</div>
+              <div class="pc-title">美麗海水族館</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.6</span><span>·</span><span>已存 1 週</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-3"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>飯店</div>
+              <div class="pc-title">ANA InterContinental 萬座海濱</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.5</span><span>·</span><span>已存 1 週</span></div>
+            </div>
+          </div>
+          <div class="poi-card">
+            <div class="pc-cover cv-6"></div>
+            <button class="pc-select-box">✓</button>
+            <div class="pc-body">
+              <div class="pc-eyebrow"><span class="pc-cat-dot"></span>購物</div>
+              <div class="pc-title">那霸機場免稅店</div>
+              <div class="pc-meta"><span class="pc-rating">★ 4.0</span><span>·</span><span>已存 2 週</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Multi-select sticky action bar -->
+      <div class="multi-action-bar">
+        <span class="ma-count">已選 <span class="accent">3</span> 個 POI</span>
+        <span class="ma-spacer"></span>
+        <button class="ma-btn secondary">取消</button>
+        <button class="ma-btn">+ 加入到行程 ▾</button>
+      </div>
+    </main>
+
+  </div>
+</div>
+
+<!-- ============ Mobile 375 — 搜尋 + POI list + bottom nav ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · 搜尋 view + POI horizontal list + bottom nav</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">探索<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="篩選"><span style="font-size: 16px;">⇩</span></button>
+    </header>
+
+    <div class="mobile-explore">
+      <div class="mobile-search-section">
+        <div class="explore-tabs">
+          <button class="explore-tab active">搜尋</button>
+          <button class="explore-tab">
+            <span>儲存池</span>
+            <span class="tab-count">12</span>
+          </button>
+        </div>
+        <div class="search-bar">
+          <span class="search-icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+          <input class="search-input" value="炸豬排" placeholder="搜尋...">
+        </div>
+        <div class="mobile-cat-chips">
+          <button class="cat-chip active">全部</button>
+          <button class="cat-chip">🍜 餐廳</button>
+          <button class="cat-chip">📍 景點</button>
+          <button class="cat-chip">🏨 飯店</button>
+          <button class="cat-chip">🛍 購物</button>
+        </div>
+      </div>
+
+      <div class="mobile-poi-list">
+        <div class="mobile-poi-row">
+          <div class="row-cover" style="background: linear-gradient(135deg, #D97848, #F0935E);"></div>
+          <div class="row-body">
+            <div class="row-eyebrow">餐廳 · 豬排 · 0.4 km</div>
+            <div class="row-title">豚正・那霸國際通本店</div>
+            <div class="row-meta"><span class="rating">★ 4.6</span> · 312 reviews</div>
+          </div>
+          <button class="row-save" title="儲存">♡</button>
+        </div>
+        <div class="mobile-poi-row">
+          <div class="row-cover" style="background: linear-gradient(135deg, #06A77D, #FBEEE4);"></div>
+          <div class="row-body">
+            <div class="row-eyebrow">餐廳 · 沖繩料理 · 1.2 km</div>
+            <div class="row-title">きじむなぁ 瀬長島</div>
+            <div class="row-meta"><span class="rating">★ 4.4</span> · 1,250 reviews</div>
+          </div>
+          <button class="row-save saved" title="已儲存">♥</button>
+        </div>
+        <div class="mobile-poi-row">
+          <div class="row-cover" style="background: linear-gradient(135deg, #B85C2E, #EADFCF);"></div>
+          <div class="row-body">
+            <div class="row-eyebrow">餐廳 · 拉麵 · 2.1 km</div>
+            <div class="row-title">通堂拉麵 小祿本店</div>
+            <div class="row-meta"><span class="rating">★ 4.5</span> · 980 reviews</div>
+          </div>
+          <button class="row-save" title="儲存">♡</button>
+        </div>
+        <div class="mobile-poi-row">
+          <div class="row-cover" style="background: linear-gradient(135deg, #C88500, #F7DFCB);"></div>
+          <div class="row-body">
+            <div class="row-eyebrow">餐廳 · 燒肉 · 3.0 km</div>
+            <div class="row-title">焼肉乃我那覇 新都心店</div>
+            <div class="row-meta"><span class="rating">★ 4.7</span> · 540 reviews</div>
+          </div>
+          <button class="row-save saved" title="已儲存">♥</button>
+        </div>
+        <div class="mobile-poi-row">
+          <div class="row-cover" style="background: linear-gradient(135deg, #0EA5C7, #F0EDE3);"></div>
+          <div class="row-body">
+            <div class="row-eyebrow">餐廳 · 海鮮 · 2.8 km</div>
+            <div class="row-title">泊いゆまち（魚市場）</div>
+            <div class="row-meta"><span class="rating">★ 4.3</span> · 2,100 reviews</div>
+          </div>
+          <button class="row-save" title="儲存">♡</button>
+        </div>
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>探索頁規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/explore</code> — search + 儲存池兩 tab；search 結果靠 POI search provider（Nominatim 免費 / Google Places 付費 — 待調查）</li>
+    <li><strong>2 個 tab</strong>：「搜尋」（active 動作）+「儲存池」（已 save 的 POI 列表）— 對齊 layout reference Q5 LOCKED</li>
+    <li><strong>Search bar</strong>：rounded-full + icon + input + 區域選擇 chip（沖繩 · 那霸 ▾）</li>
+    <li><strong>Category chips</strong>：全部 / 餐廳 / 景點 / 飯店 / 購物 / 寺廟 — 限 4-6 個（layout reference 建議「限 3-4 main category」，本 mockup 給 6 個含寺廟做 affordance demo）</li>
+    <li><strong>POI card</strong>：4:3 cover + eyebrow（cat-dot + 類別 + 子類）+ title + rating + reviews + distance；右上 ♡ save button（hover/saved 變 accent fill）</li>
+    <li><strong>儲存池 mode 多選</strong>：左上換成 checkbox（☐ → ✓ accent fill），底部 sticky action bar「已選 N 個 · 加入到行程 ▾」</li>
+    <li><strong>Sheet 展開（搜尋 mode）</strong>：cover image + eyebrow + POI title + meta chips + 位置/電話/時段/類型/筆記 + <strong>「+ 加入行程 ▾」dropdown 列出所有 trips</strong>（atd-item: cover + title + meta）</li>
+    <li><strong>跟 /map 的分工</strong>：探索 = active search + save + add to trip；地圖 = passive 看你已有 trips 的地理 view（無 search、無 save、無 add）</li>
+    <li><strong>Schema dependency</strong>：需新 <code>saved_pois(id, user_id, poi_id, saved_at, note)</code> table — FK 到既有 <code>pois</code>（POI Unification Phase 3 後 normalized）</li>
+    <li><strong>Mobile 簡化</strong>：search bar 高度 42px、無 region chip、POI list 改橫 row（80×80 cover + body + 右上 save button）</li>
+    <li><strong>實作對應</strong>：B-P4 task scope（layout reference Q5）— 約 3 週（POI search API + 儲存池 UI + cross-link to trip promotion）</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-forgot-v2.html
+++ b/docs/design-sessions/mockup-forgot-v2.html
@@ -1,0 +1,613 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Forgot Password — /login/forgot</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px; line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden; position: relative; margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* Sidebar */
+.sidebar {
+  background: var(--background); border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column; gap: 4px; overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted); font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s; min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active { background: var(--foreground); color: var(--background); font-weight: 600; }
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px; color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Main 2-col layout ========== */
+.auth-main {
+  background: var(--secondary);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%; overflow: hidden;
+}
+.auth-form-side {
+  display: flex; align-items: center; justify-content: center;
+  padding: 48px; overflow-y: auto;
+}
+.auth-card {
+  width: 100%; max-width: 420px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 20px;
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+
+/* Step indicator */
+.step-indicator {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 16px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--muted);
+}
+.step-indicator .step-dots { display: flex; gap: 4px; }
+.step-indicator .step-dot {
+  width: 16px; height: 4px; border-radius: 2px;
+  background: var(--tertiary);
+}
+.step-indicator .step-dot.done { background: var(--accent); }
+.step-indicator .step-dot.active { background: var(--foreground); }
+
+.auth-card h2 {
+  font-size: 28px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 8px;
+}
+.auth-card .ac-sub {
+  font-size: 14px; color: var(--muted); margin-bottom: 24px;
+}
+
+/* Field */
+.field { margin-bottom: 14px; }
+.field label {
+  display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 6px;
+}
+.field input {
+  width: 100%; padding: 12px 14px; border-radius: 12px;
+  border: 1px solid var(--border); background: var(--background);
+  font: inherit; font-size: 15px; color: var(--foreground);
+  outline: none; min-height: 48px;
+}
+.field input:focus { border-color: var(--accent); }
+.field input::placeholder { color: var(--muted); }
+.field .helper {
+  font-size: 12px; color: var(--muted); margin-top: 6px;
+}
+.field .helper.warn { color: var(--accent-deep); }
+
+/* Password rule meter */
+.pw-rules {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-top: 8px;
+  padding: 12px; border-radius: 10px;
+  background: var(--secondary);
+  font-size: 12px;
+}
+.pw-rule {
+  display: flex; align-items: center; gap: 8px;
+  color: var(--muted);
+}
+.pw-rule.ok { color: var(--accent-deep); }
+.pw-rule .rule-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--line-strong, #C8B89F);
+}
+.pw-rule.ok .rule-dot { background: var(--accent); }
+
+/* Primary button */
+.primary-btn {
+  width: 100%;
+  padding: 12px 18px; border-radius: 12px;
+  background: var(--foreground); color: var(--background);
+  border: none; font: inherit; font-size: 14px; font-weight: 700;
+  cursor: pointer; min-height: 48px; margin-top: 4px;
+}
+.primary-btn:hover { background: var(--accent-deep); }
+.primary-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.ac-back {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-bottom: 20px;
+  font-size: 13px; font-weight: 600; color: var(--accent-deep);
+  text-decoration: none; cursor: pointer;
+}
+.ac-back:hover { color: var(--foreground); }
+
+.ac-footer {
+  margin-top: 20px; font-size: 13px; color: var(--muted);
+  text-align: center;
+}
+.ac-footer a, .ac-footer .lc-link {
+  color: var(--accent-deep); text-decoration: none; font-weight: 600; cursor: pointer;
+}
+.ac-footer a:hover { text-decoration: underline; }
+
+/* Success state (sent email) */
+.success-state {
+  text-align: center; padding: 16px 0;
+}
+.success-state .success-circle {
+  width: 64px; height: 64px; border-radius: 50%;
+  background: var(--accent-subtle); color: var(--accent);
+  display: grid; place-items: center; margin: 0 auto 16px;
+}
+.success-state .success-circle svg { width: 32px; height: 32px; stroke: currentColor; fill: none; stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
+
+/* Right benefit side */
+.auth-aside {
+  background: linear-gradient(135deg, var(--foreground) 0%, var(--accent-deep) 100%);
+  color: var(--background);
+  padding: 56px 48px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  position: relative; overflow: hidden;
+}
+.auth-aside::before {
+  content: ''; position: absolute;
+  top: -100px; right: -100px; width: 400px; height: 400px;
+  border-radius: 50%; background: rgba(247, 223, 203, 0.1);
+}
+.auth-aside::after {
+  content: ''; position: absolute;
+  bottom: -80px; left: -80px; width: 300px; height: 300px;
+  border-radius: 50%; background: rgba(217, 120, 72, 0.18);
+}
+.auth-aside > * { position: relative; z-index: 2; }
+.aside-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; opacity: 0.7;
+}
+.aside-display {
+  font-size: 38px; font-weight: 900; letter-spacing: -0.03em; line-height: 1.1;
+  margin: 16px 0 24px; max-width: 400px;
+}
+.aside-sub { font-size: 15px; line-height: 1.6; opacity: 0.85; max-width: 380px; }
+
+/* Reassurance bullets (security / process) */
+.reassure-list {
+  display: flex; flex-direction: column; gap: 16px;
+  margin-top: 32px;
+}
+.reassure-row {
+  display: flex; gap: 14px; align-items: flex-start;
+}
+.reassure-row .r-icon {
+  width: 32px; height: 32px; border-radius: 8px;
+  background: rgba(255, 251, 245, 0.12);
+  display: grid; place-items: center; flex-shrink: 0;
+  color: var(--background);
+}
+.reassure-row .r-icon svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.reassure-row .r-body { padding-top: 4px; }
+.reassure-row .r-title { font-size: 14px; font-weight: 700; }
+.reassure-row .r-desc { font-size: 12px; opacity: 0.78; margin-top: 2px; line-height: 1.5; }
+
+.aside-footnote {
+  font-size: 11px; opacity: 0.6; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600;
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: var(--background); flex-shrink: 0;
+  position: sticky; top: 0; z-index: 10;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-auth {
+  flex: 1; overflow-y: auto;
+  padding: 24px 24px calc(var(--nav-h-mobile) + 16px);
+  display: flex; flex-direction: column; gap: 20px;
+}
+.mobile-auth h2 {
+  font-size: 26px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 6px;
+}
+.mobile-auth .ac-sub { font-size: 14px; color: var(--muted); }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: var(--background);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Forgot Password Mockup — /login/forgot</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      多步流程 · Step 1 輸入 email → Step 2 從 email 連結進來設新密碼
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Forgot</span>
+    <span class="nav-links">
+      <a href="mockup-login-v2.html">← 登入</a>
+      <a href="mockup-signup-v2.html">→ 註冊</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — Step 1: 輸入 email ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · Step 1 — 輸入 email 寄重設連結</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <div class="user-chip"><div class="avatar">?</div><span>未登入</span></div>
+      </div>
+    </aside>
+
+    <main class="auth-main">
+      <div class="auth-form-side">
+        <div class="auth-card">
+          <a class="ac-back">← 回登入</a>
+          <div class="step-indicator">
+            <span>Step 1 / 2 · 找回帳號</span>
+            <span class="step-dots">
+              <span class="step-dot active"></span>
+              <span class="step-dot"></span>
+            </span>
+          </div>
+          <h2>忘記密碼？<br>幫你寄個連結</h2>
+          <div class="ac-sub">輸入註冊時用的 email，我們寄給你重設密碼的連結，1 小時內有效。</div>
+
+          <div class="field">
+            <label>Email</label>
+            <input type="email" placeholder="ray@example.com">
+            <div class="helper">就是你登入用的那個。如果忘了，試 Google / Apple 直接登入。</div>
+          </div>
+
+          <button class="primary-btn">寄出連結 →</button>
+
+          <div class="ac-footer">
+            想起來了？<span class="lc-link">直接登入</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="auth-aside">
+        <div class="aside-eyebrow">Account Recovery</div>
+        <div>
+          <h2 class="aside-display">忘了沒關係<br>5 分鐘搞定。</h2>
+          <p class="aside-sub">我們不會請你回答秘密問題、不收手機號、不要身分證。Email 是唯一管道，最簡單也最不容易被釣魚。</p>
+          <div class="reassure-list">
+            <div class="reassure-row">
+              <div class="r-icon">
+                <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              </div>
+              <div class="r-body">
+                <div class="r-title">連結 1 小時失效</div>
+                <div class="r-desc">即使被攔截，過期後就無法用，舊密碼也不洩漏。</div>
+              </div>
+            </div>
+            <div class="reassure-row">
+              <div class="r-icon">
+                <svg viewBox="0 0 24 24"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+              </div>
+              <div class="r-body">
+                <div class="r-title">只透過 email</div>
+                <div class="r-desc">不會 SMS、不會打電話、不會私訊。只看 email 收件匣即可。</div>
+              </div>
+            </div>
+            <div class="reassure-row">
+              <div class="r-icon">
+                <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+              </div>
+              <div class="r-body">
+                <div class="r-title">舊登入裝置自動登出</div>
+                <div class="r-desc">重設後，所有手機/平板的 session 都失效，避免別人用你舊密碼。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="aside-footnote">© 2026 Tripline · 帳號安全最低承諾</div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — Step 2: 設新密碼 ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · Step 2 — 從 email 連結進來，設新密碼</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <div class="user-chip"><div class="avatar">?</div><span>從 email 連結</span></div>
+      </div>
+    </aside>
+
+    <main class="auth-main">
+      <div class="auth-form-side">
+        <div class="auth-card">
+          <div class="step-indicator">
+            <span>Step 2 / 2 · 設新密碼</span>
+            <span class="step-dots">
+              <span class="step-dot done"></span>
+              <span class="step-dot active"></span>
+            </span>
+          </div>
+          <h2>設新密碼<br>重新登入帳號</h2>
+          <div class="ac-sub">為 <strong style="color: var(--foreground);">ray@trip.io</strong> 建立新密碼。設定後，所有舊裝置會被自動登出。</div>
+
+          <div class="field">
+            <label>新密碼</label>
+            <input type="password" placeholder="至少 8 字元 + 1 個數字">
+            <div class="pw-rules">
+              <div class="pw-rule ok"><span class="rule-dot"></span>至少 8 個字元</div>
+              <div class="pw-rule ok"><span class="rule-dot"></span>包含至少 1 個數字</div>
+              <div class="pw-rule"><span class="rule-dot"></span>包含至少 1 個大寫字母</div>
+              <div class="pw-rule"><span class="rule-dot"></span>不要用過去常用密碼</div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>再次輸入新密碼</label>
+            <input type="password" placeholder="重複新密碼">
+          </div>
+
+          <button class="primary-btn">設定密碼並登入 →</button>
+        </div>
+      </div>
+
+      <div class="auth-aside">
+        <div class="aside-eyebrow">Final Step</div>
+        <div>
+          <h2 class="aside-display">最後一步<br>就完成了。</h2>
+          <p class="aside-sub">設好新密碼，你會自動登入並進入「行程」頁。記得密碼存到密碼管理器（1Password / Apple Keychain / Google Password）。</p>
+          <div class="reassure-list">
+            <div class="reassure-row">
+              <div class="r-icon">
+                <svg viewBox="0 0 24 24"><polyline points="20,6 9,17 4,12"/></svg>
+              </div>
+              <div class="r-body">
+                <div class="r-title">即時生效</div>
+                <div class="r-desc">設好密碼後立即可登入，不需等 email 或重新驗證。</div>
+              </div>
+            </div>
+            <div class="reassure-row">
+              <div class="r-icon">
+                <svg viewBox="0 0 24 24"><path d="M12 1l3 3-3 3M12 17l3 3-3 3M5 12H1l3-3M19 12h4l-3 3M9 12a3 3 0 0 1 6 0v0a3 3 0 0 1-6 0z"/></svg>
+              </div>
+              <div class="r-body">
+                <div class="r-title">舊裝置全登出</div>
+                <div class="r-desc">手機、平板、其他電腦的 session 全部清掉，重新登入才能用。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="aside-footnote">© 2026 Tripline</div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Mobile — Step 1 ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · Step 1 輸入 email（mobile 全寬 form + bottom nav）</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="關閉"><span style="font-size: 16px;">✕</span></button>
+    </header>
+
+    <div class="mobile-auth">
+      <a class="ac-back">← 回登入</a>
+      <div class="step-indicator">
+        <span>Step 1 / 2</span>
+        <span class="step-dots">
+          <span class="step-dot active"></span>
+          <span class="step-dot"></span>
+        </span>
+      </div>
+      <div>
+        <h2>忘記密碼？<br>幫你寄連結</h2>
+        <div class="ac-sub">輸入 email，1 小時內收到重設連結。</div>
+      </div>
+
+      <div class="field">
+        <label>Email</label>
+        <input type="email" placeholder="ray@example.com">
+      </div>
+
+      <button class="primary-btn">寄出連結 →</button>
+
+      <div class="ac-footer">
+        想起來了？<span class="lc-link">直接登入</span>
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>忘記密碼規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/login/forgot</code>（Step 1 輸入 email）<code>/login/reset?token=...</code>（Step 2 設新密碼，從 email 連結進入）</li>
+    <li><strong>Step indicator</strong>：上方 eyebrow「Step 1 / 2 · 找回帳號」+ 兩個 4×16 px 進度 dot（active 黑 / done accent / 未來 muted）</li>
+    <li><strong>Step 1</strong>：單 email field + helper「就是你登入用的那個。如果忘了，試 Google / Apple 直接登入」+ 主 CTA「寄出連結」</li>
+    <li><strong>Step 2</strong>：顯示鎖定的 email（提示要為哪個帳號設密碼）+ 新密碼 field + <strong>password rule meter</strong>（4 條規則 dot + 文案，達成變 accent）+ 重複輸入</li>
+    <li><strong>右側 reassurance</strong>（不是 sign-in 的 4 features）— 改 3 個安全承諾：1 小時失效 / 只透過 email / 舊裝置自動登出。對齊 V2 OAuth 安全 hardening</li>
+    <li><strong>Anti-slop</strong>：避免「秘密問題」「手機驗證碼」「身分證」這類 dark pattern；email 是唯一 recovery channel（layout reference V2 plan）</li>
+    <li><strong>Mobile</strong>：簡化版，無右側 aside，下方 bottom nav 常駐</li>
+    <li><strong>Sidebar</strong>：「未登入」chip 改為「從 email 連結」（暗示是 recovery flow 進來的）</li>
+    <li><strong>實作對應</strong>：V2 OAuth Workstream A · Phase 3「忘記密碼流程」</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-index.html
+++ b/docs/design-sessions/mockup-index.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>B-P2 Mockup Index — Tripline V2</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #F2F2EE;
+  color: #222;
+  font-size: 16px; line-height: 1.6;
+  padding: 48px 24px 80px;
+}
+.wrap { max-width: 1200px; margin: 0 auto; }
+.header {
+  padding-bottom: 24px; margin-bottom: 32px;
+  border-bottom: 2px solid #222;
+}
+.eyebrow {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase;
+  color: #666; margin-bottom: 8px;
+}
+h1 { font-size: 40px; font-weight: 900; letter-spacing: -0.03em; line-height: 1.05; max-width: 800px; }
+.intro { font-size: 16px; color: #444; margin-top: 16px; max-width: 760px; }
+
+.context {
+  background: #fff; border: 1px solid #DDD; border-radius: 12px;
+  padding: 20px 24px; margin-bottom: 28px;
+  font-size: 14px; line-height: 1.7;
+}
+.context h2 {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase;
+  color: #666; margin-bottom: 8px;
+}
+.context ul { padding-left: 20px; margin-top: 8px; }
+.context code { background: #F2F2F2; padding: 1px 6px; border-radius: 4px; font-size: 13px; color: #D97848; }
+
+/* Section heading */
+.section-head {
+  display: flex; align-items: baseline; gap: 16px;
+  margin: 40px 0 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #DDD;
+}
+.section-head .se-num {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: #999;
+}
+.section-head h2 { font-size: 22px; font-weight: 800; letter-spacing: -0.02em; }
+.section-head .se-meta { margin-left: auto; font-size: 12px; color: #888; font-variant-numeric: tabular-nums; }
+
+/* Variant grid (shell variants) */
+.variants {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.variant-card {
+  background: #fff; border: 1px solid #DDD; border-radius: 14px;
+  padding: 20px;
+  display: flex; flex-direction: column;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.variant-card:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0,0,0,0.08); }
+.variant-card .variant-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.24em; text-transform: uppercase;
+  color: #666; margin-bottom: 4px;
+}
+.variant-card h3 {
+  font-size: 20px; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 4px;
+}
+.variant-card .variant-sub { font-size: 13px; color: #666; margin-bottom: 14px; }
+.palette-strip {
+  display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; height: 32px;
+  border-radius: 6px; overflow: hidden; margin-bottom: 14px;
+}
+.palette-strip div {
+  display: grid; place-items: center;
+  font-size: 9px; font-weight: 700; color: rgba(0,0,0,0.5);
+}
+
+.v1 .variant-eyebrow, .v1 h3 { color: #0077B6; }
+.v1 .palette-strip :nth-child(1) { background: #0077B6; color: #fff; }
+.v1 .palette-strip :nth-child(2) { background: #E0F4FA; }
+.v1 .palette-strip :nth-child(3) { background: #FFFFFF; border: 1px solid #EBEBEB; }
+.v1 .palette-strip :nth-child(4) { background: #222222; color: #fff; }
+
+.v2 .variant-eyebrow, .v2 h3 { color: #B85C2E; }
+.v2 .palette-strip :nth-child(1) { background: #D97848; color: #fff; }
+.v2 .palette-strip :nth-child(2) { background: #FBEEE4; }
+.v2 .palette-strip :nth-child(3) { background: #FFFBF5; border: 1px solid #EADFCF; }
+.v2 .palette-strip :nth-child(4) { background: #2A1F18; color: #fff; }
+
+.v3 .variant-eyebrow { color: #B85C2E; }
+.v3 h3 { color: #2A1F18; }
+.v3 .palette-strip :nth-child(1) { background: #D97848; color: #fff; }
+.v3 .palette-strip :nth-child(2) { background: #FBEEE4; }
+.v3 .palette-strip :nth-child(3) { background: #FFFBF5; border: 1px solid #EADFCF; }
+.v3 .palette-strip :nth-child(4) { background: #2A1F18; color: #fff; }
+
+.variant-card ul {
+  list-style: none; margin: 0 0 16px; font-size: 13px; flex: 1;
+}
+.variant-card ul li {
+  padding: 5px 0; border-bottom: 1px dashed #EEE;
+  display: flex; gap: 8px;
+}
+.variant-card ul li::before {
+  content: '·'; color: #999; font-weight: 700; flex-shrink: 0;
+}
+.variant-card ul li:last-child { border-bottom: none; }
+
+.variant-cta {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 10px 18px; border-radius: 9999px;
+  background: #222; color: #fff; text-decoration: none;
+  font-size: 13px; font-weight: 600;
+  transition: background 0.15s;
+  align-self: flex-start;
+}
+.variant-cta:hover { background: #000; }
+.v1 .variant-cta { background: #0077B6; }
+.v1 .variant-cta:hover { background: #005C8F; }
+.v2 .variant-cta { background: #D97848; }
+.v2 .variant-cta:hover { background: #B85C2E; }
+.v3 .variant-cta { background: #2A1F18; }
+
+/* Page mockup grid */
+.pages {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  margin-bottom: 32px;
+}
+.page-card {
+  background: #fff; border: 1px solid #DDD; border-radius: 14px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  text-decoration: none; color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+.page-card:hover { transform: translateY(-2px); border-color: #D97848; box-shadow: 0 10px 28px rgba(217, 120, 72, 0.12); }
+.pc-preview {
+  height: 90px;
+  background: #FAF4EA;
+  display: grid; place-items: center;
+  position: relative; overflow: hidden;
+  border-bottom: 1px solid #EADFCF;
+}
+.pc-preview::before {
+  content: ''; position: absolute; top: 0; bottom: 0; left: 0; width: 36px;
+  background: rgba(217, 120, 72, 0.08);
+  border-right: 1px solid rgba(217, 120, 72, 0.18);
+}
+.pc-preview .pc-route {
+  position: relative; z-index: 2;
+  font-size: 14px; font-weight: 700; color: #B85C2E;
+  letter-spacing: -0.005em;
+  font-variant-numeric: tabular-nums;
+  background: #fff; padding: 4px 12px; border-radius: 9999px;
+  border: 1px solid #EADFCF;
+}
+.pc-body {
+  padding: 14px 16px 16px;
+  display: flex; flex-direction: column; gap: 6px; flex: 1;
+}
+.pc-eyebrow {
+  font-size: 9px; font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: #B85C2E;
+}
+.pc-title {
+  font-size: 16px; font-weight: 800; letter-spacing: -0.015em;
+  color: #2A1F18;
+}
+.pc-desc {
+  font-size: 12px; color: #6F5A47; line-height: 1.55;
+  flex: 1;
+}
+.pc-states {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  margin-top: 4px;
+}
+.pc-states .state-pill {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; border-radius: 9999px;
+  background: #F2EAD9; color: #6F5A47;
+  font-size: 10px; font-weight: 600; letter-spacing: 0.05em;
+}
+.pc-cta-row {
+  margin-top: 10px;
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; color: #999;
+  font-variant-numeric: tabular-nums;
+}
+.pc-cta-row .open-arrow { color: #D97848; font-weight: 700; }
+
+.footer {
+  margin-top: 40px; padding-top: 24px; border-top: 1px solid #DDD;
+  font-size: 13px; color: #666;
+}
+.footer h2 {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase;
+  color: #222; margin-bottom: 12px;
+}
+.footer code { background: #E9ECEF; padding: 1px 6px; border-radius: 4px; font-size: 12px; color: #D97848; }
+.footer ol { padding-left: 20px; }
+.footer ol li { padding: 4px 0; }
+.footer table {
+  width: 100%; border-collapse: collapse; margin-top: 12px;
+  font-size: 13px;
+}
+.footer th, .footer td {
+  text-align: left; padding: 8px 12px;
+  border-bottom: 1px solid #DDD;
+}
+.footer th {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: #999;
+}
+.footer td:first-child { font-weight: 700; color: #B85C2E; width: 140px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="header">
+  <div class="eyebrow">OpenSpec · desktop-3pane-and-nav-layout · 2026-04-24</div>
+  <h1>Tripline V2 Mockup Index<br>11 個 view · 5 個 nav route + 3 shell variant</h1>
+  <p class="intro">B-P2 layout refactor 的視覺參考集合。Shell 提供 3 個 variant（Ocean / Terracotta / Magazine）讓使用者選 palette；V2 Terracotta 是 locked palette（2026-04-24 session），各 nav route 都做完整 mockup（桌機 1440 / 1100 / mobile 375 三組 viewport）。</p>
+</header>
+
+<section class="context">
+  <h2>OpenSpec LOCKED 決策</h2>
+  <ul>
+    <li>桌機 <strong>3-pane</strong>：sidebar <code>240px</code> + main fluid + sheet <code>min(780px, 40vw)</code> collapsible</li>
+    <li>桌機 <strong>5 nav sidebar</strong>：聊天 / 行程 / 地圖 / 探索 / 登入（New Trip CTA 在 sidebar 底，不佔 nav）</li>
+    <li>手機 <strong>bottom nav 常駐</strong>：不 hide on scroll，<code>height 88px + env(safe-area-inset-bottom)</code></li>
+    <li>Per-trip sheet URL：<code>?sheet=map/ideas/itinerary/chat</code>（V2 Final 取消 sheet 內 tabs，改 trip switcher dropdown）</li>
+    <li>Breakpoint：<code>≥1280</code> 3-pane full / <code>1024-1279</code> 2-pane / <code>&lt;1024</code> mobile</li>
+    <li>Tap target <code>≥44px</code>（Apple HIG）</li>
+  </ul>
+</section>
+
+<!-- ===== Shell Variants ===== -->
+<div class="section-head">
+  <span class="se-num">Section A</span>
+  <h2>Shell Variants — 選 Palette</h2>
+  <span class="se-meta">3 個</span>
+</div>
+
+<section class="variants">
+  <article class="variant-card v1">
+    <div class="variant-eyebrow">V01 · Baseline</div>
+    <h3>Ocean</h3>
+    <div class="variant-sub">保守路線 · 零 retheme 成本</div>
+    <div class="palette-strip">
+      <div>#0077B6</div><div>subtle</div><div>bg</div><div>ink</div>
+    </div>
+    <ul>
+      <li>對齊當前 <code>tokens.css</code> 現狀</li>
+      <li>Active nav: subtle bg + accent text</li>
+      <li>白底 sidebar · Ocean 藍 accent</li>
+    </ul>
+    <a class="variant-cta" href="mockup-shell-v1-ocean.html">開啟 V1 →</a>
+  </article>
+
+  <article class="variant-card v2">
+    <div class="variant-eyebrow">V02 · Locked palette</div>
+    <h3>Terracotta</h3>
+    <div class="variant-sub">2026-04-24 session 定案的暖調</div>
+    <div class="palette-strip">
+      <div>#D97848</div><div>subtle</div><div>cream</div><div>ink</div>
+    </div>
+    <ul>
+      <li>對齊 <code>terracotta-preview.html</code></li>
+      <li>Active nav: filled dark pill</li>
+      <li>Cream bg + warm terracotta accent</li>
+    </ul>
+    <a class="variant-cta" href="mockup-shell-v2-terracotta.html">開啟 V2 →</a>
+  </article>
+
+  <article class="variant-card v3">
+    <div class="variant-eyebrow">V03 · Editorial</div>
+    <h3>Magazine</h3>
+    <div class="variant-sub">Terracotta + 雜誌 editorial typography</div>
+    <div class="palette-strip">
+      <div>#D97848</div><div>subtle</div><div>cream</div><div>ink</div>
+    </div>
+    <ul>
+      <li>Sidebar 220px · uppercase nav label</li>
+      <li>Main hero: 56px display title</li>
+      <li>Trip card poster 4:5 aspect</li>
+    </ul>
+    <a class="variant-cta" href="mockup-shell-v3-magazine.html">開啟 V3 →</a>
+  </article>
+</section>
+
+<!-- ===== V2 Page Mockups ===== -->
+<div class="section-head">
+  <span class="se-num">Section B</span>
+  <h2>V2 Page Mockups — 5 Nav + Auth Flows</h2>
+  <span class="se-meta">7 個 view · 採用 V2 Terracotta</span>
+</div>
+
+<section class="pages">
+  <a class="page-card" href="mockup-chat-v2.html">
+    <div class="pc-preview"><span class="pc-route">/chat</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Sidebar Nav 01</div>
+      <div class="pc-title">聊天</div>
+      <div class="pc-desc">全站 AI discovery entry · chat-first pivot</div>
+      <div class="pc-states">
+        <span class="state-pill">empty hero</span>
+        <span class="state-pill">對話中</span>
+        <span class="state-pill">聊出 trip</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · 4 quick actions</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-trip-v2.html">
+    <div class="pc-preview"><span class="pc-route">/manage</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Sidebar Nav 02</div>
+      <div class="pc-title">行程（V2 Final）</div>
+      <div class="pc-desc">Trip list + sheet 內 day strip + ocean-rail itinerary + trip switcher dropdown</div>
+      <div class="pc-states">
+        <span class="state-pill">trip list</span>
+        <span class="state-pill">sheet 展開</span>
+        <span class="state-pill">trip switcher</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · sheet 無 tabs</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-map-v2.html">
+    <div class="pc-preview"><span class="pc-route">/map</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Sidebar Nav 03</div>
+      <div class="pc-title">地圖（cross-trip global）</div>
+      <div class="pc-desc">所有 trips polyline + POI marker · view-only · 不含 search</div>
+      <div class="pc-states">
+        <span class="state-pill">filter chips</span>
+        <span class="state-pill">POI popup</span>
+        <span class="state-pill">mobile carousel</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · sheet 32vw</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-explore-v2.html">
+    <div class="pc-preview"><span class="pc-route">/explore</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Sidebar Nav 04</div>
+      <div class="pc-title">探索（POI 搜尋 + 儲存池）</div>
+      <div class="pc-desc">2 tab · search/儲存池 · 多選加入 trip · 跟 /map 分工 active vs passive</div>
+      <div class="pc-states">
+        <span class="state-pill">search mode</span>
+        <span class="state-pill">multi-select</span>
+        <span class="state-pill">add to trip</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · saved_pois schema</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-login-v2.html">
+    <div class="pc-preview"><span class="pc-route">/login</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Sidebar Nav 05 · Auth</div>
+      <div class="pc-title">登入</div>
+      <div class="pc-desc">未登入：Google/Apple/LINE OAuth + Email · 已登入：profile + settings</div>
+      <div class="pc-states">
+        <span class="state-pill">未登入</span>
+        <span class="state-pill">已登入 settings</span>
+        <span class="state-pill">SVG provider</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · 真實品牌 logo</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-signup-v2.html">
+    <div class="pc-preview"><span class="pc-route">/login/signup</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Auth Sub-route</div>
+      <div class="pc-title">建立帳號</div>
+      <div class="pc-desc">Step 1 OAuth/Email 三 field + password meter · Step 2 等 email verification</div>
+      <div class="pc-states">
+        <span class="state-pill">Step 1 form</span>
+        <span class="state-pill">Step 2 verify</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · 7 天未驗自動清</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+
+  <a class="page-card" href="mockup-forgot-v2.html">
+    <div class="pc-preview"><span class="pc-route">/login/forgot</span></div>
+    <div class="pc-body">
+      <div class="pc-eyebrow">Auth Sub-route</div>
+      <div class="pc-title">忘記密碼</div>
+      <div class="pc-desc">Step 1 輸入 email · Step 2 設新密碼 · email-only recovery channel</div>
+      <div class="pc-states">
+        <span class="state-pill">Step 1 寄連結</span>
+        <span class="state-pill">Step 2 重設</span>
+      </div>
+      <div class="pc-cta-row"><span>3 viewport · 1h 連結失效</span><span class="open-arrow">→</span></div>
+    </div>
+  </a>
+</section>
+
+<footer class="footer">
+  <h2>Task 對照表</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Mockup</th>
+        <th>Workstream / OpenSpec change</th>
+        <th>Phase</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Shell V1/V2/V3</td>
+        <td><code>desktop-3pane-and-nav-layout</code> §2-§4 AppShell + Sidebar + BottomNav</td>
+        <td>B-P2</td>
+      </tr>
+      <tr>
+        <td>/manage 行程</td>
+        <td><code>desktop-3pane-and-nav-layout</code> §5 Page refactor 套 AppShell</td>
+        <td>B-P2</td>
+      </tr>
+      <tr>
+        <td>/chat 聊天</td>
+        <td><code>desktop-3pane-and-nav-layout</code> §6.1 ChatPage placeholder + 完整 spec</td>
+        <td>B-P2 placeholder + 後續 V2-? 實作</td>
+      </tr>
+      <tr>
+        <td>/map 地圖</td>
+        <td><code>desktop-3pane-and-nav-layout</code> §6.2 MapPage placeholder + 完整 spec</td>
+        <td>B-P2 placeholder + 後續實作</td>
+      </tr>
+      <tr>
+        <td>/explore 探索</td>
+        <td><code>explore-nav-with-poi-search</code> 完整 scope</td>
+        <td>B-P4</td>
+      </tr>
+      <tr>
+        <td>/login + signup + forgot</td>
+        <td>V2 OAuth Workstream A</td>
+        <td>P1 (login UI) / P2 (signup) / P3 (forgot)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2 style="margin-top: 24px;">使用建議</h2>
+  <ol>
+    <li>先看 <strong>3 個 shell variant</strong> 選 palette（V2 Terracotta 已是 2026-04-24 locked）</li>
+    <li>再看 <strong>V2 page mockups</strong> 7 個 view 確認 layout/IA 一致</li>
+    <li>實作 B-P2 §2-§7 時對照「行程」mockup（V2 Final）— sheet 結構已優化（無 tabs + trip switcher）</li>
+    <li>其他 4 個 nav（聊天/地圖/探索/登入）的 mockup 可作 ChatPage / MapPage / ExplorePage / LoginPage placeholder 後續實作的視覺規格</li>
+    <li>Auth flows（signup/forgot）對應 V2 OAuth Workstream A 的 P1-P3，跟 layout refactor 可 parallel</li>
+  </ol>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/design-sessions/mockup-login-v2.html
+++ b/docs/design-sessions/mockup-login-v2.html
@@ -1,0 +1,838 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Login Page — /login</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  --grid-3pane: 240px 1fr min(420px, 32vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+  --font-caption2: 0.6875rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+/* User chip in sidebar (logged-in) */
+.sidebar-account-card {
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--accent-subtle);
+  display: flex; align-items: center; gap: 10px;
+}
+.sidebar-account-card .avatar-md {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--accent); color: #fff;
+  display: grid; place-items: center; font-size: 14px; font-weight: 800; flex-shrink: 0;
+}
+.sidebar-account-card .ac-body { flex: 1; min-width: 0; }
+.sidebar-account-card .ac-name { font-size: 13px; font-weight: 700; color: var(--foreground); }
+.sidebar-account-card .ac-email { font-size: 11px; color: var(--accent-deep); margin-top: 2px; word-break: break-all; }
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Login Main (未登入) ========== */
+.login-main {
+  background: var(--secondary);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%;
+  overflow: hidden;
+}
+.login-form-side {
+  display: flex; align-items: center; justify-content: center;
+  padding: 48px;
+  overflow-y: auto;
+}
+.login-card {
+  width: 100%; max-width: 420px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 20px;
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+.login-card .lc-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 8px;
+}
+.login-card h2 {
+  font-size: 28px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 8px;
+}
+.login-card .lc-sub {
+  font-size: 14px; color: var(--muted);
+  margin-bottom: 28px;
+}
+
+.login-providers {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-bottom: 24px;
+}
+.provider-btn {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  padding: 12px 18px; border-radius: 12px;
+  background: var(--background); border: 1px solid var(--border);
+  font: inherit; font-size: 14px; font-weight: 600; color: var(--foreground);
+  cursor: pointer; min-height: 48px;
+}
+.provider-btn:hover { background: var(--hover); border-color: var(--foreground); }
+.provider-btn.google {}
+.provider-btn .provider-icon {
+  width: 20px; height: 20px;
+  display: grid; place-items: center;
+}
+.provider-btn .provider-icon svg { width: 20px; height: 20px; display: block; }
+.provider-btn.google { color: var(--foreground); }
+.provider-btn.apple { color: var(--foreground); }
+.provider-btn.line { color: var(--foreground); }
+
+.divider {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted);
+  margin: 24px 0;
+}
+.divider::before, .divider::after {
+  content: ''; flex: 1; height: 1px; background: var(--border);
+}
+
+.field { margin-bottom: 14px; }
+.field label {
+  display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 6px;
+}
+.field input {
+  width: 100%; padding: 12px 14px; border-radius: 12px;
+  border: 1px solid var(--border); background: var(--background);
+  font: inherit; font-size: 15px; color: var(--foreground);
+  outline: none; min-height: 48px;
+}
+.field input:focus { border-color: var(--accent); }
+.field input::placeholder { color: var(--muted); }
+
+.primary-btn {
+  width: 100%;
+  padding: 12px 18px; border-radius: 12px;
+  background: var(--foreground); color: var(--background);
+  border: none; font: inherit; font-size: 14px; font-weight: 700;
+  cursor: pointer; min-height: 48px;
+  margin-top: 4px;
+}
+.primary-btn:hover { background: var(--accent-deep); }
+
+.lc-footer {
+  margin-top: 20px; font-size: 13px; color: var(--muted);
+  display: flex; justify-content: space-between; align-items: center; gap: 8px;
+}
+.lc-footer a { color: var(--accent-deep); text-decoration: none; font-weight: 600; }
+.lc-footer a:hover { text-decoration: underline; }
+.lc-link { color: var(--accent-deep); font-weight: 600; cursor: pointer; }
+
+.lc-terms { margin-top: 16px; font-size: 11px; color: var(--muted); line-height: 1.6; }
+.lc-terms a { color: var(--accent-deep); text-decoration: none; }
+.lc-terms a:hover { text-decoration: underline; }
+
+/* Right benefit side */
+.login-benefit-side {
+  background: linear-gradient(135deg, var(--foreground) 0%, var(--accent-deep) 100%);
+  color: var(--background);
+  padding: 56px 48px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  position: relative;
+  overflow: hidden;
+}
+.login-benefit-side::before {
+  content: ''; position: absolute;
+  top: -100px; right: -100px; width: 400px; height: 400px;
+  border-radius: 50%; background: rgba(247, 223, 203, 0.1);
+}
+.login-benefit-side::after {
+  content: ''; position: absolute;
+  bottom: -80px; left: -80px; width: 300px; height: 300px;
+  border-radius: 50%; background: rgba(217, 120, 72, 0.18);
+}
+.bs-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; opacity: 0.7;
+  position: relative; z-index: 2;
+}
+.bs-display {
+  font-size: 42px; font-weight: 900; letter-spacing: -0.03em; line-height: 1.05;
+  margin: 16px 0 24px;
+  position: relative; z-index: 2;
+  max-width: 380px;
+}
+.bs-features {
+  display: flex; flex-direction: column; gap: 18px;
+  position: relative; z-index: 2;
+}
+.bs-feature {
+  display: flex; gap: 14px; align-items: flex-start;
+}
+.bs-feature .feat-icon {
+  width: 36px; height: 36px; border-radius: 8px;
+  background: rgba(255, 251, 245, 0.12);
+  display: grid; place-items: center;
+  flex-shrink: 0;
+  color: var(--background);
+}
+.bs-feature .feat-icon svg { width: 18px; height: 18px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.bs-feature .feat-body { padding-top: 4px; }
+.bs-feature .feat-title { font-size: 15px; font-weight: 700; letter-spacing: -0.005em; }
+.bs-feature .feat-desc { font-size: 13px; opacity: 0.78; margin-top: 2px; line-height: 1.5; }
+
+.bs-footnote {
+  font-size: 11px; opacity: 0.6; letter-spacing: 0.12em; text-transform: uppercase;
+  font-weight: 600; position: relative; z-index: 2;
+}
+
+/* ========== Account view (已登入) ========== */
+.account-main {
+  background: var(--secondary);
+  overflow-y: auto;
+  padding: 40px 48px;
+}
+.account-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 32px; padding-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+.account-header h1 {
+  font-size: 28px; font-weight: 800; letter-spacing: -0.025em;
+}
+.account-header .signout-btn {
+  padding: 8px 16px; border-radius: 9999px;
+  background: transparent; border: 1px solid var(--border);
+  font: inherit; font-size: 13px; font-weight: 600; color: var(--foreground);
+  cursor: pointer;
+}
+.account-header .signout-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+.account-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 32px;
+  align-items: flex-start;
+}
+
+.profile-card {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 16px; padding: 28px;
+  text-align: center;
+}
+.profile-card .avatar-xl {
+  width: 80px; height: 80px; border-radius: 50%;
+  background: var(--accent); color: #fff;
+  display: grid; place-items: center; margin: 0 auto 16px;
+  font-size: 28px; font-weight: 800;
+}
+.profile-card h3 { font-size: 18px; font-weight: 700; letter-spacing: -0.005em; }
+.profile-card .pc-email { font-size: 13px; color: var(--muted); margin-top: 4px; }
+.profile-card .pc-stats {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+  margin-top: 24px; padding-top: 24px; border-top: 1px solid var(--border);
+}
+.profile-card .pc-stat-num {
+  font-size: 22px; font-weight: 800; font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.profile-card .pc-stat-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted); margin-top: 4px;
+}
+
+.settings-section {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 16px; overflow: hidden;
+}
+.settings-section .ss-eyebrow {
+  padding: 16px 24px 12px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+.settings-row {
+  display: flex; align-items: center; gap: 16px;
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--border);
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row .ss-label { font-size: 14px; font-weight: 600; flex-shrink: 0; min-width: 120px; }
+.settings-row .ss-value { font-size: 14px; color: var(--muted); flex: 1; }
+.settings-row .ss-action {
+  padding: 6px 12px; border-radius: 8px;
+  background: transparent; border: 1px solid var(--border);
+  font: inherit; font-size: 12px; font-weight: 600; color: var(--foreground);
+  cursor: pointer;
+}
+.settings-row .ss-action:hover { border-color: var(--accent); color: var(--accent); }
+.settings-row .ss-toggle {
+  width: 40px; height: 22px; border-radius: 9999px;
+  background: var(--accent); position: relative;
+  cursor: pointer; flex-shrink: 0;
+}
+.settings-row .ss-toggle::after {
+  content: ''; position: absolute; top: 2px; right: 2px;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: #fff;
+}
+.settings-row .ss-toggle.off { background: var(--tertiary); }
+.settings-row .ss-toggle.off::after { left: 2px; right: auto; }
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  flex-shrink: 0; position: sticky; top: 0; z-index: 10;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-login {
+  flex: 1; overflow-y: auto;
+  padding: 32px 24px calc(var(--nav-h-mobile) + 16px);
+  display: flex; flex-direction: column; gap: 24px;
+}
+.mobile-login .lc-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 8px;
+}
+.mobile-login h2 {
+  font-size: 28px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 6px;
+}
+.mobile-login .lc-sub { font-size: 14px; color: var(--muted); margin-bottom: 8px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Login Page Mockup — /login</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      Sidebar 第 5 項「登入」· 兩狀態 — 未登入：sign-in form；已登入：profile + settings + sign out
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Login</span>
+    <span class="nav-links">
+      <a href="mockup-explore-v2.html">探索</a>
+      <a href="mockup-map-v2.html">地圖</a>
+      <a href="mockup-trip-v2.html">行程</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — 未登入 sign-in（左 form + 右 benefit） ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · 未登入狀態 — 左 sign-in form + 右 benefit copy（左右各占 50%）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">?</div><span>未登入</span></div>
+      </div>
+    </aside>
+
+    <main class="login-main">
+      <div class="login-form-side">
+        <div class="login-card">
+          <div class="lc-eyebrow">Welcome · Tripline</div>
+          <h2>登入帳號<br>繼續規劃旅程</h2>
+          <div class="lc-sub">5 秒登入，行程跨裝置同步、可邀旅伴共編。</div>
+
+          <div class="login-providers">
+            <button class="provider-btn google">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M21.35 11.1H12v3.8h5.35a4.5 4.5 0 0 1-1.97 2.96v2.45h3.17c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-2z" fill="#4285F4"/><path d="M12 22c2.7 0 4.96-.9 6.62-2.43l-3.17-2.45a6 6 0 0 1-3.45.96 6 6 0 0 1-5.7-4.16H2.99v2.55A10 10 0 0 0 12 22z" fill="#34A853"/><path d="M6.3 13.92a6 6 0 0 1 0-3.84V7.53H2.99a10 10 0 0 0 0 8.94L6.3 13.92z" fill="#FBBC05"/><path d="M12 6.16c1.47 0 2.79.5 3.83 1.5l2.86-2.86C16.95 3.13 14.7 2 12 2A10 10 0 0 0 2.99 7.53L6.3 10.08C7.1 7.95 9.35 6.16 12 6.16z" fill="#EA4335"/></svg>
+              </span>
+              <span>使用 Google 登入</span>
+            </button>
+            <button class="provider-btn apple">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+              </span>
+              <span>使用 Apple 登入</span>
+            </button>
+            <button class="provider-btn line">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="#06C755"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+              </span>
+              <span>使用 LINE 登入</span>
+            </button>
+          </div>
+
+          <div class="divider">或 Email</div>
+
+          <div class="field">
+            <label>Email</label>
+            <input type="email" placeholder="ray@example.com">
+          </div>
+          <div class="field">
+            <label>密碼</label>
+            <input type="password" placeholder="•••••••••">
+          </div>
+
+          <button class="primary-btn">登入 →</button>
+
+          <div class="lc-footer">
+            <span><a>忘記密碼？</a></span>
+            <span>還沒帳號？<span class="lc-link">建立 →</span></span>
+          </div>
+
+          <div class="lc-terms">
+            登入即同意 <a>服務條款</a>與 <a>隱私權政策</a>。Tripline 不會在未經允許下分享您的行程資料。
+          </div>
+        </div>
+      </div>
+
+      <div class="login-benefit-side">
+        <div class="bs-eyebrow">Why sign in</div>
+        <div>
+          <h2 class="bs-display">把每次旅程<br>留在身邊。</h2>
+          <div class="bs-features">
+            <div class="bs-feature">
+              <div class="feat-icon">
+                <svg viewBox="0 0 24 24"><path d="M21 12a9 9 0 0 1-9 9M3 12a9 9 0 0 1 9-9M21 12h-4M7 12H3M12 21v-4M12 7V3"/><circle cx="12" cy="12" r="4"/></svg>
+              </div>
+              <div class="feat-body">
+                <div class="feat-title">跨裝置同步</div>
+                <div class="feat-desc">手機看到的就是平板看到的，離線也能用。</div>
+              </div>
+            </div>
+            <div class="bs-feature">
+              <div class="feat-icon">
+                <svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+              </div>
+              <div class="feat-body">
+                <div class="feat-title">邀請旅伴共編</div>
+                <div class="feat-desc">用一個 link 把家人朋友拉進行程，不用 LINE 截圖。</div>
+              </div>
+            </div>
+            <div class="bs-feature">
+              <div class="feat-icon">
+                <svg viewBox="0 0 24 24"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <div class="feat-body">
+                <div class="feat-title">儲存池跟著你</div>
+                <div class="feat-desc">看到喜歡的餐廳/景點按 ♡ 儲存，下次規劃直接拉進 trip。</div>
+              </div>
+            </div>
+            <div class="bs-feature">
+              <div class="feat-icon">
+                <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/></svg>
+              </div>
+              <div class="feat-body">
+                <div class="feat-title">AI 對話記住你</div>
+                <div class="feat-desc">告訴 Tripline 你喜歡什麼，下次規劃自動套你的偏好。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="bs-footnote">© 2026 Tripline · 由旅人為旅人打造</div>
+      </div>
+    </main>
+
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — 已登入 account view ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · 已登入狀態 — profile + 帳號設定</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+
+      <!-- Logged-in 狀態：sidebar 改顯示 account card 而非「未登入」chip -->
+      <div class="sidebar-account-card">
+        <div class="avatar-md">R</div>
+        <div class="ac-body">
+          <div class="ac-name">Ray Chiu</div>
+          <div class="ac-email">ray@trip.io</div>
+        </div>
+      </div>
+
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+      </div>
+    </aside>
+
+    <main class="account-main">
+      <div class="account-header">
+        <h1>帳號</h1>
+        <button class="signout-btn">登出</button>
+      </div>
+
+      <div class="account-grid">
+        <!-- Profile card -->
+        <div class="profile-card">
+          <div class="avatar-xl">R</div>
+          <h3>Ray Chiu</h3>
+          <div class="pc-email">ray@trip.io</div>
+          <div class="pc-stats">
+            <div>
+              <div class="pc-stat-num">3</div>
+              <div class="pc-stat-label">Active</div>
+            </div>
+            <div>
+              <div class="pc-stat-num">12</div>
+              <div class="pc-stat-label">Saved</div>
+            </div>
+            <div>
+              <div class="pc-stat-num">15</div>
+              <div class="pc-stat-label">Trips</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Settings sections -->
+        <div style="display: flex; flex-direction: column; gap: 20px;">
+          <section class="settings-section">
+            <div class="ss-eyebrow">Profile</div>
+            <div class="settings-row">
+              <span class="ss-label">名稱</span>
+              <span class="ss-value">Ray Chiu</span>
+              <button class="ss-action">編輯</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">Email</span>
+              <span class="ss-value">ray@trip.io</span>
+              <button class="ss-action">變更</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">密碼</span>
+              <span class="ss-value">••••••••• · 上次更新 30 天前</span>
+              <button class="ss-action">變更</button>
+            </div>
+          </section>
+
+          <section class="settings-section">
+            <div class="ss-eyebrow">Preferences</div>
+            <div class="settings-row">
+              <span class="ss-label">深色模式</span>
+              <span class="ss-value">跟隨系統</span>
+              <button class="ss-action">切換</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">語言</span>
+              <span class="ss-value">繁體中文（台灣）</span>
+              <button class="ss-action">切換</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">Email 通知</span>
+              <span class="ss-value">旅伴邀請、共編更新</span>
+              <span class="ss-toggle"></span>
+            </div>
+          </section>
+
+          <section class="settings-section">
+            <div class="ss-eyebrow">Connected accounts</div>
+            <div class="settings-row">
+              <span class="ss-label">Google</span>
+              <span class="ss-value">已連結 · ray@gmail.com</span>
+              <button class="ss-action">取消連結</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">Apple</span>
+              <span class="ss-value">未連結</span>
+              <button class="ss-action">連結</button>
+            </div>
+            <div class="settings-row">
+              <span class="ss-label">LINE</span>
+              <span class="ss-value">未連結</span>
+              <button class="ss-action">連結</button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Mobile 375 — 未登入 sign-in ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · 未登入狀態 — 全寬 form + bottom nav</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="關閉"><span style="font-size: 16px;">✕</span></button>
+    </header>
+
+    <div class="mobile-login">
+      <div>
+        <div class="lc-eyebrow">Welcome · Tripline</div>
+        <h2>登入<br>繼續規劃旅程</h2>
+        <div class="lc-sub">5 秒登入，行程跨裝置同步、可邀旅伴共編。</div>
+      </div>
+
+      <div class="login-providers">
+        <button class="provider-btn google">
+          <span class="provider-icon">G</span>
+          <span>使用 Google 登入</span>
+        </button>
+        <button class="provider-btn">
+          <span class="provider-icon"></span>
+          <span>使用 Apple 登入</span>
+        </button>
+        <button class="provider-btn">
+          <span class="provider-icon">L</span>
+          <span>使用 LINE 登入</span>
+        </button>
+      </div>
+
+      <div class="divider">或 Email</div>
+
+      <div>
+        <div class="field">
+          <label>Email</label>
+          <input type="email" placeholder="ray@example.com">
+        </div>
+        <div class="field">
+          <label>密碼</label>
+          <input type="password" placeholder="•••••••••">
+        </div>
+        <button class="primary-btn">登入 →</button>
+      </div>
+
+      <div class="lc-footer">
+        <span><a>忘記密碼？</a></span>
+        <span>沒帳號？<span class="lc-link">建立</span></span>
+      </div>
+
+      <div class="lc-terms">
+        登入即同意 <a>服務條款</a>與 <a>隱私權政策</a>。
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>登入頁規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/login</code> — 兩狀態 view（未登入 form / 已登入 account）；不是 modal，是正式 page route</li>
+    <li><strong>Sidebar nav 第 5 項</strong>：未登入 active 顯示 <code>「登入」</code>；登入後 sidebar 底部 chip 改顯示 account card（avatar + 名 + email），nav 第 5 項標籤可改為「帳號」</li>
+    <li><strong>未登入 desktop layout</strong>：50/50 split — 左 sign-in card（max 420px centered）+ 右 dark gradient 暖調 benefit copy（hero + 4 feature row + footnote）</li>
+    <li><strong>OAuth providers</strong>：Google / Apple / LINE 三個（對齊 layout reference V2 OAuth provider plan + 適合台灣市場）</li>
+    <li><strong>Email + password fallback</strong>：雙 field + 黑底 primary 「登入 →」button + 「忘記密碼 / 建立帳號」footer</li>
+    <li><strong>已登入 layout</strong>：左 profile card（avatar 80px + name + email + 3 stats）+ 右 settings 三 section（Profile / Preferences / Connected accounts）</li>
+    <li><strong>Settings row 樣式</strong>：固定 label width 120px + value（muted）+ 右側 action button（編輯/變更/切換）或 toggle</li>
+    <li><strong>Sign out</strong>：account header 右上 outline pill button（不放在 settings 列表，避免誤觸；視覺上 destructive 應更明顯但 V2 暫保守）</li>
+    <li><strong>Mobile</strong>：sign-in 全寬 + bottom nav 常駐；form 順序由上至下：title hero → providers → divider → email/password → primary CTA → footer link → terms</li>
+    <li><strong>實作對應</strong>：V2 OAuth Server 任務（Workstream A · Phase 1-3）— 路由 + form UI 是 P1 起可做的部分；OAuth integration 在 P2-P3</li>
+    <li><strong>Anti-slop check</strong>：未做 welcome cover 第一屏（DESIGN.md 禁止）— 第一屏即是 form，承載 primary action（登入），右側 benefit 是輔助 affordance 不是 title-only</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-map-v2.html
+++ b/docs/design-sessions/mockup-map-v2.html
@@ -1,0 +1,1038 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Map Page — /map (cross-trip global)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  /* Map palette: cross-trip 每 trip 一個主色（DESIGN.md 10 色 Day palette 取前 3） */
+  --trip-okinawa: #D97848;  /* terracotta accent */
+  --trip-seoul: #06A77D;    /* teal */
+  --trip-taichung: #0EA5C7; /* sky */
+
+  --map-bg: #E5E7E0;
+  --map-water: #C8D6DC;
+  --map-land: #F0EDE3;
+  --map-road: #FFFFFF;
+
+  --grid-3pane: 240px 1fr min(420px, 32vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+  --font-caption2: 0.6875rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Map main ========== */
+.map-main {
+  position: relative;
+  overflow: hidden;
+  background: var(--map-bg);
+}
+
+/* SVG map illustration */
+.map-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+}
+
+/* Floating controls overlay */
+.map-overlay {
+  position: absolute; inset: 0;
+  pointer-events: none;
+}
+.map-overlay > * { pointer-events: auto; }
+
+.map-topbar {
+  position: absolute; top: 16px; left: 16px; right: 16px;
+  display: flex; align-items: flex-start; gap: 12px;
+}
+.map-eyebrow-card {
+  flex: 1;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border); border-radius: 12px;
+  padding: 12px 16px;
+  box-shadow: var(--shadow-sm);
+  display: flex; align-items: center; gap: 12px;
+  max-width: 480px;
+}
+.map-eyebrow-card .me-label {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+}
+.map-eyebrow-card .me-title { font-size: 14px; font-weight: 600; letter-spacing: -0.005em; }
+.map-eyebrow-card .me-meta { font-size: 12px; color: var(--muted); margin-left: auto; font-variant-numeric: tabular-nums; }
+
+.map-filter-bar {
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.trip-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px; border-radius: 9999px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: var(--foreground); cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: border-color 0.15s, opacity 0.15s;
+}
+.trip-chip:hover { border-color: var(--foreground); }
+.trip-chip.is-off { opacity: 0.4; }
+.trip-chip .chip-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.trip-chip[data-trip="okinawa"] .chip-dot { background: var(--trip-okinawa); }
+.trip-chip[data-trip="seoul"] .chip-dot { background: var(--trip-seoul); }
+.trip-chip[data-trip="taichung"] .chip-dot { background: var(--trip-taichung); }
+.trip-chip .chip-meta { color: var(--muted); font-weight: 500; font-size: 11px; }
+
+/* Bottom-left zoom-to-fit */
+.map-action-bar {
+  position: absolute; bottom: 24px; left: 24px;
+  display: flex; gap: 8px;
+}
+.map-pill-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 10px 16px; border-radius: 9999px;
+  background: color-mix(in srgb, var(--background) 95%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: var(--foreground); cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+.map-pill-btn:hover { background: var(--background); border-color: var(--accent); color: var(--accent); }
+
+/* Bottom-right zoom + locate */
+.map-control-stack {
+  position: absolute; bottom: 24px; right: 24px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.map-square-btn {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: color-mix(in srgb, var(--background) 95%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--foreground); font: inherit; font-size: 18px;
+  box-shadow: var(--shadow-sm);
+}
+.map-square-btn:hover { background: var(--background); border-color: var(--accent); color: var(--accent); }
+.map-zoom-group {
+  display: flex; flex-direction: column;
+  background: color-mix(in srgb, var(--background) 95%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border); border-radius: 10px;
+  overflow: hidden; box-shadow: var(--shadow-sm);
+}
+.map-zoom-group .map-square-btn { background: transparent; border: none; border-radius: 0; box-shadow: none; backdrop-filter: none; }
+.map-zoom-group .map-square-btn + .map-square-btn { border-top: 1px solid var(--border); }
+
+/* Trip legend (bottom center on mobile, hidden on desktop where chip bar覆蓋功能) */
+
+/* POI marker popup (when selected) */
+.poi-popup {
+  position: absolute;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  padding: 12px;
+  min-width: 220px;
+  pointer-events: auto;
+}
+.poi-popup .pp-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--accent-deep);
+  margin-bottom: 4px;
+}
+.poi-popup .pp-title {
+  font-size: 14px; font-weight: 700; letter-spacing: -0.005em;
+  margin-bottom: 4px;
+}
+.poi-popup .pp-meta {
+  font-size: 12px; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.poi-popup .pp-actions {
+  display: flex; gap: 6px; margin-top: 10px;
+  padding-top: 10px; border-top: 1px solid var(--border);
+}
+.poi-popup .pp-btn {
+  flex: 1;
+  padding: 6px 10px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--foreground); cursor: pointer;
+  text-align: center;
+}
+.poi-popup .pp-btn.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.poi-popup .pp-btn:hover { border-color: var(--accent); color: var(--accent); }
+.poi-popup .pp-btn.primary:hover { background: var(--accent-deep); color: #fff; }
+
+/* ========== Right Sheet (cross-trip selected POI / trip detail) ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+.sheet-header .save-btn {
+  padding: 6px 14px; border-radius: 9999px;
+  background: var(--accent); color: #fff; border: none;
+  font: inherit; font-size: 12px; font-weight: 600;
+  cursor: pointer;
+}
+.sheet-header .save-btn:hover { background: var(--accent-deep); }
+
+.sheet-body { flex: 1; overflow-y: auto; padding: 20px; }
+
+.sheet-eyebrow {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 8px;
+}
+.sheet-eyebrow .trip-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--trip-okinawa);
+}
+.sheet-poi-title {
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+  line-height: 1.2; margin-bottom: 8px;
+}
+.sheet-poi-meta {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 16px;
+}
+.sheet-poi-meta .chip {
+  padding: 3px 10px; border-radius: 9999px;
+  background: var(--tertiary); color: var(--muted);
+  font-weight: 600; letter-spacing: 0.05em;
+}
+.sheet-poi-meta .chip.accent { background: var(--accent-subtle); color: var(--accent-deep); }
+.sheet-poi-meta .rating { color: var(--foreground); font-weight: 700; }
+
+.sheet-section {
+  margin-top: 20px; padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.sheet-section h4 {
+  font-size: var(--font-caption2); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 8px;
+}
+.sheet-section p { font-size: 14px; line-height: 1.55; color: var(--foreground); }
+.sheet-section .info-row {
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 13px; padding: 6px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.sheet-section .info-row:last-child { border-bottom: none; }
+.sheet-section .info-row .info-label {
+  font-size: var(--font-caption2); font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+  width: 80px; flex-shrink: 0;
+}
+.sheet-section .info-row .info-value { color: var(--foreground); }
+
+/* Other stops in same day */
+.day-stop-mini {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--border); cursor: pointer;
+}
+.day-stop-mini:last-child { border-bottom: none; }
+.day-stop-mini:hover .ds-name { color: var(--accent-deep); }
+.day-stop-mini .ds-time {
+  font-size: 12px; font-weight: 700;
+  font-variant-numeric: tabular-nums; color: var(--foreground);
+  width: 44px; flex-shrink: 0;
+}
+.day-stop-mini .ds-dot {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--background); border: 1.5px solid var(--line-strong);
+  display: grid; place-items: center;
+  font-size: 9px; font-weight: 700; color: var(--muted);
+  flex-shrink: 0;
+}
+.day-stop-mini.active .ds-dot { background: var(--accent); border-color: var(--accent); color: #fff; }
+.day-stop-mini .ds-name {
+  font-size: 13px; font-weight: 500; flex: 1;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.day-stop-mini.active .ds-name { font-weight: 700; color: var(--accent-deep); }
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  flex-shrink: 0;
+  position: relative; z-index: 10;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-map {
+  flex: 1; position: relative; overflow: hidden;
+  background: var(--map-bg);
+}
+
+/* Mobile filter chip strip (top) */
+.mobile-filter-strip {
+  position: absolute; top: 12px; left: 12px; right: 12px;
+  display: flex; gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  z-index: 6;
+}
+.mobile-filter-strip::-webkit-scrollbar { display: none; }
+.mobile-filter-strip .trip-chip {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+/* Mobile poi card carousel (bottom over map) */
+.mobile-poi-stack {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  background: linear-gradient(to top, var(--background) 75%, transparent);
+  padding: 12px 0 16px;
+  z-index: 6;
+}
+.mobile-poi-handle {
+  width: 36px; height: 4px; border-radius: 2px;
+  background: var(--line-strong);
+  margin: 0 auto 8px;
+}
+.mobile-poi-eyebrow {
+  display: flex; align-items: center; gap: 6px;
+  padding: 0 16px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 4px;
+}
+.mobile-poi-eyebrow .trip-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--trip-okinawa); }
+.mobile-poi-title { padding: 0 16px; font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.mobile-poi-cards {
+  display: flex; gap: 10px;
+  padding: 4px 16px 4px;
+  overflow-x: auto; scrollbar-width: none;
+}
+.mobile-poi-cards::-webkit-scrollbar { display: none; }
+.mobile-poi-card {
+  flex: 0 0 200px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 10px;
+  cursor: pointer;
+}
+.mobile-poi-card.active { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.mobile-poi-card .pc-mini-cover {
+  height: 80px; border-radius: 6px; margin-bottom: 6px;
+  background: var(--tertiary);
+}
+.mobile-poi-card .pc-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 2px;
+}
+.mobile-poi-card .pc-title { font-size: 13px; font-weight: 600; line-height: 1.3; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Map Page Mockup — /map (cross-trip global)</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      Sidebar 第 3 項「地圖」· 全域 cross-trip 地圖 · view-only（不含 search，那是探索的事）
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Map</span>
+    <span class="nav-links">
+      <a href="mockup-trip-v2.html">行程</a>
+      <a href="mockup-chat-v2.html">聊天</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — sheet 展開顯示選中的 POI detail ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · 3-pane（map 占主區，sheet 展開顯示選中 POI）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <!-- Map main -->
+    <main class="map-main">
+      <!-- SVG illustrative map (simplified 沖繩 + 首爾 + 台中 stylized region) -->
+      <svg class="map-canvas" viewBox="0 0 800 700" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+        <!-- water bg -->
+        <rect width="800" height="700" fill="#C8D6DC"/>
+        <!-- land masses (stylized) -->
+        <path d="M-20,200 Q120,180 200,220 Q280,260 350,250 Q420,240 500,290 Q580,340 700,330 L820,330 L820,720 L-20,720 Z" fill="#F0EDE3"/>
+        <path d="M150,80 Q220,60 280,90 Q330,120 360,100 L380,150 Q330,170 270,160 Q200,150 150,180 Q140,130 150,80 Z" fill="#F0EDE3"/>
+        <path d="M580,80 Q640,70 690,100 Q720,140 700,180 Q650,200 600,190 Q560,160 580,80 Z" fill="#F0EDE3"/>
+
+        <!-- subtle grid lines -->
+        <g stroke="#D8DCD2" stroke-width="0.4" opacity="0.7">
+          <line x1="0" y1="100" x2="800" y2="100"/>
+          <line x1="0" y1="200" x2="800" y2="200"/>
+          <line x1="0" y1="300" x2="800" y2="300"/>
+          <line x1="0" y1="400" x2="800" y2="400"/>
+          <line x1="0" y1="500" x2="800" y2="500"/>
+          <line x1="0" y1="600" x2="800" y2="600"/>
+          <line x1="100" y1="0" x2="100" y2="700"/>
+          <line x1="200" y1="0" x2="200" y2="700"/>
+          <line x1="300" y1="0" x2="300" y2="700"/>
+          <line x1="400" y1="0" x2="400" y2="700"/>
+          <line x1="500" y1="0" x2="500" y2="700"/>
+          <line x1="600" y1="0" x2="600" y2="700"/>
+          <line x1="700" y1="0" x2="700" y2="700"/>
+        </g>
+
+        <!-- 沖繩 polyline (Day 1 → Day 5) terracotta -->
+        <g>
+          <polyline points="180,420 220,440 260,460 280,490 320,510 380,490 430,470" fill="none" stroke="#D97848" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0"/>
+          <!-- markers -->
+          <circle cx="180" cy="420" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="180" y="424" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">1</text>
+          <circle cx="220" cy="440" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="220" y="444" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">2</text>
+          <!-- selected (large) -->
+          <circle cx="260" cy="460" r="14" fill="#D97848" stroke="#fff" stroke-width="3"/>
+          <text x="260" y="464" font-size="11" font-weight="700" fill="#fff" text-anchor="middle" font-family="Inter">3</text>
+          <circle cx="280" cy="490" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="280" y="494" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">4</text>
+          <circle cx="320" cy="510" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="320" y="514" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">5</text>
+          <circle cx="380" cy="490" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="380" y="494" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">6</text>
+          <circle cx="430" cy="470" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="430" y="474" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">7</text>
+        </g>
+
+        <!-- 首爾 polyline teal -->
+        <g>
+          <polyline points="220,120 250,140 280,130 310,150 290,170" fill="none" stroke="#06A77D" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="220" cy="120" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <text x="220" y="124" font-size="8" font-weight="700" fill="#06A77D" text-anchor="middle" font-family="Inter">1</text>
+          <circle cx="250" cy="140" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <text x="250" y="144" font-size="8" font-weight="700" fill="#06A77D" text-anchor="middle" font-family="Inter">2</text>
+          <circle cx="280" cy="130" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <text x="280" y="134" font-size="8" font-weight="700" fill="#06A77D" text-anchor="middle" font-family="Inter">3</text>
+          <circle cx="310" cy="150" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <text x="310" y="154" font-size="8" font-weight="700" fill="#06A77D" text-anchor="middle" font-family="Inter">4</text>
+          <circle cx="290" cy="170" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <text x="290" y="174" font-size="8" font-weight="700" fill="#06A77D" text-anchor="middle" font-family="Inter">5</text>
+        </g>
+
+        <!-- 台中 polyline sky -->
+        <g>
+          <polyline points="610,120 630,140 650,135" fill="none" stroke="#0EA5C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="610" cy="120" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+          <text x="610" y="124" font-size="8" font-weight="700" fill="#0EA5C7" text-anchor="middle" font-family="Inter">1</text>
+          <circle cx="630" cy="140" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+          <text x="630" y="144" font-size="8" font-weight="700" fill="#0EA5C7" text-anchor="middle" font-family="Inter">2</text>
+          <circle cx="650" cy="135" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+          <text x="650" y="139" font-size="8" font-weight="700" fill="#0EA5C7" text-anchor="middle" font-family="Inter">3</text>
+        </g>
+
+        <!-- region labels -->
+        <text x="280" y="510" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">沖繩</text>
+        <text x="270" y="200" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">首爾</text>
+        <text x="630" y="170" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">台中</text>
+      </svg>
+
+      <!-- Floating overlay -->
+      <div class="map-overlay">
+        <!-- Topbar with eyebrow card + filter chips -->
+        <div class="map-topbar">
+          <div class="map-eyebrow-card">
+            <div>
+              <div class="me-label">Global Map</div>
+              <div class="me-title">所有行程</div>
+            </div>
+            <div class="me-meta">3 trips · 15 stops</div>
+          </div>
+          <div class="map-filter-bar">
+            <button class="trip-chip" data-trip="okinawa">
+              <span class="chip-dot"></span>
+              <span>沖繩</span>
+              <span class="chip-meta">7 stops</span>
+            </button>
+            <button class="trip-chip" data-trip="seoul">
+              <span class="chip-dot"></span>
+              <span>首爾</span>
+              <span class="chip-meta">5 stops</span>
+            </button>
+            <button class="trip-chip is-off" data-trip="taichung">
+              <span class="chip-dot"></span>
+              <span>台中</span>
+              <span class="chip-meta">3 stops</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- POI popup (hover/click on marker 3) -->
+        <div class="poi-popup" style="top: 360px; left: 200px;">
+          <div class="pp-eyebrow">沖繩 · DAY 01 · STOP 03</div>
+          <div class="pp-title">MEGA唐吉軻德 宜野灣店</div>
+          <div class="pp-meta">用餐 · ★ 4.2 · 13:00</div>
+          <div class="pp-actions">
+            <button class="pp-btn">查看詳情</button>
+            <button class="pp-btn primary">跳到行程</button>
+          </div>
+        </div>
+
+        <!-- Bottom-left action -->
+        <div class="map-action-bar">
+          <button class="map-pill-btn">▣ 全覽</button>
+          <button class="map-pill-btn">⊕ 我的位置</button>
+        </div>
+
+        <!-- Bottom-right zoom + layer -->
+        <div class="map-control-stack">
+          <button class="map-square-btn" title="圖層">≡</button>
+          <div class="map-zoom-group">
+            <button class="map-square-btn" title="放大">+</button>
+            <button class="map-square-btn" title="縮小">−</button>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Right Sheet — selected POI detail -->
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="save-btn">跳到行程</button>
+      </div>
+
+      <div class="sheet-body">
+        <div class="sheet-eyebrow">
+          <span class="trip-dot" style="background: var(--trip-okinawa);"></span>
+          沖繩 · Day 01 · Stop 03
+        </div>
+        <h2 class="sheet-poi-title">MEGA唐吉軻德 宜野灣店（含午餐）</h2>
+        <div class="sheet-poi-meta">
+          <span class="chip accent">用餐</span>
+          <span class="chip rating">★ 4.2 · 1,580 reviews</span>
+          <span class="chip">13:00 – 15:10</span>
+          <span class="chip">2h</span>
+        </div>
+
+        <div class="sheet-section">
+          <h4>位置 · Address</h4>
+          <p>沖縄県宜野湾市真志喜３丁目２８−４１</p>
+        </div>
+
+        <div class="sheet-section">
+          <div class="info-row">
+            <span class="info-label">Phone</span>
+            <span class="info-value">+81 98-942-9911</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Hours</span>
+            <span class="info-value">10:00 – 24:00（每日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Travel</span>
+            <span class="info-value">飯店 → 12 km · 車程 25 分</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Coords</span>
+            <span class="info-value">26.2870, 127.7475</span>
+          </div>
+        </div>
+
+        <div class="sheet-section">
+          <h4>同日其他 stop</h4>
+          <div class="day-stop-mini">
+            <span class="ds-time">10:45</span>
+            <span class="ds-dot">1</span>
+            <span class="ds-name">抵達那霸機場</span>
+          </div>
+          <div class="day-stop-mini">
+            <span class="ds-time">12:10</span>
+            <span class="ds-dot">2</span>
+            <span class="ds-name">租車取車</span>
+          </div>
+          <div class="day-stop-mini active">
+            <span class="ds-time">13:00</span>
+            <span class="ds-dot">3</span>
+            <span class="ds-name">MEGA唐吉軻德 宜野灣店</span>
+          </div>
+          <div class="day-stop-mini">
+            <span class="ds-time">15:10</span>
+            <span class="ds-dot">4</span>
+            <span class="ds-name">Check in Vessel Hotel</span>
+          </div>
+          <div class="day-stop-mini">
+            <span class="ds-time">16:00</span>
+            <span class="ds-dot">5</span>
+            <span class="ds-name">美國村 + Sunset Beach</span>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — sheet 收起，純 map view ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · 2-pane（sheet 收起 → map 全寬，純瀏覽 mode）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <main class="map-main">
+      <svg class="map-canvas" viewBox="0 0 800 700" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+        <rect width="800" height="700" fill="#C8D6DC"/>
+        <path d="M-20,200 Q120,180 200,220 Q280,260 350,250 Q420,240 500,290 Q580,340 700,330 L820,330 L820,720 L-20,720 Z" fill="#F0EDE3"/>
+        <path d="M150,80 Q220,60 280,90 Q330,120 360,100 L380,150 Q330,170 270,160 Q200,150 150,180 Q140,130 150,80 Z" fill="#F0EDE3"/>
+        <path d="M580,80 Q640,70 690,100 Q720,140 700,180 Q650,200 600,190 Q560,160 580,80 Z" fill="#F0EDE3"/>
+        <g stroke="#D8DCD2" stroke-width="0.4" opacity="0.7">
+          <line x1="0" y1="200" x2="800" y2="200"/>
+          <line x1="0" y1="400" x2="800" y2="400"/>
+          <line x1="200" y1="0" x2="200" y2="700"/>
+          <line x1="400" y1="0" x2="400" y2="700"/>
+          <line x1="600" y1="0" x2="600" y2="700"/>
+        </g>
+        <g>
+          <polyline points="180,420 220,440 260,460 280,490 320,510 380,490 430,470" fill="none" stroke="#D97848" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="180" cy="420" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="220" cy="440" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="260" cy="460" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="280" cy="490" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="320" cy="510" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="380" cy="490" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <circle cx="430" cy="470" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+        </g>
+        <g>
+          <polyline points="220,120 250,140 280,130 310,150 290,170" fill="none" stroke="#06A77D" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="220" cy="120" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <circle cx="250" cy="140" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <circle cx="280" cy="130" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <circle cx="310" cy="150" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+          <circle cx="290" cy="170" r="7" fill="#fff" stroke="#06A77D" stroke-width="2.5"/>
+        </g>
+        <g>
+          <polyline points="610,120 630,140 650,135" fill="none" stroke="#0EA5C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="610" cy="120" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+          <circle cx="630" cy="140" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+          <circle cx="650" cy="135" r="7" fill="#fff" stroke="#0EA5C7" stroke-width="2.5"/>
+        </g>
+        <text x="280" y="510" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">沖繩</text>
+        <text x="270" y="200" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">首爾</text>
+        <text x="630" y="170" font-size="14" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">台中</text>
+      </svg>
+
+      <div class="map-overlay">
+        <div class="map-topbar">
+          <div class="map-eyebrow-card">
+            <div>
+              <div class="me-label">Global Map</div>
+              <div class="me-title">所有行程</div>
+            </div>
+            <div class="me-meta">3 trips · 15 stops</div>
+          </div>
+          <div class="map-filter-bar">
+            <button class="trip-chip" data-trip="okinawa">
+              <span class="chip-dot"></span><span>沖繩</span>
+            </button>
+            <button class="trip-chip" data-trip="seoul">
+              <span class="chip-dot"></span><span>首爾</span>
+            </button>
+            <button class="trip-chip" data-trip="taichung">
+              <span class="chip-dot"></span><span>台中</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="map-action-bar">
+          <button class="map-pill-btn">▣ 全覽</button>
+          <button class="map-pill-btn">⊕ 我的位置</button>
+        </div>
+
+        <div class="map-control-stack">
+          <button class="map-square-btn" title="圖層">≡</button>
+          <div class="map-zoom-group">
+            <button class="map-square-btn" title="放大">+</button>
+            <button class="map-square-btn" title="縮小">−</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Mobile 375 — full-screen map + bottom POI carousel ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · 全螢幕 map + 上 filter chips + 下 POI carousel + bottom nav</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="圖層"><span style="font-size: 16px;">≡</span></button>
+    </header>
+
+    <div class="mobile-map">
+      <svg class="map-canvas" viewBox="0 0 400 600" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+        <rect width="400" height="600" fill="#C8D6DC"/>
+        <path d="M-20,180 Q80,160 160,200 Q220,230 280,250 Q340,260 420,300 L420,620 L-20,620 Z" fill="#F0EDE3"/>
+        <path d="M80,40 Q150,30 200,60 Q230,90 250,80 L260,130 Q200,150 130,140 Q70,120 80,40 Z" fill="#F0EDE3"/>
+        <g stroke="#D8DCD2" stroke-width="0.4" opacity="0.7">
+          <line x1="0" y1="150" x2="400" y2="150"/>
+          <line x1="0" y1="300" x2="400" y2="300"/>
+          <line x1="0" y1="450" x2="400" y2="450"/>
+          <line x1="100" y1="0" x2="100" y2="600"/>
+          <line x1="200" y1="0" x2="200" y2="600"/>
+          <line x1="300" y1="0" x2="300" y2="600"/>
+        </g>
+
+        <!-- 沖繩（focused trip）-->
+        <g>
+          <polyline points="100,360 140,380 180,400 200,430 240,450 290,430" fill="none" stroke="#D97848" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="100" cy="360" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="100" y="364" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">1</text>
+          <circle cx="140" cy="380" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="140" y="384" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">2</text>
+          <circle cx="180" cy="400" r="14" fill="#D97848" stroke="#fff" stroke-width="3"/>
+          <text x="180" y="404" font-size="11" font-weight="700" fill="#fff" text-anchor="middle" font-family="Inter">3</text>
+          <circle cx="200" cy="430" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="200" y="434" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">4</text>
+          <circle cx="240" cy="450" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="240" y="454" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">5</text>
+          <circle cx="290" cy="430" r="8" fill="#fff" stroke="#D97848" stroke-width="2.5"/>
+          <text x="290" y="434" font-size="9" font-weight="700" fill="#D97848" text-anchor="middle" font-family="Inter">6</text>
+        </g>
+        <text x="200" y="490" font-size="13" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">沖繩</text>
+
+        <!-- 首爾 -->
+        <g>
+          <polyline points="120,80 150,100 180,90 210,110" fill="none" stroke="#06A77D" stroke-width="2.5" stroke-linecap="round"/>
+          <circle cx="120" cy="80" r="6" fill="#fff" stroke="#06A77D" stroke-width="2.2"/>
+          <circle cx="150" cy="100" r="6" fill="#fff" stroke="#06A77D" stroke-width="2.2"/>
+          <circle cx="180" cy="90" r="6" fill="#fff" stroke="#06A77D" stroke-width="2.2"/>
+          <circle cx="210" cy="110" r="6" fill="#fff" stroke="#06A77D" stroke-width="2.2"/>
+        </g>
+        <text x="170" y="135" font-size="12" font-weight="700" fill="#6F5A47" font-family="Inter" letter-spacing="2">首爾</text>
+      </svg>
+
+      <!-- Filter chips (top) -->
+      <div class="mobile-filter-strip">
+        <button class="trip-chip" data-trip="okinawa">
+          <span class="chip-dot"></span><span>沖繩</span>
+        </button>
+        <button class="trip-chip" data-trip="seoul">
+          <span class="chip-dot"></span><span>首爾</span>
+        </button>
+        <button class="trip-chip is-off" data-trip="taichung">
+          <span class="chip-dot"></span><span>台中</span>
+        </button>
+      </div>
+
+      <!-- Right floating: layer + zoom -->
+      <div class="map-control-stack" style="bottom: 200px; right: 12px;">
+        <div class="map-zoom-group">
+          <button class="map-square-btn" title="放大">+</button>
+          <button class="map-square-btn" title="縮小">−</button>
+        </div>
+      </div>
+
+      <!-- Bottom POI carousel for selected trip -->
+      <div class="mobile-poi-stack">
+        <div class="mobile-poi-handle" aria-hidden="true"></div>
+        <div class="mobile-poi-eyebrow">
+          <span class="trip-dot"></span>
+          沖繩 · DAY 01 · 7 STOPS
+        </div>
+        <div class="mobile-poi-title">點選 marker 看詳情，左右滑換 stop</div>
+        <div class="mobile-poi-cards">
+          <div class="mobile-poi-card">
+            <div class="pc-mini-cover" style="background: linear-gradient(135deg, #D97848 0%, #F0935E 100%);"></div>
+            <div class="pc-eyebrow">10:45 · STOP 1</div>
+            <div class="pc-title">抵達那霸機場</div>
+          </div>
+          <div class="mobile-poi-card active">
+            <div class="pc-mini-cover" style="background: linear-gradient(135deg, #B85C2E 0%, #D97848 100%);"></div>
+            <div class="pc-eyebrow">13:00 · STOP 3</div>
+            <div class="pc-title">MEGA唐吉軻德</div>
+          </div>
+          <div class="mobile-poi-card">
+            <div class="pc-mini-cover" style="background: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%);"></div>
+            <div class="pc-eyebrow">15:10 · STOP 4</div>
+            <div class="pc-title">Vessel Hotel</div>
+          </div>
+          <div class="mobile-poi-card">
+            <div class="pc-mini-cover" style="background: linear-gradient(135deg, #06A77D 0%, #EADFCF 100%);"></div>
+            <div class="pc-eyebrow">16:00 · STOP 5</div>
+            <div class="pc-title">美國村 + Sunset Beach</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>地圖頁規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/map</code> — 全域 cross-trip 地圖；跟 per-trip <code>/trip/:id?sheet=map</code> 不同（後者是單 trip view）</li>
+    <li><strong>Scope</strong>：view-only（不含 search、不含 add to trip）；search 屬於 <code>/explore</code></li>
+    <li><strong>Trip palette</strong>：每 trip 一個主色 — 沖繩 <code>#D97848</code> / 首爾 <code>#06A77D</code> / 台中 <code>#0EA5C7</code>。對齊 DESIGN.md Day Palette 10 色（取前三色作 trip 區分）</li>
+    <li><strong>Floating overlay</strong>（map 上層）：<ul style="padding-left: 16px; margin-top: 4px;">
+      <li>Top-left: eyebrow card「Global Map · 所有行程 · 3 trips · 15 stops」</li>
+      <li>Top-right: filter chips（每 trip 一個，dot + 名稱 + stops 計數，可 toggle off）</li>
+      <li>Bottom-left: ▣ 全覽 / ⊕ 我的位置 pill button</li>
+      <li>Bottom-right: 圖層切換 + 放大/縮小</li>
+    </ul></li>
+    <li><strong>Marker</strong>：number circle，selected 變大 + accent fill；trip 色用 stroke 區分</li>
+    <li><strong>POI popup</strong>：點 marker 浮出 — eyebrow（trip · day · stop 編號）+ title + meta + 「查看詳情 / 跳到行程」雙按鈕</li>
+    <li><strong>Sheet 展開時</strong>（width 收窄至 <code>min(420px, 32vw)</code> — 比 trip sheet 的 780 窄，留更多 map 面積）：</li>
+    <li>Sheet 內容：trip dot + scope eyebrow → POI title → meta chips → 位置 / 電話 / 時段 / 距離 / 座標 → 同日其他 stop mini-list（active 高亮）</li>
+    <li><strong>Sheet 主 CTA</strong>：「跳到行程」accent button（router 跳到 <code>/trip/:id?sheet=itinerary&day=N</code> 並 anchor 到該 stop）</li>
+    <li><strong>Mobile</strong>：full-screen map（占整個 main）+ top filter chips + bottom POI card carousel（被選 trip 的 stops，左右滑換）+ bottom nav 常駐</li>
+    <li><strong>不該有的</strong>：search bar / 新增 POI / heart save — 那些都在 <code>/explore</code>。地圖頁只是「看你已有 trips 的地理 view」</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-shell-v1-ocean.html
+++ b/docs/design-sessions/mockup-shell-v1-ocean.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V1 Ocean — AppShell Mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #0077B6;
+  --accent-subtle: #E0F4FA;
+  --accent-bg: #CAF0F8;
+  --background: #FFFFFF;
+  --secondary: #F7FBFD;
+  --tertiary: #F2F2F2;
+  --hover: #F2F8FB;
+  --foreground: #222222;
+  --muted: #6A6A6A;
+  --border: #EBEBEB;
+  --sidebar-bg: #FFFFFF;
+  --sheet-bg: #FFFFFF;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 6px 16px rgba(0,0,0,0.08);
+  --shadow-lg: 0 10px 28px rgba(0,0,0,0.12);
+
+  --grid-3pane: 240px 1fr min(780px, 40vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --sidebar-w: 240px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8EBEF;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px;
+  margin: 0 auto 24px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid rgba(0,0,0,0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 {
+  font-size: 24px; font-weight: 800; letter-spacing: -0.02em;
+}
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: #555; text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  max-width: 1600px;
+  margin: 40px auto 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #555;
+  display: flex; align-items: center; gap: 12px;
+}
+.viewport-label::after {
+  content: ''; flex: 1; height: 1px; background: rgba(0,0,0,0.1);
+}
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.15), 0 2px 6px rgba(0,0,0,0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; max-width: 100%; height: 900px; }
+.vp-desktop-narrow { width: 1100px; max-width: 100%; height: 780px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+/* ========== AppShell Grid ========== */
+.shell-3pane {
+  display: grid;
+  grid-template-columns: var(--grid-3pane);
+  height: 100%;
+}
+.shell-2pane {
+  display: grid;
+  grid-template-columns: var(--grid-2pane);
+  height: 100%;
+}
+.shell-mobile {
+  display: flex; flex-direction: column;
+  height: 100%; position: relative;
+}
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav {
+  display: flex; flex-direction: column; gap: 2px;
+}
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px; border-radius: 8px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--accent-subtle); color: var(--accent);
+  font-weight: 600;
+}
+.nav-item .icon {
+  width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0;
+}
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { filter: brightness(0.92); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Main Content ========== */
+.main-content {
+  overflow-y: auto;
+  padding: 32px 40px;
+  background: var(--secondary);
+}
+.main-header {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  margin-bottom: 28px;
+}
+.main-header h1 {
+  font-size: 32px; font-weight: 700; letter-spacing: -0.02em;
+}
+.main-header .header-meta {
+  color: var(--muted); font-size: 14px; margin-top: 4px;
+}
+.main-header .header-actions {
+  display: flex; gap: 8px;
+}
+.btn-ghost {
+  padding: 8px 14px; border-radius: 8px;
+  background: transparent; border: 1px solid var(--border);
+  color: var(--foreground); font: inherit; font-size: 13px; font-weight: 500;
+  cursor: pointer;
+}
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+.trip-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;
+}
+.trip-card {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px;
+  cursor: pointer; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.trip-card:hover { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card.active { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card .card-cover {
+  aspect-ratio: 16/9; background: var(--tertiary); border-radius: 8px; margin-bottom: 12px;
+  background-size: cover; background-position: center;
+}
+.trip-card .cover-okinawa { background-image: linear-gradient(135deg, #0077B6 0%, #48CAE4 100%); }
+.trip-card .cover-seoul { background-image: linear-gradient(135deg, #8FB8D1 0%, #EADFCF 100%); }
+.trip-card .cover-taichung { background-image: linear-gradient(135deg, #06A77D 0%, #CAF0F8 100%); }
+.trip-card .card-eyebrow {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 6px;
+}
+.trip-card .card-title {
+  font-size: 17px; font-weight: 700; letter-spacing: -0.005em; margin-bottom: 4px;
+}
+.trip-card .card-meta {
+  font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+
+/* ========== Right Sheet ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+
+.sheet-title {
+  padding: 16px 24px 8px;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+}
+.sheet-meta {
+  padding: 0 24px 16px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+}
+.sheet-meta .chip {
+  padding: 4px 10px; border-radius: 9999px;
+  background: var(--tertiary);
+}
+.sheet-meta .chip.active { background: var(--accent-subtle); color: var(--accent); font-weight: 600; }
+
+.sheet-tabs {
+  display: flex; gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+.sheet-tab {
+  padding: 12px 14px; font-size: 14px; font-weight: 500;
+  color: var(--muted); cursor: pointer;
+  border: none; background: transparent; font-family: inherit;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.sheet-tab.active { color: var(--foreground); font-weight: 600; border-bottom-color: var(--accent); }
+.sheet-tab:hover:not(.active) { color: var(--foreground); }
+
+.sheet-body { flex: 1; overflow-y: auto; padding: 20px 24px; }
+
+.day-group { margin-bottom: 20px; }
+.day-header-row {
+  display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px;
+}
+.day-header-row h3 {
+  font-size: 16px; font-weight: 700; letter-spacing: -0.005em;
+}
+.day-header-row .day-meta {
+  font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.entry {
+  display: flex; gap: 12px; padding: 12px;
+  border: 1px solid var(--border); border-radius: 12px;
+  margin-bottom: 8px;
+}
+.entry .thumb {
+  width: 48px; height: 48px; border-radius: 8px; flex-shrink: 0;
+  background: var(--accent-subtle); display: grid; place-items: center;
+  color: var(--accent); font-size: 18px;
+}
+.entry .entry-body { flex: 1; min-width: 0; }
+.entry .entry-name {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.005em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.entry .entry-time {
+  font-size: 12px; color: var(--muted); margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.entry .entry-detail-btn {
+  align-self: center; padding: 4px 10px; border-radius: 9999px;
+  border: 1px solid var(--border); background: transparent;
+  font: inherit; font-size: 12px; color: var(--muted); cursor: pointer;
+}
+.entry-travel {
+  padding: 6px 0 6px 64px; font-size: 11px; color: var(--muted);
+  font-style: italic;
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  position: sticky; top: 0; z-index: 10;
+  flex-shrink: 0;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-main {
+  flex: 1; overflow-y: auto;
+  padding: 20px 16px calc(var(--nav-h-mobile) + 16px);
+}
+.mobile-main h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 16px; }
+.mobile-main .trip-card { margin-bottom: 12px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit;
+  min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+/* Icon stroke */
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+/* Footnote */
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: #F7F8FA; border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; color: #444; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; color: #000; }
+.spec-card code { background: #E9ECEF; padding: 1px 6px; border-radius: 4px; font-size: 12px; color: #0077B6; }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V1 Ocean Baseline — AppShell Mockup</h1>
+    <div style="font-size: 13px; color: #555; margin-top: 4px;">保守路線 · 對齊 tokens.css 現狀 · 零 retheme 風險</div>
+  </div>
+  <div>
+    <span class="variant-chip">V1 · Ocean #0077B6</span>
+    <span class="nav-links">
+      <a href="mockup-shell-v2-terracotta.html">→ V2 Terracotta</a>
+      <a href="mockup-shell-v3-magazine.html">→ V3 Magazine</a>
+      <a href="mockup-index.html">← Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ========================= Desktop 1440px (3-pane) ========================= -->
+<div class="viewport-label">Desktop · 1440 × 900 · 3-pane（sidebar 240 / main fluid / sheet 40vw）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · 最近更新 2026-04-24</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">篩選</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card active">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Right Sheet -->
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="icon-btn" title="分享">↗</button>
+        <button class="icon-btn" title="更多">⋯</button>
+      </div>
+      <div class="sheet-title">沖繩之旅</div>
+      <div class="sheet-meta">
+        <span class="chip active">沖繩 · 那霸</span>
+        <span class="chip">7/26 – 7/30</span>
+        <span class="chip">2 旅伴</span>
+      </div>
+      <div class="sheet-tabs">
+        <button class="sheet-tab active">行程</button>
+        <button class="sheet-tab">想法</button>
+        <button class="sheet-tab">地圖</button>
+        <button class="sheet-tab">聊天</button>
+      </div>
+      <div class="sheet-body">
+        <div class="day-group">
+          <div class="day-header-row">
+            <h3>Day 1 · 7/26 週六</h3>
+            <span class="day-meta">3 stops · 12 km</span>
+          </div>
+          <div class="entry">
+            <div class="thumb">✈</div>
+            <div class="entry-body">
+              <div class="entry-name">那霸機場抵達</div>
+              <div class="entry-time">10:30 – 11:30</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">12 km · 車程 25 分</div>
+          <div class="entry">
+            <div class="thumb">🏨</div>
+            <div class="entry-body">
+              <div class="entry-name">ANA Crowne Plaza 沖繩</div>
+              <div class="entry-time">12:00 入住</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">3 km · 步行 12 分</div>
+          <div class="entry">
+            <div class="thumb">🍜</div>
+            <div class="entry-body">
+              <div class="entry-name">通堂拉麵 小祿本店</div>
+              <div class="entry-time">13:00 – 14:00</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+        <div class="day-group">
+          <div class="day-header-row">
+            <h3>Day 2 · 7/27 週日</h3>
+            <span class="day-meta">4 stops · 48 km</span>
+          </div>
+          <div class="entry">
+            <div class="thumb">🐠</div>
+            <div class="entry-body">
+              <div class="entry-name">美麗海水族館</div>
+              <div class="entry-time">10:00 – 13:00</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<!-- ========================= Desktop 1100px (2-pane, sheet collapsed) ========================= -->
+<div class="viewport-label">Desktop Narrow · 1100 × 780 · 2-pane（sheet 收起、只剩 sidebar + main）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · Sheet 收起時 main 擴寬填滿</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">篩選</button>
+          <button class="btn-ghost">↗ 開啟 sheet</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+
+  </div>
+</div>
+
+<!-- ========================= Mobile 375px ========================= -->
+<div class="viewport-label">Mobile · 375 × 812 · 單欄 + sticky bottom nav（常駐，不 hide on scroll）</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="更多"><span>⋯</span></button>
+    </header>
+
+    <main class="mobile-main">
+      <h1>我的行程</h1>
+      <div class="trip-card">
+        <div class="card-cover cover-okinawa"></div>
+        <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+        <div class="card-title">沖繩之旅</div>
+        <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-seoul"></div>
+        <div class="card-eyebrow">KOREA · 4 DAYS</div>
+        <div class="card-title">首爾美食行</div>
+        <div class="card-meta">8/15 – 8/18 · 草稿</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-taichung"></div>
+        <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+        <div class="card-title">台中週末小旅</div>
+        <div class="card-meta">6/8 – 6/9 · 已結束</div>
+      </div>
+    </main>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+
+  </div>
+</div>
+
+<!-- Spec card -->
+<section class="spec-card">
+  <h3>V1 Ocean 特徵</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li>Palette 採 <code>--color-accent: #0077B6</code> — 對齊 <code>css/tokens.css</code> 現狀，task 實作時 CSS tokens 零改動</li>
+    <li>Active nav state：<code>background: var(--accent-subtle)</code> + accent text color（低調，不搶眼）</li>
+    <li>Sidebar 白底（非 Mindtrip 深色）符合 DESIGN.md 的 restrained editorial</li>
+    <li>Bottom nav 用 <code>position: sticky; inset-block-end: 0</code> + <code>padding-bottom: env(safe-area-inset-bottom)</code>，取代既有 <code>position: fixed</code></li>
+    <li>5 nav items 全部 ≥44px tap target，符合 Apple HIG</li>
+    <li>New Trip CTA 在 sidebar 底部 pill button（非 Mindtrip outline style）— 跟現有 Ocean accent button 視覺一致</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-shell-v2-terracotta.html
+++ b/docs/design-sessions/mockup-shell-v2-terracotta.html
@@ -1,0 +1,624 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Terracotta — AppShell Mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  --grid-3pane: 240px 1fr min(780px, 40vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px;
+  margin: 0 auto 24px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  max-width: 1600px;
+  margin: 40px auto 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px;
+}
+.viewport-label::after {
+  content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1);
+}
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; max-width: 100%; height: 900px; }
+.vp-desktop-narrow { width: 1100px; max-width: 100%; height: 780px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar — V2 filled active pill（Mindtrip inspired）========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav {
+  display: flex; flex-direction: column; gap: 2px;
+}
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon {
+  width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0;
+}
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Main Content ========== */
+.main-content {
+  overflow-y: auto;
+  padding: 32px 40px;
+  background: var(--secondary);
+}
+.main-header {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  margin-bottom: 28px;
+}
+.main-header h1 {
+  font-size: 32px; font-weight: 700; letter-spacing: -0.02em;
+}
+.main-header .header-meta {
+  color: var(--muted); font-size: 14px; margin-top: 4px;
+}
+.main-header .header-actions { display: flex; gap: 8px; }
+.btn-ghost {
+  padding: 8px 14px; border-radius: 8px;
+  background: transparent; border: 1px solid var(--border);
+  color: var(--foreground); font: inherit; font-size: 13px; font-weight: 500;
+  cursor: pointer;
+}
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); background: var(--hover); }
+
+.trip-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;
+}
+.trip-card {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px;
+  cursor: pointer; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.trip-card:hover { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card.active { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card .card-cover {
+  aspect-ratio: 16/9; background: var(--tertiary); border-radius: 8px; margin-bottom: 12px;
+}
+.trip-card .cover-okinawa { background-image: linear-gradient(135deg, #D97848 0%, #F0935E 100%); }
+.trip-card .cover-seoul { background-image: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%); }
+.trip-card .cover-taichung { background-image: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%); }
+.trip-card .card-eyebrow {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 6px;
+}
+.trip-card .card-title {
+  font-size: 17px; font-weight: 700; letter-spacing: -0.005em; margin-bottom: 4px;
+}
+.trip-card .card-meta {
+  font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+
+/* ========== Right Sheet ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+
+.sheet-title {
+  padding: 16px 24px 8px;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+}
+.sheet-meta {
+  padding: 0 24px 16px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+}
+.sheet-meta .chip {
+  padding: 4px 10px; border-radius: 9999px;
+  background: var(--tertiary);
+}
+.sheet-meta .chip.active { background: var(--accent-subtle); color: var(--accent-deep); font-weight: 600; }
+
+.sheet-tabs {
+  display: flex; gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+.sheet-tab {
+  padding: 12px 14px; font-size: 14px; font-weight: 500;
+  color: var(--muted); cursor: pointer;
+  border: none; background: transparent; font-family: inherit;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.sheet-tab.active { color: var(--foreground); font-weight: 600; border-bottom-color: var(--accent); }
+.sheet-tab:hover:not(.active) { color: var(--foreground); }
+
+.sheet-body { flex: 1; overflow-y: auto; padding: 20px 24px; }
+
+.day-group { margin-bottom: 20px; }
+.day-header-row {
+  display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px;
+}
+.day-header-row h3 {
+  font-size: 16px; font-weight: 700; letter-spacing: -0.005em;
+}
+.day-header-row .day-meta {
+  font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.entry {
+  display: flex; gap: 12px; padding: 12px;
+  border: 1px solid var(--border); border-radius: 12px;
+  margin-bottom: 8px; background: var(--background);
+}
+.entry .thumb {
+  width: 48px; height: 48px; border-radius: 8px; flex-shrink: 0;
+  background: var(--accent-subtle); display: grid; place-items: center;
+  color: var(--accent); font-size: 18px;
+}
+.entry .entry-body { flex: 1; min-width: 0; }
+.entry .entry-name {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.005em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.entry .entry-time {
+  font-size: 12px; color: var(--muted); margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.entry .entry-detail-btn {
+  align-self: center; padding: 4px 10px; border-radius: 9999px;
+  border: 1px solid var(--border); background: transparent;
+  font: inherit; font-size: 12px; color: var(--muted); cursor: pointer;
+}
+.entry-travel {
+  padding: 6px 0 6px 64px; font-size: 11px; color: var(--muted);
+  font-style: italic;
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  position: sticky; top: 0; z-index: 10;
+  flex-shrink: 0;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-main {
+  flex: 1; overflow-y: auto;
+  padding: 20px 16px calc(var(--nav-h-mobile) + 16px);
+}
+.mobile-main h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 16px; }
+.mobile-main .trip-card { margin-bottom: 12px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit;
+  min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; color: var(--foreground); line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; color: var(--foreground); }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Terracotta Warm — AppShell Mockup</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">2026-04-24 session locked palette · 旅遊雜誌暖調 · 對齊 design-sessions/terracotta-preview</div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Terracotta #D97848</span>
+    <span class="nav-links">
+      <a href="mockup-shell-v1-ocean.html">← V1 Ocean</a>
+      <a href="mockup-shell-v3-magazine.html">→ V3 Magazine</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- Desktop 1440px -->
+<div class="viewport-label">Desktop · 1440 × 900 · 3-pane（sidebar 240 / main fluid / sheet 40vw）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · 最近更新 2026-04-24</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">篩選</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card active">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="icon-btn" title="分享">↗</button>
+        <button class="icon-btn" title="更多">⋯</button>
+      </div>
+      <div class="sheet-title">沖繩之旅</div>
+      <div class="sheet-meta">
+        <span class="chip active">沖繩 · 那霸</span>
+        <span class="chip">7/26 – 7/30</span>
+        <span class="chip">2 旅伴</span>
+      </div>
+      <div class="sheet-tabs">
+        <button class="sheet-tab active">行程</button>
+        <button class="sheet-tab">想法</button>
+        <button class="sheet-tab">地圖</button>
+        <button class="sheet-tab">聊天</button>
+      </div>
+      <div class="sheet-body">
+        <div class="day-group">
+          <div class="day-header-row">
+            <h3>Day 1 · 7/26 週六</h3>
+            <span class="day-meta">3 stops · 12 km</span>
+          </div>
+          <div class="entry">
+            <div class="thumb">✈</div>
+            <div class="entry-body">
+              <div class="entry-name">那霸機場抵達</div>
+              <div class="entry-time">10:30 – 11:30</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">12 km · 車程 25 分</div>
+          <div class="entry">
+            <div class="thumb">🏨</div>
+            <div class="entry-body">
+              <div class="entry-name">ANA Crowne Plaza 沖繩</div>
+              <div class="entry-time">12:00 入住</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">3 km · 步行 12 分</div>
+          <div class="entry">
+            <div class="thumb">🍜</div>
+            <div class="entry-body">
+              <div class="entry-name">通堂拉麵 小祿本店</div>
+              <div class="entry-time">13:00 – 14:00</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+        <div class="day-group">
+          <div class="day-header-row">
+            <h3>Day 2 · 7/27 週日</h3>
+            <span class="day-meta">4 stops · 48 km</span>
+          </div>
+          <div class="entry">
+            <div class="thumb">🐠</div>
+            <div class="entry-body">
+              <div class="entry-name">美麗海水族館</div>
+              <div class="entry-time">10:00 – 13:00</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- Desktop 1100px -->
+<div class="viewport-label">Desktop Narrow · 1100 × 780 · 2-pane（sheet 收起）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · Sheet 收起時 main 擴寬填滿</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">篩選</button>
+          <button class="btn-ghost">↗ 開啟 sheet</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- Mobile 375px -->
+<div class="viewport-label">Mobile · 375 × 812 · 單欄 + sticky bottom nav</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="更多"><span>⋯</span></button>
+    </header>
+    <main class="mobile-main">
+      <h1>我的行程</h1>
+      <div class="trip-card">
+        <div class="card-cover cover-okinawa"></div>
+        <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+        <div class="card-title">沖繩之旅</div>
+        <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-seoul"></div>
+        <div class="card-eyebrow">KOREA · 4 DAYS</div>
+        <div class="card-title">首爾美食行</div>
+        <div class="card-meta">8/15 – 8/18 · 草稿</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-taichung"></div>
+        <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+        <div class="card-title">台中週末小旅</div>
+        <div class="card-meta">6/8 – 6/9 · 已結束</div>
+      </div>
+    </main>
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>V2 Terracotta 特徵</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li>Palette 採 <code>--accent: #D97848</code>（Terracotta warm）+ <code>--background: #FFFBF5</code>（cream），對齊 2026-04-24 session 定案</li>
+    <li>Active nav state：<strong>filled dark pill</strong>（<code>background: var(--foreground)</code> + <code>color: var(--background)</code>）— 比 V1 更搶眼，參考 Mindtrip 的 dark active pill</li>
+    <li>Sidebar 仍白底但略帶 cream 色調（<code>#FFFBF5</code>），跟 Mindtrip 深色 sidebar 差異化（DESIGN.md 暖調）</li>
+    <li>Trip card cover 改用 Terracotta 漸層（從 <code>#D97848</code> → <code>#F0935E</code>），POC 風雜誌感</li>
+    <li>Tokens.css 需新增 Terracotta palette — 需要 <code>/design-consultation update</code> 走 retheme 流程（不直接改）</li>
+    <li>Bottom nav + safe-area-inset-bottom 跟 V1 相同（behavior 統一）</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-shell-v3-magazine.html
+++ b/docs/design-sessions/mockup-shell-v3-magazine.html
@@ -1,0 +1,715 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V3 Magazine Editorial — AppShell Mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+
+  --grid-3pane: 220px 1fr min(780px, 40vw);  /* sidebar 稍窄 220 */
+  --grid-2pane: 220px 1fr;
+  --nav-h-mobile: 88px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--foreground); color: var(--accent);
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  max-width: 1600px; margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; max-width: 100%; height: 900px; }
+.vp-desktop-narrow { width: 1100px; max-width: 100%; height: 780px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar — V3 editorial uppercase nav + left indicator bar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px 20px;
+  display: flex; flex-direction: column;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 0 8px 28px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+}
+.sidebar-brand .wordmark {
+  font-size: 20px; font-weight: 900; letter-spacing: -0.025em; line-height: 1;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-brand .eyebrow {
+  font-size: 9px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted);
+}
+
+.sidebar-nav-label {
+  padding: 8px 8px 12px;
+  font-size: 9px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted);
+}
+.sidebar-nav {
+  display: flex; flex-direction: column; gap: 0;
+}
+.nav-item {
+  position: relative;
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 14px; border-radius: 0;
+  color: var(--muted);
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  cursor: pointer; text-decoration: none;
+  transition: color 0.15s;
+  min-height: 44px;
+  border-left: 2px solid transparent;
+}
+.nav-item:hover { color: var(--foreground); background: var(--hover); }
+.nav-item.active {
+  color: var(--foreground);
+  border-left-color: var(--accent);
+  background: linear-gradient(90deg, var(--accent-subtle) 0%, transparent 100%);
+  font-weight: 800;
+}
+.nav-item.active .icon { color: var(--accent); }
+.nav-item .icon { width: 18px; height: 18px; flex-shrink: 0; color: var(--muted); }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 20px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 12px; border-radius: 0;
+  background: var(--foreground); color: var(--background);
+  border: none; font: inherit;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); color: var(--background); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 4px 6px; color: var(--muted); font-size: 12px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--foreground); color: var(--background);
+  display: grid; place-items: center; font-size: 12px; font-weight: 800; flex-shrink: 0;
+}
+
+/* ========== Main Content — editorial hero ========== */
+.main-content {
+  overflow-y: auto;
+  padding: 40px 48px;
+  background: var(--secondary);
+}
+.main-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.main-hero {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  margin-bottom: 40px;
+  padding-bottom: 24px;
+  border-bottom: 2px solid var(--foreground);
+}
+.main-hero h1 {
+  font-size: 56px; font-weight: 900; letter-spacing: -0.04em; line-height: 0.95;
+  max-width: 600px;
+}
+.main-hero .hero-meta {
+  display: flex; gap: 24px; font-size: 11px; color: var(--muted);
+  letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.main-hero .hero-meta strong {
+  display: block; font-size: 24px; color: var(--foreground); letter-spacing: -0.02em;
+  text-transform: none; font-weight: 700; margin-top: 4px;
+}
+
+.trip-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 24px;
+}
+.trip-card {
+  background: var(--background);
+  cursor: pointer; transition: transform 0.15s;
+  border: none; padding: 0;
+}
+.trip-card:hover { transform: translateY(-2px); }
+.trip-card .card-cover {
+  aspect-ratio: 4/5; background: var(--tertiary); margin-bottom: 14px;
+}
+.trip-card .cover-okinawa { background-image: linear-gradient(135deg, #D97848 0%, #F0935E 100%); }
+.trip-card .cover-seoul { background-image: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%); }
+.trip-card .cover-taichung { background-image: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%); }
+.trip-card .card-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 8px;
+  font-variant-numeric: tabular-nums;
+}
+.trip-card .card-title {
+  font-size: 24px; font-weight: 800; letter-spacing: -0.02em; line-height: 1.1;
+  margin-bottom: 6px;
+}
+.trip-card .card-meta {
+  font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.trip-card.active .card-title { color: var(--accent-deep); }
+
+/* ========== Right Sheet — editorial ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 0;
+  border: 1px solid var(--border); background: transparent;
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+
+.sheet-eyebrow {
+  padding: 20px 24px 4px;
+  font-size: 10px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted);
+}
+.sheet-title {
+  padding: 0 24px 14px;
+  font-size: 34px; font-weight: 900; letter-spacing: -0.03em; line-height: 1;
+}
+.sheet-meta {
+  padding: 0 24px 16px;
+  display: flex; gap: 6px; flex-wrap: wrap;
+  font-size: 11px; color: var(--muted);
+  letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600;
+}
+.sheet-meta .chip {
+  padding: 3px 10px; border: 1px solid var(--border);
+}
+.sheet-meta .chip.active { border-color: var(--accent); color: var(--accent-deep); background: var(--accent-subtle); }
+
+.sheet-tabs {
+  display: flex; gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--foreground);
+}
+.sheet-tab {
+  padding: 14px 14px 12px;
+  font-size: 10px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted); cursor: pointer;
+  border: none; background: transparent; font-family: inherit;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.sheet-tab.active { color: var(--foreground); border-bottom-color: var(--accent); }
+.sheet-tab:hover:not(.active) { color: var(--foreground); }
+
+.sheet-body { flex: 1; overflow-y: auto; padding: 24px; }
+
+.day-group { margin-bottom: 28px; }
+.day-header-row {
+  display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 14px;
+  padding-bottom: 8px; border-bottom: 1px solid var(--border);
+}
+.day-header-row h3 {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+}
+.day-header-row .day-title-date {
+  display: block; font-size: 24px; font-weight: 900; letter-spacing: -0.02em;
+  text-transform: none; margin-top: 2px; color: var(--foreground);
+}
+.day-header-row .day-meta {
+  font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums;
+  letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600;
+}
+.entry {
+  display: flex; gap: 14px; padding: 12px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.entry:last-child { border-bottom: none; }
+.entry .time-col {
+  width: 56px; flex-shrink: 0; padding-top: 2px;
+  text-align: right;
+}
+.entry .time {
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em; line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.entry .time-dur {
+  font-size: 9px; color: var(--muted); letter-spacing: 0.18em; text-transform: uppercase;
+  margin-top: 4px; font-weight: 600;
+}
+.entry .thumb {
+  width: 40px; height: 40px; flex-shrink: 0;
+  background: var(--accent-subtle); display: grid; place-items: center;
+  color: var(--accent); font-size: 16px;
+}
+.entry .entry-body { flex: 1; min-width: 0; padding-top: 2px; }
+.entry .entry-type {
+  font-size: 9px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 2px;
+}
+.entry .entry-name {
+  font-size: 15px; font-weight: 700; letter-spacing: -0.005em; line-height: 1.3;
+}
+.entry .entry-detail-btn {
+  align-self: flex-start; padding: 4px 10px; border: 1px solid var(--border);
+  background: transparent;
+  font: inherit; font-size: 10px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--muted); cursor: pointer;
+}
+.entry-travel {
+  padding: 4px 0 4px 70px; font-size: 10px; color: var(--muted);
+  font-variant-numeric: tabular-nums; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600;
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 20px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  position: sticky; top: 0; z-index: 10;
+  flex-shrink: 0;
+}
+.mobile-topbar .brand { font-size: 18px; font-weight: 900; letter-spacing: -0.025em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border: 1px solid var(--border); background: transparent;
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-main {
+  flex: 1; overflow-y: auto;
+  padding: 24px 20px calc(var(--nav-h-mobile) + 16px);
+}
+.mobile-main .main-eyebrow { font-size: 10px; margin-bottom: 8px; }
+.mobile-main h1 {
+  font-size: 36px; font-weight: 900; letter-spacing: -0.03em; line-height: 1;
+  margin-bottom: 28px;
+  padding-bottom: 16px; border-bottom: 2px solid var(--foreground);
+}
+.mobile-main .trip-card { margin-bottom: 20px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 5px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit;
+  min-height: 44px;
+  position: relative;
+}
+.bottom-nav-btn .icon { width: 20px; height: 20px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span {
+  font-size: 9px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+}
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active::before {
+  content: '';
+  position: absolute; top: 0; left: 20%; right: 20%; height: 2px;
+  background: var(--accent);
+}
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  padding: 20px 24px;
+  font-size: 13px; color: var(--foreground); line-height: 1.7;
+}
+.spec-card h3 {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  margin-bottom: 12px; color: var(--muted);
+}
+.spec-card code { background: var(--tertiary); padding: 1px 6px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V3 Magazine Editorial — AppShell Mockup</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">Terracotta + 雜誌 editorial · uppercase eyebrow · big display hero · left bar active</div>
+  </div>
+  <div>
+    <span class="variant-chip">V3 · Editorial</span>
+    <span class="nav-links">
+      <a href="mockup-shell-v1-ocean.html">← V1 Ocean</a>
+      <a href="mockup-shell-v2-terracotta.html">← V2 Terracotta</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- Desktop 1440px -->
+<div class="viewport-label">Desktop · 1440 × 900 · 3-pane（sidebar 220 / main fluid / sheet 40vw）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">
+        <div class="wordmark">Tripline<span class="accent-dot">.</span></div>
+        <div class="eyebrow">Edition · 2026</div>
+      </div>
+      <div class="sidebar-nav-label">Navigate</div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn">+ 新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <div class="main-eyebrow">Issue 01 · My Trips · 2026</div>
+      <div class="main-hero">
+        <h1>我的行程。<br>五段旅程，正在<br>發生。</h1>
+        <div class="hero-meta">
+          <div>
+            Active
+            <strong>3</strong>
+          </div>
+          <div>
+            Drafts
+            <strong>1</strong>
+          </div>
+          <div>
+            Archive
+            <strong>12</strong>
+          </div>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card active">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">Japan · 5 Days · 進行中</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">Korea · 4 Days · 草稿</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 1 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">Taiwan · 2 Days · 已結束</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 3 旅伴</div>
+        </div>
+      </div>
+    </main>
+
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="icon-btn" title="分享">↗</button>
+        <button class="icon-btn" title="更多">⋯</button>
+      </div>
+      <div class="sheet-eyebrow">Issue 01 · Feature</div>
+      <div class="sheet-title">沖繩之旅</div>
+      <div class="sheet-meta">
+        <span class="chip active">沖繩 · 那霸</span>
+        <span class="chip">7/26 – 7/30</span>
+        <span class="chip">2 旅伴</span>
+      </div>
+      <div class="sheet-tabs">
+        <button class="sheet-tab active">行程</button>
+        <button class="sheet-tab">想法</button>
+        <button class="sheet-tab">地圖</button>
+        <button class="sheet-tab">聊天</button>
+      </div>
+      <div class="sheet-body">
+        <div class="day-group">
+          <div class="day-header-row">
+            <div>
+              <h3>Day 01</h3>
+              <span class="day-title-date">7/26 週六</span>
+            </div>
+            <span class="day-meta">3 stops · 12 km</span>
+          </div>
+          <div class="entry">
+            <div class="time-col">
+              <div class="time">10:30</div>
+              <div class="time-dur">60 min</div>
+            </div>
+            <div class="thumb">✈</div>
+            <div class="entry-body">
+              <div class="entry-type">Arrival</div>
+              <div class="entry-name">那霸機場抵達</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">12 KM · 車程 25 分</div>
+          <div class="entry">
+            <div class="time-col">
+              <div class="time">12:00</div>
+              <div class="time-dur">Check-in</div>
+            </div>
+            <div class="thumb">🏨</div>
+            <div class="entry-body">
+              <div class="entry-type">Hotel</div>
+              <div class="entry-name">ANA Crowne Plaza 沖繩</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+          <div class="entry-travel">3 KM · 步行 12 分</div>
+          <div class="entry">
+            <div class="time-col">
+              <div class="time">13:00</div>
+              <div class="time-dur">60 min</div>
+            </div>
+            <div class="thumb">🍜</div>
+            <div class="entry-body">
+              <div class="entry-type">Meal</div>
+              <div class="entry-name">通堂拉麵 小祿本店</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+        <div class="day-group">
+          <div class="day-header-row">
+            <div>
+              <h3>Day 02</h3>
+              <span class="day-title-date">7/27 週日</span>
+            </div>
+            <span class="day-meta">4 stops · 48 km</span>
+          </div>
+          <div class="entry">
+            <div class="time-col">
+              <div class="time">10:00</div>
+              <div class="time-dur">180 min</div>
+            </div>
+            <div class="thumb">🐠</div>
+            <div class="entry-body">
+              <div class="entry-type">Sight</div>
+              <div class="entry-name">美麗海水族館</div>
+            </div>
+            <button class="entry-detail-btn">詳情</button>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- Desktop 1100px -->
+<div class="viewport-label">Desktop Narrow · 1100 × 780 · 2-pane</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">
+        <div class="wordmark">Tripline<span class="accent-dot">.</span></div>
+        <div class="eyebrow">Edition · 2026</div>
+      </div>
+      <div class="sidebar-nav-label">Navigate</div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn">+ 新增行程</button>
+        <div class="user-chip">
+          <div class="avatar">R</div>
+          <span>ray@trip.io</span>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <div class="main-eyebrow">Issue 01 · My Trips · 2026</div>
+      <div class="main-hero">
+        <h1>我的行程。<br>Sheet 收起<br>時 main 擴寬。</h1>
+        <div class="hero-meta">
+          <div>Active<strong>3</strong></div>
+          <div>Drafts<strong>1</strong></div>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">Japan · 5 Days · 進行中</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">Korea · 4 Days · 草稿</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 1 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">Taiwan · 2 Days · 已結束</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 3 旅伴</div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- Mobile 375px -->
+<div class="viewport-label">Mobile · 375 × 812 · editorial typography + sticky bottom nav</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="更多"><span>⋯</span></button>
+    </header>
+    <main class="mobile-main">
+      <div class="main-eyebrow">Issue 01 · My Trips</div>
+      <h1>我的<br>行程。</h1>
+      <div class="trip-card">
+        <div class="card-cover cover-okinawa"></div>
+        <div class="card-eyebrow">Japan · 5 Days · 進行中</div>
+        <div class="card-title">沖繩之旅</div>
+        <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-seoul"></div>
+        <div class="card-eyebrow">Korea · 4 Days · 草稿</div>
+        <div class="card-title">首爾美食行</div>
+        <div class="card-meta">8/15 – 8/18 · 1 旅伴</div>
+      </div>
+      <div class="trip-card">
+        <div class="card-cover cover-taichung"></div>
+        <div class="card-eyebrow">Taiwan · 2 Days · 已結束</div>
+        <div class="card-title">台中週末小旅</div>
+        <div class="card-meta">6/8 – 6/9 · 3 旅伴</div>
+      </div>
+    </main>
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>V3 Magazine Editorial 特徵</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li>Sidebar 改 <code>220px</code>（比 spec 的 240px 稍窄），nav label 全 uppercase + <code>letter-spacing: 0.18em</code> 走 editorial</li>
+    <li>Active nav：左 2px <code>--accent</code> bar + 水平漸層淡背景（非 filled pill）— 參考雜誌目錄頁</li>
+    <li>Main hero：<code>56px / weight 900 / line-height 0.95</code> 大 display title + 底線分隔，有 Issue 01 eyebrow</li>
+    <li>Trip card：4:5 aspect（雜誌 poster 比例）+ 24px 粗標題，無 border + hover translate</li>
+    <li>Sheet：<code>34px / weight 900</code> display title + Issue 01 Feature eyebrow + 實線 tab 底線</li>
+    <li>Entry 改 time-first 布局（左時間欄粗體 → thumb → 內容 → 詳情 button），更像時刻表</li>
+    <li>Bottom nav active：頂部橫線 indicator + uppercase 縮寫 label</li>
+    <li><strong>風險</strong>：全 uppercase 中文字不適合（這 mockup 中文 label 保持原形，只有 meta 用 uppercase；實作時要注意）</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-signup-v2.html
+++ b/docs/design-sessions/mockup-signup-v2.html
@@ -1,0 +1,752 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Sign Up — /login/signup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+  --font-eyebrow: 0.625rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px; line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px; max-width: 1600px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden; position: relative; margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* Sidebar */
+.sidebar {
+  background: var(--background); border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column; gap: 4px; overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted); font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s; min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active { background: var(--foreground); color: var(--background); font-weight: 600; }
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px; color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Main 2-col layout ========== */
+.auth-main {
+  background: var(--secondary);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%; overflow: hidden;
+}
+.auth-form-side {
+  display: flex; align-items: center; justify-content: center;
+  padding: 48px; overflow-y: auto;
+}
+.auth-card {
+  width: 100%; max-width: 440px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 20px;
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+
+/* Step indicator */
+.step-indicator {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 16px;
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--muted);
+}
+.step-indicator .step-dots { display: flex; gap: 4px; }
+.step-indicator .step-dot { width: 16px; height: 4px; border-radius: 2px; background: var(--tertiary); }
+.step-indicator .step-dot.done { background: var(--accent); }
+.step-indicator .step-dot.active { background: var(--foreground); }
+
+.auth-card h2 {
+  font-size: 28px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 8px;
+}
+.auth-card .ac-sub {
+  font-size: 14px; color: var(--muted); margin-bottom: 20px;
+}
+
+.ac-back {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-bottom: 16px;
+  font-size: 13px; font-weight: 600; color: var(--accent-deep);
+  text-decoration: none; cursor: pointer;
+}
+.ac-back:hover { color: var(--foreground); }
+
+/* Provider */
+.providers {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-bottom: 20px;
+}
+.provider-btn {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  padding: 12px 18px; border-radius: 12px;
+  background: var(--background); border: 1px solid var(--border);
+  font: inherit; font-size: 14px; font-weight: 600; color: var(--foreground);
+  cursor: pointer; min-height: 48px;
+}
+.provider-btn:hover { background: var(--hover); border-color: var(--foreground); }
+.provider-btn .provider-icon { width: 20px; height: 20px; display: grid; place-items: center; }
+.provider-btn .provider-icon svg { width: 20px; height: 20px; display: block; }
+
+.divider {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted); margin: 20px 0;
+}
+.divider::before, .divider::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+
+/* Field */
+.field { margin-bottom: 14px; }
+.field label {
+  display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 6px;
+}
+.field input {
+  width: 100%; padding: 12px 14px; border-radius: 12px;
+  border: 1px solid var(--border); background: var(--background);
+  font: inherit; font-size: 15px; color: var(--foreground);
+  outline: none; min-height: 48px;
+}
+.field input:focus { border-color: var(--accent); }
+.field input::placeholder { color: var(--muted); }
+.field .helper { font-size: 12px; color: var(--muted); margin-top: 6px; }
+
+/* Password rules */
+.pw-rules {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-top: 8px;
+  padding: 12px; border-radius: 10px;
+  background: var(--secondary);
+  font-size: 12px;
+}
+.pw-rule { display: flex; align-items: center; gap: 8px; color: var(--muted); }
+.pw-rule.ok { color: var(--accent-deep); }
+.pw-rule .rule-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--line-strong);
+}
+.pw-rule.ok .rule-dot { background: var(--accent); }
+
+/* Terms checkbox */
+.terms-row {
+  display: flex; align-items: flex-start; gap: 10px;
+  margin: 16px 0;
+  font-size: 12px; color: var(--muted); line-height: 1.6;
+}
+.terms-row .checkbox {
+  width: 18px; height: 18px; border-radius: 5px;
+  border: 1.5px solid var(--accent); background: var(--accent);
+  display: grid; place-items: center; flex-shrink: 0;
+  cursor: pointer; color: #fff; font-size: 12px; font-weight: 700;
+  margin-top: 1px;
+}
+.terms-row a { color: var(--accent-deep); text-decoration: none; font-weight: 600; }
+.terms-row a:hover { text-decoration: underline; }
+
+/* Primary button */
+.primary-btn {
+  width: 100%;
+  padding: 12px 18px; border-radius: 12px;
+  background: var(--foreground); color: var(--background);
+  border: none; font: inherit; font-size: 14px; font-weight: 700;
+  cursor: pointer; min-height: 48px; margin-top: 4px;
+}
+.primary-btn:hover { background: var(--accent-deep); }
+
+.ac-footer {
+  margin-top: 16px; font-size: 13px; color: var(--muted);
+  text-align: center;
+}
+.ac-footer a, .ac-footer .lc-link {
+  color: var(--accent-deep); text-decoration: none; font-weight: 600; cursor: pointer;
+}
+.ac-footer a:hover { text-decoration: underline; }
+
+/* Verification waiting state */
+.verify-card .verify-icon {
+  width: 72px; height: 72px; border-radius: 18px;
+  background: var(--accent-subtle); color: var(--accent-deep);
+  display: grid; place-items: center;
+  margin: 0 auto 20px;
+}
+.verify-card .verify-icon svg {
+  width: 36px; height: 36px;
+  stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+}
+.verify-card h2 { text-align: center; }
+.verify-card .ac-sub { text-align: center; }
+.verify-card .verify-email {
+  display: inline-block;
+  background: var(--accent-subtle); color: var(--accent-deep);
+  padding: 4px 12px; border-radius: 9999px;
+  font-weight: 700; font-size: 13px;
+  margin: 0 4px;
+}
+
+.verify-actions {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 24px;
+}
+.btn-secondary {
+  width: 100%;
+  padding: 11px 18px; border-radius: 12px;
+  background: transparent; color: var(--foreground);
+  border: 1px solid var(--border);
+  font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer;
+}
+.btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+
+.verify-help {
+  margin-top: 20px; padding-top: 20px;
+  border-top: 1px solid var(--border);
+  font-size: 12px; color: var(--muted); line-height: 1.7;
+}
+.verify-help strong { color: var(--foreground); display: block; margin-bottom: 4px; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; font-weight: 700; }
+
+/* Right benefit aside */
+.auth-aside {
+  background: linear-gradient(135deg, var(--foreground) 0%, var(--accent-deep) 100%);
+  color: var(--background);
+  padding: 56px 48px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  position: relative; overflow: hidden;
+}
+.auth-aside::before {
+  content: ''; position: absolute;
+  top: -100px; right: -100px; width: 400px; height: 400px;
+  border-radius: 50%; background: rgba(247, 223, 203, 0.1);
+}
+.auth-aside::after {
+  content: ''; position: absolute;
+  bottom: -80px; left: -80px; width: 300px; height: 300px;
+  border-radius: 50%; background: rgba(217, 120, 72, 0.18);
+}
+.auth-aside > * { position: relative; z-index: 2; }
+.aside-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.22em;
+  text-transform: uppercase; opacity: 0.7;
+}
+.aside-display {
+  font-size: 38px; font-weight: 900; letter-spacing: -0.03em; line-height: 1.1;
+  margin: 16px 0 24px; max-width: 400px;
+}
+.aside-sub { font-size: 15px; line-height: 1.6; opacity: 0.85; max-width: 380px; }
+
+.feature-list {
+  display: flex; flex-direction: column; gap: 16px;
+  margin-top: 32px;
+}
+.feature-row {
+  display: flex; gap: 14px; align-items: flex-start;
+}
+.feature-row .f-icon {
+  width: 32px; height: 32px; border-radius: 8px;
+  background: rgba(255, 251, 245, 0.12);
+  display: grid; place-items: center; flex-shrink: 0;
+  color: var(--background);
+}
+.feature-row .f-icon svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.feature-row .f-body { padding-top: 4px; }
+.feature-row .f-title { font-size: 14px; font-weight: 700; }
+.feature-row .f-desc { font-size: 12px; opacity: 0.78; margin-top: 2px; line-height: 1.5; }
+
+.aside-footnote {
+  font-size: 11px; opacity: 0.6; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600;
+}
+
+/* Mobile */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: var(--background); flex-shrink: 0;
+  position: sticky; top: 0; z-index: 10;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-auth {
+  flex: 1; overflow-y: auto;
+  padding: 24px 24px calc(var(--nav-h-mobile) + 16px);
+  display: flex; flex-direction: column; gap: 18px;
+}
+.mobile-auth h2 {
+  font-size: 26px; font-weight: 800; letter-spacing: -0.025em; line-height: 1.15;
+  margin-bottom: 6px;
+}
+.mobile-auth .ac-sub { font-size: 14px; color: var(--muted); }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: var(--background);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit; min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Sign Up Mockup — /login/signup</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      多步註冊 · Step 1 OAuth 一鍵 / Email 註冊 → Step 2 等 email verification
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 · Sign up</span>
+    <span class="nav-links">
+      <a href="mockup-login-v2.html">← 登入</a>
+      <a href="mockup-forgot-v2.html">忘記密碼</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- ============ Desktop 1440 — Step 1 註冊表單 ============ -->
+<div class="viewport-label">Desktop · 1440 × 940 · Step 1 — OAuth 一鍵 / Email + 密碼 + 名稱建立帳號</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <div class="user-chip"><div class="avatar">+</div><span>建立帳號中</span></div>
+      </div>
+    </aside>
+
+    <main class="auth-main">
+      <div class="auth-form-side">
+        <div class="auth-card">
+          <a class="ac-back">← 回登入</a>
+          <div class="step-indicator">
+            <span>Step 1 / 2 · 建立帳號</span>
+            <span class="step-dots">
+              <span class="step-dot active"></span>
+              <span class="step-dot"></span>
+            </span>
+          </div>
+          <h2>建立 Tripline 帳號<br>開始規劃旅程</h2>
+          <div class="ac-sub">兩種方式都行 — OAuth 5 秒搞定，或用 email 自己建。</div>
+
+          <div class="providers">
+            <button class="provider-btn">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M21.35 11.1H12v3.8h5.35a4.5 4.5 0 0 1-1.97 2.96v2.45h3.17c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-2z" fill="#4285F4"/><path d="M12 22c2.7 0 4.96-.9 6.62-2.43l-3.17-2.45a6 6 0 0 1-3.45.96 6 6 0 0 1-5.7-4.16H2.99v2.55A10 10 0 0 0 12 22z" fill="#34A853"/><path d="M6.3 13.92a6 6 0 0 1 0-3.84V7.53H2.99a10 10 0 0 0 0 8.94L6.3 13.92z" fill="#FBBC05"/><path d="M12 6.16c1.47 0 2.79.5 3.83 1.5l2.86-2.86C16.95 3.13 14.7 2 12 2A10 10 0 0 0 2.99 7.53L6.3 10.08C7.1 7.95 9.35 6.16 12 6.16z" fill="#EA4335"/></svg>
+              </span>
+              <span>用 Google 註冊</span>
+            </button>
+            <button class="provider-btn">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+              </span>
+              <span>用 Apple 註冊</span>
+            </button>
+            <button class="provider-btn">
+              <span class="provider-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="#06C755"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+              </span>
+              <span>用 LINE 註冊</span>
+            </button>
+          </div>
+
+          <div class="divider">或 Email 註冊</div>
+
+          <div class="field">
+            <label>顯示名稱</label>
+            <input type="text" placeholder="旅伴會看到這個名字">
+            <div class="helper">至少 2 個字，可隨時改。</div>
+          </div>
+          <div class="field">
+            <label>Email</label>
+            <input type="email" placeholder="ray@example.com">
+          </div>
+          <div class="field">
+            <label>密碼</label>
+            <input type="password" placeholder="至少 8 字元 + 1 個數字">
+            <div class="pw-rules">
+              <div class="pw-rule ok"><span class="rule-dot"></span>至少 8 個字元</div>
+              <div class="pw-rule ok"><span class="rule-dot"></span>包含至少 1 個數字</div>
+              <div class="pw-rule"><span class="rule-dot"></span>包含至少 1 個大寫字母</div>
+            </div>
+          </div>
+
+          <div class="terms-row">
+            <span class="checkbox">✓</span>
+            <span>我同意 <a>服務條款</a>與 <a>隱私權政策</a>，了解 Tripline 不會在未經允許下分享行程資料。</span>
+          </div>
+
+          <button class="primary-btn">建立帳號 →</button>
+
+          <div class="ac-footer">
+            已有帳號？<span class="lc-link">直接登入</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="auth-aside">
+        <div class="aside-eyebrow">Why Tripline</div>
+        <div>
+          <h2 class="aside-display">把每次旅程<br>留在身邊。</h2>
+          <p class="aside-sub">註冊後可同步行程到所有裝置、邀請旅伴共編、儲存喜歡的 POI 一鍵加入下次 trip。</p>
+          <div class="feature-list">
+            <div class="feature-row">
+              <div class="f-icon">
+                <svg viewBox="0 0 24 24"><path d="M21 12a9 9 0 0 1-9 9M3 12a9 9 0 0 1 9-9M21 12h-4M7 12H3M12 21v-4M12 7V3"/><circle cx="12" cy="12" r="4"/></svg>
+              </div>
+              <div class="f-body">
+                <div class="f-title">跨裝置同步</div>
+                <div class="f-desc">手機看到的就是平板看到的，離線也能用。</div>
+              </div>
+            </div>
+            <div class="feature-row">
+              <div class="f-icon">
+                <svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+              </div>
+              <div class="f-body">
+                <div class="f-title">邀請旅伴共編</div>
+                <div class="f-desc">用一個 link 把家人朋友拉進行程，不用 LINE 截圖。</div>
+              </div>
+            </div>
+            <div class="feature-row">
+              <div class="f-icon">
+                <svg viewBox="0 0 24 24"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <div class="f-body">
+                <div class="f-title">儲存池跟著你</div>
+                <div class="f-desc">看到喜歡的餐廳/景點按 ♡ 儲存，下次規劃直接拉進 trip。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="aside-footnote">© 2026 Tripline · 由旅人為旅人打造</div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Desktop 1100 — Step 2: 等 email verification ============ -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · Step 2 — 等 email verification（pending state）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <div class="user-chip"><div class="avatar">R</div><span>等待驗證...</span></div>
+      </div>
+    </aside>
+
+    <main class="auth-main">
+      <div class="auth-form-side">
+        <div class="auth-card verify-card">
+          <div class="step-indicator" style="justify-content: center;">
+            <span>Step 2 / 2 · 驗證 email</span>
+            <span class="step-dots">
+              <span class="step-dot done"></span>
+              <span class="step-dot active"></span>
+            </span>
+          </div>
+
+          <div class="verify-icon">
+            <svg viewBox="0 0 24 24"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+          </div>
+          <h2>檢查信箱</h2>
+          <div class="ac-sub">
+            驗證連結已寄到 <span class="verify-email">ray@trip.io</span>，點擊後就能開始規劃。連結 24 小時內有效。
+          </div>
+
+          <div class="verify-actions">
+            <button class="primary-btn">開啟 email app</button>
+            <button class="btn-secondary">沒收到？重寄連結</button>
+          </div>
+
+          <div class="verify-help">
+            <strong>找不到信？</strong>
+            檢查垃圾信件 / 推廣信件夾。寄件人是 <span style="font-weight: 600; color: var(--foreground);">noreply@trip.io</span>。
+            如果還是沒看到，<a style="color: var(--accent-deep); text-decoration: none; font-weight: 600;">改用其他 email</a>。
+          </div>
+        </div>
+      </div>
+
+      <div class="auth-aside">
+        <div class="aside-eyebrow">Almost there</div>
+        <div>
+          <h2 class="aside-display">差最後一步<br>就能開始。</h2>
+          <p class="aside-sub">驗證 email 是為了確保你能收到旅伴邀請、行程更新通知，以及哪天忘記密碼時的重設連結。</p>
+          <div class="feature-list">
+            <div class="feature-row">
+              <div class="f-icon">
+                <svg viewBox="0 0 24 24"><polyline points="20,6 9,17 4,12"/></svg>
+              </div>
+              <div class="f-body">
+                <div class="f-title">驗證後立即可用</div>
+                <div class="f-desc">點完連結會自動回到這個頁面，可以直接開始規劃 trip。</div>
+              </div>
+            </div>
+            <div class="feature-row">
+              <div class="f-icon">
+                <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              </div>
+              <div class="f-body">
+                <div class="f-title">未驗證不算啟用</div>
+                <div class="f-desc">沒驗證的帳號 7 天後自動清除，避免假帳號占空間。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="aside-footnote">© 2026 Tripline</div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============ Mobile — Step 1 簡化版 ============ -->
+<div class="viewport-label">Mobile · 375 × 812 · Step 1 註冊（mobile 全寬簡化版 + bottom nav）</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">Tripline<span class="accent-dot">.</span></div>
+      <button class="icon-btn" title="關閉"><span style="font-size: 16px;">✕</span></button>
+    </header>
+
+    <div class="mobile-auth">
+      <a class="ac-back">← 回登入</a>
+      <div class="step-indicator">
+        <span>Step 1 / 2</span>
+        <span class="step-dots">
+          <span class="step-dot active"></span>
+          <span class="step-dot"></span>
+        </span>
+      </div>
+      <div>
+        <h2>建立帳號<br>開始規劃</h2>
+        <div class="ac-sub">OAuth 5 秒搞定 · 或用 email 自己建</div>
+      </div>
+
+      <div class="providers">
+        <button class="provider-btn">
+          <span class="provider-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24"><path d="M21.35 11.1H12v3.8h5.35a4.5 4.5 0 0 1-1.97 2.96v2.45h3.17c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-2z" fill="#4285F4"/><path d="M12 22c2.7 0 4.96-.9 6.62-2.43l-3.17-2.45a6 6 0 0 1-3.45.96 6 6 0 0 1-5.7-4.16H2.99v2.55A10 10 0 0 0 12 22z" fill="#34A853"/><path d="M6.3 13.92a6 6 0 0 1 0-3.84V7.53H2.99a10 10 0 0 0 0 8.94L6.3 13.92z" fill="#FBBC05"/><path d="M12 6.16c1.47 0 2.79.5 3.83 1.5l2.86-2.86C16.95 3.13 14.7 2 12 2A10 10 0 0 0 2.99 7.53L6.3 10.08C7.1 7.95 9.35 6.16 12 6.16z" fill="#EA4335"/></svg>
+          </span>
+          <span>用 Google 註冊</span>
+        </button>
+        <button class="provider-btn">
+          <span class="provider-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+          </span>
+          <span>用 Apple 註冊</span>
+        </button>
+        <button class="provider-btn">
+          <span class="provider-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="#06C755"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+          </span>
+          <span>用 LINE 註冊</span>
+        </button>
+      </div>
+
+      <div class="divider">或 Email 註冊</div>
+
+      <div>
+        <div class="field">
+          <label>顯示名稱</label>
+          <input type="text" placeholder="旅伴會看到這個名字">
+        </div>
+        <div class="field">
+          <label>Email</label>
+          <input type="email" placeholder="ray@example.com">
+        </div>
+        <div class="field">
+          <label>密碼</label>
+          <input type="password" placeholder="至少 8 字元 + 1 個數字">
+        </div>
+
+        <div class="terms-row">
+          <span class="checkbox">✓</span>
+          <span>同意 <a>服務條款</a>與 <a>隱私權</a></span>
+        </div>
+
+        <button class="primary-btn">建立帳號 →</button>
+      </div>
+
+      <div class="ac-footer">
+        已有帳號？<span class="lc-link">直接登入</span>
+      </div>
+    </div>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>註冊頁規格摘要</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>路由</strong>：<code>/login/signup</code>（Step 1 填表）<code>/login/verify</code>（Step 2 等 email 驗證）</li>
+    <li><strong>Step 1</strong>：3 個 OAuth provider（Google/Apple/LINE 真實 logo SVG）+ Email 註冊三 field（顯示名稱 / Email / 密碼）+ 即時 password rule meter + terms checkbox（預設 checked）+ primary CTA「建立帳號」</li>
+    <li><strong>Step 2 verify state</strong>：72px accent-subtle icon + 「檢查信箱」hero + 顯示已寄到的 email chip + 雙 action（「開啟 email app」primary / 「重寄連結」secondary）+ help footer（垃圾信件提示 / 改用其他 email）</li>
+    <li><strong>Provider buttons</strong>：跟 login 同樣 3 個 OAuth 真實 logo SVG（Google 4 色、Apple 黑、LINE #06C755 綠）— 對齊品牌 guideline 要求</li>
+    <li><strong>顯示名稱欄位</strong>：mockup 多一個 field（login 沒有）— 旅伴會看到這個名字，後續可改</li>
+    <li><strong>Password rules 即時驗證</strong>：3 條規則 dot + 文案（&gt;=8 字 / 至少 1 數字 / 至少 1 大寫），達成的變 accent</li>
+    <li><strong>Terms 行</strong>：accent-fill checkbox（預設勾選 — 但實作要 user 主動勾才符合 dark pattern 規避；mockup 為 demo 預勾）+ 雙 link 條款</li>
+    <li><strong>未驗證帳號 7 天清除</strong>：spec card 提到的 reassurance — 避免假帳號累積，符合 V2 OAuth Workstream A 的 hardening</li>
+    <li><strong>Mobile</strong>：簡化 — 無右側 aside、無 password rule meter（僅 placeholder hint）、terms 縮短「同意條款與隱私權」</li>
+    <li><strong>實作對應</strong>：V2 OAuth Workstream A · Phase 2「Local password + email verification」</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/docs/design-sessions/mockup-trip-v2.html
+++ b/docs/design-sessions/mockup-trip-v2.html
@@ -1,0 +1,985 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V2 Terracotta Final — AppShell + ocean-rail Itinerary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+TC:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --accent: #D97848;
+  --accent-subtle: #FBEEE4;
+  --accent-bg: #F7DFCB;
+  --accent-deep: #B85C2E;
+  --background: #FFFBF5;
+  --secondary: #FAF4EA;
+  --tertiary: #F2EAD9;
+  --hover: #F9EDE0;
+  --foreground: #2A1F18;
+  --muted: #6F5A47;
+  --border: #EADFCF;
+  --line-strong: #C8B89F;
+  --sidebar-bg: #FFFBF5;
+  --sheet-bg: #FFFBF5;
+  --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+  --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+  --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
+
+  --grid-3pane: 240px 1fr min(780px, 40vw);
+  --grid-2pane: 240px 1fr;
+  --nav-h-mobile: 88px;
+
+  --font-eyebrow: 0.625rem;
+  --font-caption2: 0.6875rem;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: light; }
+body {
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #E8E3D8;
+  color: var(--foreground);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 32px 24px 80px;
+}
+
+.page-header {
+  max-width: 1600px; margin: 0 auto 24px;
+  padding-bottom: 20px; border-bottom: 2px solid rgba(42, 31, 24, 0.08);
+  display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
+}
+.page-header h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+.page-header .variant-chip {
+  background: var(--accent); color: #fff;
+  padding: 6px 14px; border-radius: 9999px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.05em;
+}
+.page-header .nav-links a {
+  color: var(--muted); text-decoration: none; margin-left: 16px; font-size: 14px; font-weight: 500;
+}
+.page-header .nav-links a:hover { color: var(--accent); }
+
+.viewport-label {
+  max-width: 1600px; margin: 40px auto 12px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 12px;
+}
+.viewport-label::after { content: ''; flex: 1; height: 1px; background: rgba(42, 31, 24, 0.1); }
+
+.viewport-frame {
+  background: var(--background);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(42, 31, 24, 0.2), 0 2px 6px rgba(42, 31, 24, 0.08);
+  overflow: hidden;
+  position: relative;
+  margin: 0 auto;
+}
+.vp-desktop-full { width: 1440px; height: 940px; }
+.vp-desktop-narrow { width: 1100px; height: 800px; }
+.vp-mobile { width: 375px; height: 812px; }
+
+.shell-3pane { display: grid; grid-template-columns: var(--grid-3pane); height: 100%; }
+.shell-2pane { display: grid; grid-template-columns: var(--grid-2pane); height: 100%; }
+.shell-mobile { display: flex; flex-direction: column; height: 100%; position: relative; }
+
+/* ========== Sidebar ========== */
+.sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px 16px;
+  display: flex; flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.sidebar-brand {
+  padding: 6px 12px 20px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.sidebar-brand .accent-dot { color: var(--accent); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
+.nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px; border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+}
+.nav-item:hover { background: var(--hover); color: var(--foreground); }
+.nav-item.active {
+  background: var(--foreground); color: var(--background);
+  font-weight: 600;
+}
+.nav-item .icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
+.nav-item .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+
+.sidebar-cta {
+  margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.new-trip-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; border-radius: 9999px;
+  background: var(--accent); color: #fff;
+  border: none; font: inherit; font-size: 14px; font-weight: 600;
+  cursor: pointer; min-height: 44px;
+}
+.new-trip-btn:hover { background: var(--accent-deep); }
+.user-chip {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px; border-radius: 8px;
+  color: var(--muted); font-size: 13px;
+}
+.user-chip .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-bg); color: var(--accent-deep);
+  display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0;
+}
+
+/* ========== Main Content ========== */
+.main-content {
+  overflow-y: auto;
+  padding: 32px 40px;
+  background: var(--secondary);
+}
+.main-header {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  margin-bottom: 28px;
+}
+.main-header h1 { font-size: 32px; font-weight: 700; letter-spacing: -0.02em; }
+.main-header .header-meta { color: var(--muted); font-size: 14px; margin-top: 4px; }
+.main-header .header-actions { display: flex; gap: 8px; }
+.btn-ghost {
+  padding: 8px 14px; border-radius: 8px;
+  background: transparent; border: 1px solid var(--border);
+  color: var(--foreground); font: inherit; font-size: 13px; font-weight: 500;
+  cursor: pointer;
+}
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); background: var(--hover); }
+
+.trip-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;
+}
+.trip-card {
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px;
+  cursor: pointer; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.trip-card:hover { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card.active { border-color: var(--accent); box-shadow: var(--shadow-md); }
+.trip-card .card-cover {
+  aspect-ratio: 16/9; background: var(--tertiary); border-radius: 8px; margin-bottom: 12px;
+}
+.trip-card .cover-okinawa { background-image: linear-gradient(135deg, #D97848 0%, #F0935E 100%); }
+.trip-card .cover-seoul { background-image: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%); }
+.trip-card .cover-taichung { background-image: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%); }
+.trip-card .card-eyebrow {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 6px;
+}
+.trip-card .card-title { font-size: 17px; font-weight: 700; letter-spacing: -0.005em; margin-bottom: 4px; }
+.trip-card .card-meta { font-size: 13px; color: var(--muted); font-variant-numeric: tabular-nums; }
+
+/* ========== Right Sheet ========== */
+.sheet {
+  background: var(--sheet-bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.sheet-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px;
+}
+.sheet-header .icon-btn {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+  color: var(--muted); font-size: 14px;
+}
+.sheet-header .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+.sheet-header .spacer { flex: 1; }
+
+/* Trip switcher — title 變 dropdown trigger */
+.sheet-title-row {
+  position: relative;
+  padding: 16px 24px 8px;
+}
+.sheet-title-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 0; border: none; background: transparent;
+  cursor: pointer; font-family: inherit;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+  color: var(--foreground);
+  text-align: left;
+}
+.sheet-title-btn:hover { color: var(--accent-deep); }
+.sheet-title-btn .switch-chevron {
+  font-size: 14px; line-height: 1; color: var(--muted);
+  display: inline-grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 6px;
+  background: var(--tertiary);
+  transition: background 0.15s, color 0.15s;
+}
+.sheet-title-btn:hover .switch-chevron { background: var(--accent-subtle); color: var(--accent); }
+.sheet-title-btn[aria-expanded="true"] .switch-chevron { background: var(--accent); color: #fff; transform: rotate(180deg); }
+
+.trip-switcher-menu {
+  position: absolute;
+  top: calc(100% + 4px); left: 24px; right: 24px;
+  background: var(--background);
+  border: 1px solid var(--border); border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  padding: 6px;
+  z-index: 20;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.tsm-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px; border-radius: 8px;
+  text-decoration: none; color: var(--foreground);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.tsm-item:hover { background: var(--hover); }
+.tsm-item.active { background: var(--accent-subtle); }
+.tsm-item .tsm-cover {
+  width: 36px; height: 36px; border-radius: 6px; flex-shrink: 0;
+  background-size: cover;
+}
+.tsm-item .tsm-cover.cover-okinawa { background: linear-gradient(135deg, #D97848 0%, #F0935E 100%); }
+.tsm-item .tsm-cover.cover-seoul { background: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%); }
+.tsm-item .tsm-cover.cover-taichung { background: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%); }
+.tsm-item .tsm-body { flex: 1; min-width: 0; }
+.tsm-item .tsm-title {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.005em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.tsm-item .tsm-meta {
+  font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em; margin-top: 2px;
+}
+.tsm-item.active .tsm-title { color: var(--accent-deep); }
+.tsm-item .tsm-check {
+  font-size: 14px; color: var(--accent); flex-shrink: 0;
+  opacity: 0; transition: opacity 0.15s;
+}
+.tsm-item.active .tsm-check { opacity: 1; }
+
+.tsm-divider { height: 1px; background: var(--border); margin: 4px 0; }
+
+.tsm-action {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px; border-radius: 8px;
+  background: transparent; border: none; cursor: pointer; font-family: inherit;
+  font-size: 13px; font-weight: 600; color: var(--accent-deep);
+  text-align: left;
+}
+.tsm-action:hover { background: var(--accent-subtle); }
+.tsm-action .icon-plus {
+  width: 20px; height: 20px; border-radius: 50%;
+  background: var(--accent); color: #fff;
+  display: grid; place-items: center; font-size: 14px; line-height: 1;
+}
+
+.sheet-meta {
+  padding: 0 24px 16px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+.sheet-meta .chip { padding: 4px 10px; border-radius: 9999px; background: var(--tertiary); }
+.sheet-meta .chip.active { background: var(--accent-subtle); color: var(--accent-deep); font-weight: 600; }
+
+/* ========== Day strip (sticky inside sheet body) — DayNav 桌機 underline tab style ========== */
+.day-strip {
+  display: flex; gap: 4px;
+  overflow-x: auto;
+  padding: 0 24px;
+  position: sticky; top: 0;
+  background: color-mix(in srgb, var(--sheet-bg) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  z-index: 5;
+  scrollbar-width: none;
+}
+.day-strip::-webkit-scrollbar { display: none; }
+.day-strip-btn {
+  flex: 0 0 auto;
+  padding: 10px 12px;
+  border: none; background: transparent;
+  border-bottom: 2px solid transparent;
+  cursor: pointer; font-family: inherit;
+  color: var(--muted);
+  display: inline-flex; flex-direction: column; gap: 2px;
+  min-height: 44px;
+  transition: color 160ms, border-bottom-color 160ms;
+}
+.day-strip-btn:hover:not(.active) { color: var(--foreground); }
+.day-strip-btn.active { color: var(--accent-deep); border-bottom-color: var(--accent); }
+.day-strip-btn .dn-head { display: inline-flex; align-items: center; gap: 4px; }
+.day-strip-btn .dn-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+.day-strip-btn.active .dn-eyebrow { opacity: 1; }
+.day-strip-btn .dn-today {
+  font-size: 9px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 2px 5px; border-radius: 4px;
+  background: var(--accent-subtle); color: var(--accent-deep);
+}
+.day-strip-btn .dn-date {
+  font-size: 14px; font-weight: 600;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.005em;
+  line-height: 1; color: var(--foreground);
+}
+.day-strip-btn.active .dn-date { color: var(--accent-deep); }
+.day-strip-btn .dn-dow {
+  font-size: var(--font-caption2); font-weight: 500;
+  opacity: 0.55; margin-left: 4px;
+}
+
+/* ========== Ocean Rail (stop list) — 對齊現有 .ocean-rail-* ========== */
+.sheet-body { flex: 1; overflow-y: auto; }
+.rail {
+  padding: 16px 20px 20px;
+}
+.rail-header {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 10px; padding: 0 4px;
+}
+.rail-eyebrow {
+  font-size: var(--font-caption2); letter-spacing: 0.2em; color: var(--muted);
+  text-transform: uppercase; font-weight: 600;
+}
+.rail-meta { font-size: var(--font-caption2); color: var(--muted); font-variant-numeric: tabular-nums; }
+.rail-body { position: relative; padding: 0; }
+.rail-line {
+  position: absolute; left: 66px; top: 12px; bottom: 12px;
+  width: 1px; background: var(--border);
+  pointer-events: none;
+}
+.rail-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 44px 24px 22px 1fr 18px;
+  column-gap: 10px; align-items: center;
+  width: 100%; padding: 12px 4px;
+  border-bottom: 1px dashed var(--border);
+  color: var(--foreground);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.rail-item:hover { background: var(--hover); }
+.rail-item[data-last="true"] { border-bottom: none; }
+.rail-item[data-past="true"] { opacity: 0.55; }
+.rail-item[data-now="true"] {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  border-radius: 8px;
+  border-bottom-color: var(--accent);
+}
+.rail-time {
+  text-align: right;
+  font-size: 13px; font-weight: 700;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.02em;
+  color: var(--foreground); line-height: 1.2;
+}
+.rail-dot {
+  justify-self: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--background);
+  border: 1.5px solid var(--line-strong);
+  display: grid; place-items: center;
+  font-size: var(--font-caption2); font-weight: 700;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  line-height: 1; z-index: 1;
+}
+.rail-item[data-accent="true"] .rail-dot { border-color: var(--accent); color: var(--accent); }
+.rail-item[data-now="true"] .rail-dot { background: var(--accent); border-color: var(--accent); color: #fff; }
+.rail-icon {
+  width: 22px; height: 22px;
+  display: grid; place-items: center;
+  color: var(--muted); flex-shrink: 0;
+}
+.rail-icon svg { width: 18px; height: 18px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.rail-item[data-accent="true"] .rail-icon { color: var(--accent); }
+.rail-content { min-width: 0; overflow: hidden; }
+.rail-name {
+  display: block; font-size: 15px; font-weight: 600;
+  letter-spacing: -0.01em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  color: var(--foreground);
+}
+.rail-sub {
+  display: flex; gap: 6px; align-items: center;
+  font-size: 12px; color: var(--muted); margin-top: 3px;
+}
+.rail-type {
+  font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--muted);
+}
+.rail-item[data-accent="true"] .rail-type { color: var(--accent); }
+.rail-sep { opacity: 0.5; }
+.rail-caret {
+  font-size: 18px; color: var(--muted);
+  flex-shrink: 0; line-height: 1; text-align: center;
+}
+
+/* ========== Mobile ========== */
+.mobile-topbar {
+  height: 56px; padding: 0 16px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(14px);
+  position: sticky; top: 0; z-index: 10;
+  flex-shrink: 0;
+}
+.mobile-topbar .brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+.mobile-topbar .brand .accent-dot { color: var(--accent); }
+.mobile-topbar .icon-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--background);
+  display: grid; place-items: center; cursor: pointer;
+}
+
+.mobile-main {
+  flex: 1; overflow-y: auto;
+  padding-bottom: calc(var(--nav-h-mobile) + 0px);
+}
+
+/* Mobile day strip — pill style（DayNav mobile pattern）*/
+.mobile-day-strip {
+  display: flex; gap: 6px;
+  overflow-x: auto;
+  padding: 8px 16px;
+  position: sticky; top: 56px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  z-index: 5;
+  scrollbar-width: none;
+}
+.mobile-day-strip::-webkit-scrollbar { display: none; }
+.mobile-day-strip-btn {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid var(--border); border-radius: 10px;
+  background: transparent; cursor: pointer; font-family: inherit;
+  color: var(--foreground);
+  display: inline-flex; flex-direction: column; gap: 4px;
+  min-height: 44px;
+  transition: background 0.15s, border-color 0.15s;
+}
+.mobile-day-strip-btn .ds-eyebrow {
+  font-size: var(--font-eyebrow); font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; opacity: 0.6; line-height: 1;
+}
+.mobile-day-strip-btn .ds-date {
+  font-size: 13px; font-weight: 600;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.005em; line-height: 1;
+}
+.mobile-day-strip-btn .ds-area { font-size: 11px; opacity: 0.6; line-height: 1; }
+.mobile-day-strip-btn:hover:not(.active) { border-color: var(--accent); }
+.mobile-day-strip-btn.active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+}
+.mobile-day-strip-btn.active .ds-eyebrow,
+.mobile-day-strip-btn.active .ds-area { opacity: 0.85; }
+
+.mobile-itinerary { padding-bottom: 24px; }
+
+.bottom-nav {
+  position: sticky; inset-block-end: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-h-mobile);
+  background: color-mix(in srgb, var(--background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.bottom-nav-btn {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  background: transparent; border: none; cursor: pointer;
+  color: var(--muted); font: inherit;
+  min-height: 44px;
+}
+.bottom-nav-btn .icon { width: 22px; height: 22px; }
+.bottom-nav-btn .icon svg { width: 100%; height: 100%; stroke-width: 2; }
+.bottom-nav-btn span { font-size: 10px; font-weight: 500; }
+.bottom-nav-btn.active { color: var(--accent); }
+.bottom-nav-btn.active span { font-weight: 700; }
+
+.icon { display: inline-flex; align-items: center; justify-content: center; }
+.icon svg { stroke: currentColor; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+.spec-card {
+  max-width: 1600px; margin: 32px auto 0;
+  background: var(--background); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px;
+  font-size: 13px; color: var(--foreground); line-height: 1.7;
+}
+.spec-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+.spec-card code { background: var(--tertiary); padding: 1px 6px; border-radius: 4px; font-size: 12px; color: var(--accent-deep); }
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <div>
+    <h1>V2 Terracotta Final — AppShell + ocean-rail itinerary</h1>
+    <div style="font-size: 13px; color: var(--muted); margin-top: 4px;">
+      V2 palette · stop list 用既有 <code style="font-family: inherit; color: var(--accent-deep);">.ocean-rail-*</code> 樣式 · 每日切換用 <code style="font-family: inherit; color: var(--accent-deep);">DayNav</code> 既有 pattern
+    </div>
+  </div>
+  <div>
+    <span class="variant-chip">V2 Final</span>
+    <span class="nav-links">
+      <a href="mockup-shell-v1-ocean.html">V1 Ocean</a>
+      <a href="mockup-shell-v2-terracotta.html">V2</a>
+      <a href="mockup-shell-v3-magazine.html">V3</a>
+      <a href="mockup-index.html">Index</a>
+    </span>
+  </div>
+</header>
+
+<!-- Desktop 1440px -->
+<div class="viewport-label">Desktop · 1440 × 940 · 3-pane（sheet 內 day strip + ocean-rail stop list）</div>
+<div class="viewport-frame vp-desktop-full">
+  <div class="shell-3pane">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · 最近更新 2026-04-24</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">篩選</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card active">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Sheet -->
+    <aside class="sheet">
+      <div class="sheet-header">
+        <button class="icon-btn" title="關閉">✕</button>
+        <button class="icon-btn" title="收窄">⇤</button>
+        <div class="spacer"></div>
+        <button class="icon-btn" title="分享">↗</button>
+        <button class="icon-btn" title="更多">⋯</button>
+      </div>
+      <div class="sheet-title-row">
+        <button class="sheet-title-btn" aria-expanded="true" aria-haspopup="listbox">
+          沖繩之旅
+          <span class="switch-chevron" aria-hidden="true">▾</span>
+        </button>
+        <!-- Trip switcher dropdown (mockup: 已展開狀態) -->
+        <div class="trip-switcher-menu" role="listbox" aria-label="切換行程">
+          <a class="tsm-item active" role="option" aria-selected="true">
+            <div class="tsm-cover cover-okinawa"></div>
+            <div class="tsm-body">
+              <div class="tsm-title">沖繩之旅</div>
+              <div class="tsm-meta">7/26 – 7/30 · 5 days · 進行中</div>
+            </div>
+            <span class="tsm-check">✓</span>
+          </a>
+          <a class="tsm-item" role="option">
+            <div class="tsm-cover cover-seoul"></div>
+            <div class="tsm-body">
+              <div class="tsm-title">首爾美食行</div>
+              <div class="tsm-meta">8/15 – 8/18 · 4 days · 草稿</div>
+            </div>
+            <span class="tsm-check">✓</span>
+          </a>
+          <a class="tsm-item" role="option">
+            <div class="tsm-cover cover-taichung"></div>
+            <div class="tsm-body">
+              <div class="tsm-title">台中週末小旅</div>
+              <div class="tsm-meta">6/8 – 6/9 · 2 days · 已結束</div>
+            </div>
+            <span class="tsm-check">✓</span>
+          </a>
+          <div class="tsm-divider"></div>
+          <button class="tsm-action">
+            <span class="icon-plus">+</span>
+            新增行程
+          </button>
+        </div>
+      </div>
+      <div class="sheet-meta">
+        <span class="chip active">沖繩 · 那霸</span>
+        <span class="chip">7/26 – 7/30</span>
+        <span class="chip">2 旅伴</span>
+      </div>
+
+      <div class="sheet-body">
+        <!-- Day strip (sticky inside sheet body) -->
+        <div class="day-strip" role="tablist" aria-label="行程日期">
+          <button class="day-strip-btn active" role="tab" aria-selected="true">
+            <div class="dn-head">
+              <span class="dn-eyebrow">DAY 01</span>
+              <span class="dn-today">TODAY</span>
+            </div>
+            <div class="dn-date">7/26<span class="dn-dow">Sat</span></div>
+          </button>
+          <button class="day-strip-btn" role="tab">
+            <div class="dn-head"><span class="dn-eyebrow">DAY 02</span></div>
+            <div class="dn-date">7/27<span class="dn-dow">Sun</span></div>
+          </button>
+          <button class="day-strip-btn" role="tab">
+            <div class="dn-head"><span class="dn-eyebrow">DAY 03</span></div>
+            <div class="dn-date">7/28<span class="dn-dow">Mon</span></div>
+          </button>
+          <button class="day-strip-btn" role="tab">
+            <div class="dn-head"><span class="dn-eyebrow">DAY 04</span></div>
+            <div class="dn-date">7/29<span class="dn-dow">Tue</span></div>
+          </button>
+          <button class="day-strip-btn" role="tab">
+            <div class="dn-head"><span class="dn-eyebrow">DAY 05</span></div>
+            <div class="dn-date">7/30<span class="dn-dow">Wed</span></div>
+          </button>
+          <button class="day-strip-btn" role="tab" aria-label="全覽地圖">
+            <div class="dn-head"><span class="dn-eyebrow">MAP</span></div>
+            <div class="dn-date">全覽</div>
+          </button>
+        </div>
+
+        <!-- Ocean rail itinerary -->
+        <div class="rail">
+          <div class="rail-header">
+            <span class="rail-eyebrow">Itinerary</span>
+            <span class="rail-meta">7 stops · 10:45–21:00</span>
+          </div>
+          <div class="rail-body">
+            <div class="rail-line" aria-hidden="true"></div>
+
+            <div class="rail-item">
+              <span class="rail-time">10:45</span>
+              <span class="rail-dot">1</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5z"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">抵達那霸機場</span>
+                <div class="rail-sub"><span class="rail-type">飛行</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item">
+              <span class="rail-time">12:10</span>
+              <span class="rail-dot">2</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="6" rx="1.5"/><path d="M5 11l2-5h10l2 5"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">租車取車</span>
+                <div class="rail-sub"><span class="rail-type">移動</span><span class="rail-sep">·</span><span>30m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-accent="true">
+              <span class="rail-time">13:00</span>
+              <span class="rail-dot">3</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M5 3v8a3 3 0 0 0 6 0V3M8 11v10M16 3c-1.5 0-3 1.5-3 4v4h3v10"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">MEGA唐吉軻德 宜野灣店（含午餐）</span>
+                <div class="rail-sub"><span class="rail-type">用餐</span><span class="rail-sep">·</span><span>2h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item">
+              <span class="rail-time">15:10</span>
+              <span class="rail-dot">4</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M3 18v-6h7a3 3 0 0 1 3 3v3M3 18h18M21 18v-3a4 4 0 0 0-4-4M5 12V8a2 2 0 0 1 2-2h6"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">Check in Vessel Hotel</span>
+                <div class="rail-sub"><span class="rail-type">住宿</span><span class="rail-sep">·</span><span>20m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-accent="true">
+              <span class="rail-time">16:00</span>
+              <span class="rail-dot">5</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">美國村 + Sunset Beach</span>
+                <div class="rail-sub"><span class="rail-type">景點</span><span class="rail-sep">·</span><span>3h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-accent="true">
+              <span class="rail-time">19:30</span>
+              <span class="rail-dot">6</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M5 3v8a3 3 0 0 0 6 0V3M8 11v10M16 3c-1.5 0-3 1.5-3 4v4h3v10"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">通堂拉麵 小祿本店</span>
+                <div class="rail-sub"><span class="rail-type">用餐</span><span class="rail-sep">·</span><span>1h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-last="true">
+              <span class="rail-time">21:00</span>
+              <span class="rail-dot">7</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M3 18v-6h7a3 3 0 0 1 3 3v3M3 18h18M21 18v-3a4 4 0 0 0-4-4M5 12V8a2 2 0 0 1 2-2h6"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">回飯店休息</span>
+                <div class="rail-sub"><span class="rail-type">住宿</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<!-- Desktop 1100px -->
+<div class="viewport-label">Desktop Narrow · 1100 × 800 · 2-pane（sheet 收起）</div>
+<div class="viewport-frame vp-desktop-narrow">
+  <div class="shell-2pane">
+    <aside class="sidebar">
+      <div class="sidebar-brand">Tripline<span class="accent-dot">.</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>聊天</a>
+        <a class="nav-item active"><span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>行程</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>地圖</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>探索</a>
+        <a class="nav-item"><span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>登入</a>
+      </nav>
+      <div class="sidebar-cta">
+        <button class="new-trip-btn"><span style="font-size: 16px;">+</span>新增行程</button>
+        <div class="user-chip"><div class="avatar">R</div><span>ray@trip.io</span></div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <div class="main-header">
+        <div>
+          <h1>我的行程</h1>
+          <div class="header-meta">3 個進行中 · Sheet 收起時 main 擴寬填滿</div>
+        </div>
+        <div class="header-actions">
+          <button class="btn-ghost">⋮ 排序</button>
+          <button class="btn-ghost">↗ 開啟 sheet</button>
+        </div>
+      </div>
+      <div class="trip-grid">
+        <div class="trip-card">
+          <div class="card-cover cover-okinawa"></div>
+          <div class="card-eyebrow">JAPAN · 5 DAYS</div>
+          <div class="card-title">沖繩之旅</div>
+          <div class="card-meta">7/26 – 7/30 · 2 旅伴</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-seoul"></div>
+          <div class="card-eyebrow">KOREA · 4 DAYS</div>
+          <div class="card-title">首爾美食行</div>
+          <div class="card-meta">8/15 – 8/18 · 草稿</div>
+        </div>
+        <div class="trip-card">
+          <div class="card-cover cover-taichung"></div>
+          <div class="card-eyebrow">TAIWAN · 2 DAYS</div>
+          <div class="card-title">台中週末小旅</div>
+          <div class="card-meta">6/8 – 6/9 · 已結束</div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- Mobile -->
+<div class="viewport-label">Mobile · 375 × 812 · 行程頁（pill day strip + ocean-rail）</div>
+<div class="viewport-frame vp-mobile">
+  <div class="shell-mobile">
+    <header class="mobile-topbar">
+      <div class="brand">沖繩之旅<span class="accent-dot"> ›</span></div>
+      <button class="icon-btn" title="更多"><span>⋯</span></button>
+    </header>
+
+    <main class="mobile-main">
+      <!-- Mobile day strip pill style -->
+      <div class="mobile-day-strip" role="tablist" aria-label="行程日期">
+        <button class="mobile-day-strip-btn active">
+          <span class="ds-eyebrow">DAY 01</span>
+          <span class="ds-date">7/26</span>
+        </button>
+        <button class="mobile-day-strip-btn">
+          <span class="ds-eyebrow">DAY 02</span>
+          <span class="ds-date">7/27</span>
+        </button>
+        <button class="mobile-day-strip-btn">
+          <span class="ds-eyebrow">DAY 03</span>
+          <span class="ds-date">7/28</span>
+        </button>
+        <button class="mobile-day-strip-btn">
+          <span class="ds-eyebrow">DAY 04</span>
+          <span class="ds-date">7/29</span>
+        </button>
+        <button class="mobile-day-strip-btn">
+          <span class="ds-eyebrow">DAY 05</span>
+          <span class="ds-date">7/30</span>
+        </button>
+      </div>
+
+      <div class="mobile-itinerary">
+        <div class="rail">
+          <div class="rail-header">
+            <span class="rail-eyebrow">Itinerary</span>
+            <span class="rail-meta">7 stops · 10:45–21:00</span>
+          </div>
+          <div class="rail-body">
+            <div class="rail-line" aria-hidden="true"></div>
+
+            <div class="rail-item">
+              <span class="rail-time">10:45</span>
+              <span class="rail-dot">1</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5z"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">抵達那霸機場</span>
+                <div class="rail-sub"><span class="rail-type">飛行</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item">
+              <span class="rail-time">12:10</span>
+              <span class="rail-dot">2</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="6" rx="1.5"/><path d="M5 11l2-5h10l2 5"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">租車取車</span>
+                <div class="rail-sub"><span class="rail-type">移動</span><span class="rail-sep">·</span><span>30m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-accent="true">
+              <span class="rail-time">13:00</span>
+              <span class="rail-dot">3</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M5 3v8a3 3 0 0 0 6 0V3M8 11v10M16 3c-1.5 0-3 1.5-3 4v4h3v10"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">MEGA唐吉軻德 宜野灣店</span>
+                <div class="rail-sub"><span class="rail-type">用餐</span><span class="rail-sep">·</span><span>2h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item">
+              <span class="rail-time">15:10</span>
+              <span class="rail-dot">4</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><path d="M3 18v-6h7a3 3 0 0 1 3 3v3M3 18h18M21 18v-3a4 4 0 0 0-4-4M5 12V8a2 2 0 0 1 2-2h6"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">Check in Vessel Hotel</span>
+                <div class="rail-sub"><span class="rail-type">住宿</span><span class="rail-sep">·</span><span>20m</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+
+            <div class="rail-item" data-accent="true" data-last="true">
+              <span class="rail-time">16:00</span>
+              <span class="rail-dot">5</span>
+              <span class="rail-icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg></span>
+              <div class="rail-content">
+                <span class="rail-name">美國村 + Sunset Beach</span>
+                <div class="rail-sub"><span class="rail-type">景點</span><span class="rail-sep">·</span><span>3h</span></div>
+              </div>
+              <span class="rail-caret">›</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <nav class="bottom-nav" aria-label="主要功能">
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"/></svg></span>
+        <span>聊天</span>
+      </button>
+      <button class="bottom-nav-btn active">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M4 7h16v13H4z"/><path d="M8 3v4M16 3v4"/></svg></span>
+        <span>行程</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><path d="M9 4l-6 3v13l6-3 6 3 6-3V4l-6 3-6-3z"/><path d="M9 4v13M15 7v13"/></svg></span>
+        <span>地圖</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+        <span>探索</span>
+      </button>
+      <button class="bottom-nav-btn">
+        <span class="icon"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg></span>
+        <span>登入</span>
+      </button>
+    </nav>
+  </div>
+</div>
+
+<section class="spec-card">
+  <h3>V2 Final 特徵 — V2 palette + 既有 stop layout</h3>
+  <ul style="padding-left: 20px; list-style: disc;">
+    <li><strong>Palette</strong>：V2 Terracotta 不變（<code>--accent: #D97848</code>）</li>
+    <li><strong>Sidebar / nav</strong>：V2 不變（filled dark active pill + 白底 cream sidebar）</li>
+    <li><strong>Sheet 內 stop list</strong>：採既有 <code>.ocean-rail-*</code> CSS class 結構 — header「ITINERARY」+ N stops · time-time，每列 <code>time / dot 編號 / icon / name + type+duration / caret</code> 配虛線分隔</li>
+    <li><strong>Active dot</strong>（用餐/景點）：dot border + dot number 上 accent 色（<code>data-accent="true"</code>）— 跟現有 <code>.ocean-rail-item[data-accent]</code> 同 logic</li>
+    <li><strong>Now indicator</strong>：<code>data-now="true"</code> → 6% accent tint bg + accent dot fill + accent border-bottom</li>
+    <li><strong>桌機 day strip</strong>：採 <code>DayNav</code> 桌機 underline tab style — DAY 01 eyebrow + 7/26 Sat date + active border-bottom，sticky 在 sheet body 頂</li>
+    <li><strong>手機 day strip</strong>：採 <code>DayNav</code> mobile pill style — 圓角 box，active 用 filled accent bg + 白字</li>
+    <li><strong>實作對應</strong>：sheet 改 sticky day strip + reuse <code>TimelineRail</code> component（<code>src/components/trip/TimelineRail.tsx</code>），CSS 原 <code>.ocean-rail-*</code> class 全部沿用，只 retheme tokens.css palette → Terracotta</li>
+    <li><strong>沒做</strong>：MAP 全覽 button（桌機 day strip 末有預留位）、weather chip on day pill、tooltip on long-press（這些 DayNav 既有功能，實作時直接 reuse）</li>
+  </ul>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

B-P2 layout refactor 視覺參考集合 — 透過 `tp-claude-design` skill 產出 11 個 HTML mockup 放在 `docs/design-sessions/`，每個檔含桌機 1440 / 1100 / mobile 375 三組 viewport。同時更新 roadmap 加入 Mockup 章節 + 移除 agent-skills plugin。

**11 個 mockup**

- `mockup-index.html` — 入口導覽頁 + task 對照表
- 3 shell variants：Ocean / **Terracotta（locked）** / Magazine
- 7 page routes：
  - `mockup-trip-v2.html` — 行程（無 sheet tabs + trip switcher dropdown + ocean-rail itinerary）
  - `mockup-chat-v2.html` — 聊天（empty hero / 對話中 / 聊出 trip → sheet 展開）
  - `mockup-map-v2.html` — 地圖（cross-trip global view-only，sheet 32vw）
  - `mockup-explore-v2.html` — 探索（search + 儲存池 multi-select）
  - `mockup-login-v2.html` — 登入（OAuth Google/Apple/LINE 真實 SVG / settings）
  - `mockup-signup-v2.html` — 註冊（OAuth + Email + password meter / verify）
  - `mockup-forgot-v2.html` — 忘記密碼（寄連結 / 設新密碼）

**設計關鍵決定**

- Sheet 移除 tabs（功能跟 sidebar nav 重複）→ 改 trip switcher dropdown
- OAuth provider 用真實品牌 SVG logo（Google 4 色 / Apple mono / LINE green）
- /map 跟 /explore 分工：地圖 = passive view、探索 = active search/save/add

**Roadmap 更新**

- `docs/2026-04-24-saas-pivot-roadmap.md` 新增「Mockup HTML」章節（產出索引）
- 相關資源 link 加入 `mockup-index.html`
- Changelog 補一筆 2026-04-24 mockup batch 紀錄

**Cleanup**

- `.claude/settings.json` 移除 `agent-skills@addy-agent-skills` plugin enable
- `~/.claude/settings.json` 移除 `extraKnownMarketplaces.addy-agent-skills`（不在此 PR，是 global config）

## Test plan

純 docs/config PR — 沒 code 變更，無需跑 tests。驗證方式：

- [ ] 在瀏覽器開啟 `docs/design-sessions/mockup-index.html` 確認 3 個 variant card + 7 個 page card 全部顯示
- [ ] 點擊 V2 Terracotta 開啟 `mockup-shell-v2-terracotta.html`，確認三個 viewport（1440 / 1100 / 375）都 render 正常
- [ ] 點擊行程開啟 `mockup-trip-v2.html`，確認 sheet 內無 tabs、有 trip switcher dropdown、ocean-rail itinerary 樣式
- [ ] 點擊登入開啟 `mockup-login-v2.html`，確認 Google/Apple/LINE 三個 provider button 顯示真實 logo SVG
- [ ] 從 index 頁的相對 link 在新位置（design-sessions）正確跳轉到其他 mockup

## Notes

- 跳過 `/ship` 完整 pipeline（tests / coverage / pre-landing review / version bump / CHANGELOG）— 這是 design artifact PR，不是 code PR
- B-P2 OpenSpec change `desktop-3pane-and-nav-layout` 的 §2-§7 實作日後對照 V2 Terracotta mockup
- 5 個 nav 中 4 個（聊天/地圖/探索/登入）是 §6 placeholder pages 的 visual ref，後續 V2-? 階段實作

🤖 Generated with [Claude Code](https://claude.com/claude-code)