### PR TITLE
feat(layout-p2): §2 — AppShell layout primitive

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -1,0 +1,104 @@
+/**
+ * AppShell — B-P2 §2 layout primitive
+ *
+ * 桌機 ≥1024px：CSS Grid 三欄（3-pane）或兩欄（2-pane，無 sheet）
+ *   3-pane: var(--grid-3pane-desktop) = 240px sidebar | 1fr main | min(780px, 40vw) sheet
+ *   2-pane: var(--grid-2pane-desktop) = 240px sidebar | 1fr main
+ *
+ * 手機 <1024px：單欄 main + sticky bottom nav
+ *   sidebar / sheet 仍 render 在 DOM（CSS display:none 隱藏）— 避免 unmount/mount 副作用
+ *   main 自動加 padding-bottom: var(--nav-height-mobile) 讓內容不被 nav 蓋
+ *
+ * 視覺對應：docs/design-sessions/mockup-trip-v2.html
+ */
+import type { ReactNode } from 'react';
+
+export const APP_SHELL_STYLES = `
+.app-shell {
+  display: grid;
+  min-height: 100dvh;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr auto;
+}
+
+.app-shell-sidebar,
+.app-shell-main,
+.app-shell-sheet {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.app-shell-bottom-nav {
+  position: sticky;
+  inset-block-end: 0;
+  z-index: var(--z-sticky-nav);
+}
+
+/* Desktop ≥1024px：grid 兩 / 三欄 */
+@media (min-width: 1024px) {
+  .app-shell[data-layout="3pane"] {
+    grid-template-columns: var(--grid-3pane-desktop);
+    grid-template-rows: 1fr;
+  }
+  .app-shell[data-layout="2pane"] {
+    grid-template-columns: var(--grid-2pane-desktop);
+    grid-template-rows: 1fr;
+  }
+  .app-shell-bottom-nav {
+    display: none;
+  }
+}
+
+/* Mobile <1024px：單欄 + bottom nav 常駐 */
+@media (max-width: 1023px) {
+  .app-shell-sidebar {
+    display: none;
+  }
+  .app-shell-sheet {
+    display: none;
+  }
+  .app-shell-main {
+    padding-bottom: var(--nav-height-mobile);
+  }
+}
+`;
+
+export interface AppShellProps {
+  /** 桌機左側 sidebar slot（mobile 隱藏） */
+  sidebar: ReactNode;
+  /** 主要內容區（必填，所有 viewport 都顯示） */
+  main: ReactNode;
+  /** 桌機右側 sheet slot（可選；不傳即 2-pane；mobile 隱藏） */
+  sheet?: ReactNode;
+  /** 手機底部 nav slot（可選；桌機隱藏） */
+  bottomNav?: ReactNode;
+}
+
+export default function AppShell({ sidebar, main, sheet, bottomNav }: AppShellProps) {
+  const layout = sheet ? '3pane' : '2pane';
+  return (
+    <>
+      <style>{APP_SHELL_STYLES}</style>
+      <div className="app-shell" data-layout={layout} data-testid="app-shell">
+        <aside className="app-shell-sidebar" data-testid="app-shell-sidebar">
+          {sidebar}
+        </aside>
+        <main className="app-shell-main" data-testid="app-shell-main">
+          {main}
+        </main>
+        {sheet && (
+          <aside className="app-shell-sheet" data-testid="app-shell-sheet">
+            {sheet}
+          </aside>
+        )}
+        {bottomNav && (
+          <nav className="app-shell-bottom-nav" data-testid="app-shell-bottom-nav" aria-label="主要功能">
+            {bottomNav}
+          </nav>
+        )}
+      </div>
+    </>
+  );
+}

--- a/tests/unit/__snapshots__/app-shell-snapshot.test.tsx.snap
+++ b/tests/unit/__snapshots__/app-shell-snapshot.test.tsx.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppShell snapshot > §2.6 手機典型（sidebar + main + bottomNav，無 sheet） 1`] = `"<div class="app-shell" data-layout="2pane" data-testid="app-shell"><aside class="app-shell-sidebar" data-testid="app-shell-sidebar"><div class="mock-sidebar">Sidebar</div></aside><main class="app-shell-main" data-testid="app-shell-main"><div class="mock-main">Main</div></main><nav class="app-shell-bottom-nav" data-testid="app-shell-bottom-nav" aria-label="主要功能"><div class="mock-nav">BottomNav</div></nav></div>"`;
+
+exports[`AppShell snapshot > §2.6 桌機 2-pane（sidebar + main，無 sheet 無 bottomNav） 1`] = `"<div class="app-shell" data-layout="2pane" data-testid="app-shell"><aside class="app-shell-sidebar" data-testid="app-shell-sidebar"><div class="mock-sidebar">Sidebar</div></aside><main class="app-shell-main" data-testid="app-shell-main"><div class="mock-main">Main</div></main></div>"`;
+
+exports[`AppShell snapshot > §2.6 桌機 3-pane（sidebar + main + sheet + bottomNav 全 slot） 1`] = `"<div class="app-shell" data-layout="3pane" data-testid="app-shell"><aside class="app-shell-sidebar" data-testid="app-shell-sidebar"><div class="mock-sidebar">Sidebar</div></aside><main class="app-shell-main" data-testid="app-shell-main"><div class="mock-main">Main</div></main><aside class="app-shell-sheet" data-testid="app-shell-sheet"><div class="mock-sheet">Sheet</div></aside><nav class="app-shell-bottom-nav" data-testid="app-shell-bottom-nav" aria-label="主要功能"><div class="mock-nav">BottomNav</div></nav></div>"`;

--- a/tests/unit/app-shell-snapshot.test.tsx
+++ b/tests/unit/app-shell-snapshot.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * AppShell snapshot — B-P2 §2.6
+ *
+ * 三種 layout 結構固定 — snapshot 防止未來無意 regress slot 順序、className、data-layout。
+ * Snapshot 排除 <style> 內容（CSS rules 已由 app-shell.test.tsx 字串斷言覆蓋）。
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import AppShell from '../../src/components/shell/AppShell';
+
+/** 抽出 .app-shell outerHTML（不含 <style> tag）讓 snapshot 聚焦 DOM 結構 */
+function shellMarkup(container: HTMLElement): string {
+  const node = container.querySelector('[data-testid="app-shell"]');
+  return node ? node.outerHTML : '';
+}
+
+describe('AppShell snapshot', () => {
+  it('§2.6 桌機 3-pane（sidebar + main + sheet + bottomNav 全 slot）', () => {
+    const { container } = render(
+      <AppShell
+        sidebar={<div className="mock-sidebar">Sidebar</div>}
+        main={<div className="mock-main">Main</div>}
+        sheet={<div className="mock-sheet">Sheet</div>}
+        bottomNav={<div className="mock-nav">BottomNav</div>}
+      />,
+    );
+    expect(shellMarkup(container)).toMatchSnapshot();
+  });
+
+  it('§2.6 桌機 2-pane（sidebar + main，無 sheet 無 bottomNav）', () => {
+    const { container } = render(
+      <AppShell
+        sidebar={<div className="mock-sidebar">Sidebar</div>}
+        main={<div className="mock-main">Main</div>}
+      />,
+    );
+    expect(shellMarkup(container)).toMatchSnapshot();
+  });
+
+  it('§2.6 手機典型（sidebar + main + bottomNav，無 sheet）', () => {
+    const { container } = render(
+      <AppShell
+        sidebar={<div className="mock-sidebar">Sidebar</div>}
+        main={<div className="mock-main">Main</div>}
+        bottomNav={<div className="mock-nav">BottomNav</div>}
+      />,
+    );
+    expect(shellMarkup(container)).toMatchSnapshot();
+  });
+});

--- a/tests/unit/app-shell.test.tsx
+++ b/tests/unit/app-shell.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * AppShell — B-P2 §2 layout primitive
+ *
+ * 桌機 3-pane (sidebar + main + sheet) / 2-pane (sidebar + main, no sheet)
+ * 手機單欄 + bottom nav，sidebar / sheet 由 CSS media query 隱藏（DOM 仍存在）
+ *
+ * 視覺對應：docs/design-sessions/mockup-trip-v2.html
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import AppShell, { APP_SHELL_STYLES } from '../../src/components/shell/AppShell';
+
+describe('AppShell — render slots + data-layout', () => {
+  it('§2.1 桌機 3-pane：傳 sheet prop 時 data-layout="3pane" + sheet slot 存在', () => {
+    const { getByTestId } = render(
+      <AppShell
+        sidebar={<div>SIDE</div>}
+        main={<div>MAIN</div>}
+        sheet={<div>SHEET</div>}
+      />,
+    );
+    expect(getByTestId('app-shell').getAttribute('data-layout')).toBe('3pane');
+    expect(getByTestId('app-shell-sheet').textContent).toBe('SHEET');
+  });
+
+  it('§2.2 桌機 2-pane：不傳 sheet prop 時 data-layout="2pane" + sheet slot 不存在', () => {
+    const { getByTestId, queryByTestId } = render(
+      <AppShell sidebar={<div>SIDE</div>} main={<div>MAIN</div>} />,
+    );
+    expect(getByTestId('app-shell').getAttribute('data-layout')).toBe('2pane');
+    expect(queryByTestId('app-shell-sheet')).toBeNull();
+  });
+
+  it('§2.3 4 個 slot 都 render 在 DOM 中（手機 hide via CSS，非 unmount）', () => {
+    const { getByTestId } = render(
+      <AppShell
+        sidebar={<div>SIDE</div>}
+        main={<div>MAIN</div>}
+        sheet={<div>SHEET</div>}
+        bottomNav={<div>NAV</div>}
+      />,
+    );
+    expect(getByTestId('app-shell-sidebar').textContent).toBe('SIDE');
+    expect(getByTestId('app-shell-main').textContent).toBe('MAIN');
+    expect(getByTestId('app-shell-sheet').textContent).toBe('SHEET');
+    expect(getByTestId('app-shell-bottom-nav').textContent).toBe('NAV');
+  });
+
+  it('§2.3 沒傳 bottomNav 時不 render bottom nav 元素', () => {
+    const { queryByTestId } = render(
+      <AppShell sidebar={<div>SIDE</div>} main={<div>MAIN</div>} />,
+    );
+    expect(queryByTestId('app-shell-bottom-nav')).toBeNull();
+  });
+});
+
+describe('AppShell — CSS rules（驗 SCOPED_STYLES，jsdom 不套 media query）', () => {
+  it('§2.1 desktop 3-pane 用 var(--grid-3pane-desktop)', () => {
+    expect(APP_SHELL_STYLES).toMatch(
+      /\[data-layout="3pane"\][\s\S]*?grid-template-columns:\s*var\(--grid-3pane-desktop\)/,
+    );
+  });
+
+  it('§2.2 desktop 2-pane 用 var(--grid-2pane-desktop)', () => {
+    expect(APP_SHELL_STYLES).toMatch(
+      /\[data-layout="2pane"\][\s\S]*?grid-template-columns:\s*var\(--grid-2pane-desktop\)/,
+    );
+  });
+
+  it('§2.3 mobile breakpoint <1024px 隱藏 sidebar', () => {
+    // 找 max-width: 1023px 內的 sidebar display: none
+    expect(APP_SHELL_STYLES).toMatch(
+      /@media[^{]*max-width:\s*1023px[\s\S]*?\.app-shell-sidebar[\s\S]*?display:\s*none/,
+    );
+  });
+
+  it('§2.3 mobile breakpoint <1024px 隱藏 sheet', () => {
+    expect(APP_SHELL_STYLES).toMatch(
+      /@media[^{]*max-width:\s*1023px[\s\S]*?\.app-shell-sheet[\s\S]*?display:\s*none/,
+    );
+  });
+
+  it('§2.4 mobile main 有 padding-bottom: var(--nav-height-mobile)', () => {
+    expect(APP_SHELL_STYLES).toMatch(
+      /@media[^{]*max-width:\s*1023px[\s\S]*?\.app-shell-main[\s\S]*?padding-bottom:\s*var\(--nav-height-mobile\)/,
+    );
+  });
+
+  it('§2.3 desktop breakpoint ≥1024px 顯示 3-pane / 2-pane grid', () => {
+    expect(APP_SHELL_STYLES).toMatch(/@media[^{]*min-width:\s*1024px/);
+  });
+});


### PR DESCRIPTION
## Summary

OpenSpec change `desktop-3pane-and-nav-layout` §2 實作。新增 `<AppShell>` layout primitive — 桌機 3-pane / 2-pane CSS Grid + 手機單欄 + sticky bottom nav。

**新增**

- `src/components/shell/AppShell.tsx` — 4 slot props（`sidebar` / `main` / `sheet?` / `bottomNav?`）+ exported `APP_SHELL_STYLES`
  - 桌機 `≥1024px`：傳 `sheet` 自動 `data-layout="3pane"`，不傳則 `2pane`，grid template 從 `tokens.css` 取
  - 手機 `<1024px`：CSS 隱藏 sidebar / sheet（DOM 保留避免 unmount/mount 副作用），main 自動加 `padding-bottom: var(--nav-height-mobile)`
- `tests/unit/app-shell.test.tsx` — 10 tests 覆蓋 §2.1-2.4（slot 渲染 + data-layout 切換 + CSS 規則字串斷言）
- `tests/unit/app-shell-snapshot.test.tsx` — 3 snapshot 覆蓋 §2.6（3-pane / 2-pane / 手機）

**Design ref**

- `docs/design-sessions/mockup-trip-v2.html`（V2 Terracotta，2026-04-24 locked palette）
- 詳細 spec：`openspec/changes/desktop-3pane-and-nav-layout/`

**Test results**

- `npx vitest run tests/unit/app-shell*.test.tsx` → 13/13 pass（10 unit + 3 snapshot）
- `npm run typecheck` → 0 error

## Tasks 進度

- [x] §2.1 桌機 3-pane test
- [x] §2.2 桌機 2-pane test
- [x] §2.3 手機 4 slot 都 render（CSS 隱藏 sidebar/sheet）
- [x] §2.4 手機 main padding-bottom test
- [x] §2.5 AppShell.tsx 實作
- [x] §2.6 snapshot 三種 layout
- [ ] §3 DesktopSidebar（next PR）
- [ ] §4 BottomNavBar（next PR）
- [ ] §5 Page refactor 套 AppShell（next PR）
- [ ] §6 Placeholder pages（next PR）
- [ ] §7 驗證 + ship（最終）

## Test plan

- [x] Unit tests pass：`npx vitest run tests/unit/app-shell*.test.tsx` (13/13)
- [x] Typecheck pass：`npm run typecheck` (0 errors)
- [ ] Smoke：實際 import AppShell 到一個 page 確認 grid template 套上去（§5 page refactor 時驗）
- [ ] E2E：`/design-review` 對照 mockup-trip-v2.html 視覺（§7 驗證階段做）

## Notes

- AppShell 目前還沒被任何 page import — 是純 primitive。§5 才會把 TripPage / ManagePage refactor 套用
- SCOPED_STYLES 用 `<style>` tag 注入，跟既有 DayNav / OceanMap 同 pattern
- `data-testid` 在所有 slot 上方便 §3-§5 整合測試

🤖 Generated with [Claude Code](https://claude.com/claude-code)