### PR TITLE
feat(layout-p2): §4 — BottomNavBar sticky + rename

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -711,7 +711,8 @@ body.dark {
     .ocean-bottom-nav { display: none; }
     @media (max-width: 760px) {
         .ocean-bottom-nav {
-            position: fixed; left: 0; right: 0; bottom: 0;
+            /* B-P2 §4: sticky 讓 nav 在 AppShell grid 內正確定位（取代 PR3 的 fixed） */
+            position: sticky; inset-block-end: 0;
             /* PR3 Q3=B: 5→4 tabs */
             display: grid; grid-template-columns: repeat(4, 1fr);
             background: color-mix(in srgb, var(--color-background) 97%, transparent);

--- a/src/components/shell/BottomNavBar.tsx
+++ b/src/components/shell/BottomNavBar.tsx
@@ -1,14 +1,17 @@
 /**
- * MobileBottomNav — bottom tab bar on ≤760px viewports (PR3: 4-tab route-based)
+ * BottomNavBar — bottom tab bar（B-P2 §4 rename from MobileBottomNav）
  *
- * 4 tabs: 行程 / 地圖 / 訊息 / 更多
+ * 4 tabs: 行程 / 地圖 / 助理 / 更多
  *  - 行程: navigate('/trip/:tripId') + scroll-to-top
  *  - 地圖: navigate('/trip/:tripId/map')
- *  - 訊息: navigate('/manage')
+ *  - 助理: navigate('/manage')
  *  - 更多: onOpenSheet('action-menu')
  *
  * Active state driven by useLocation pathname match.
- * CSS: grid-template-columns: repeat(4, 1fr)
+ * CSS: tokens.css .ocean-bottom-nav — grid-template-columns: repeat(4, 1fr)
+ * position: sticky + inset-block-end: 0 讓 nav 在 AppShell grid 中正確定位。
+ *
+ * Note：5-tab 全站化 + shell-aware active state 留給 §5 page refactor PR。
  */
 
 import clsx from 'clsx';
@@ -17,7 +20,7 @@ import Icon from '../shared/Icon';
 
 type TabKey = 'home' | 'map' | 'message' | 'menu';
 
-interface MobileBottomNavProps {
+interface BottomNavBarProps {
   /** Trip ID used for navigate targets. */
   tripId: string;
   /** Currently-open sheet key (used to highlight 更多 tab). */
@@ -30,12 +33,12 @@ interface MobileBottomNavProps {
   isOnline?: boolean;
 }
 
-export default function MobileBottomNav({
+export default function BottomNavBar({
   tripId,
   activeSheet,
   onOpenSheet,
   isOnline: _isOnline = true,
-}: MobileBottomNavProps) {
+}: BottomNavBarProps) {
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -21,7 +21,7 @@ import { extractPinsFromDay } from '../hooks/useMapData';
 const TripMapRail = lazy(() => import('../components/trip/TripMapRail'));
 import Footer, { type FooterData } from '../components/trip/Footer';
 import OverflowMenu from '../components/trip/OverflowMenu';
-import MobileBottomNav from '../components/trip/MobileBottomNav';
+import BottomNavBar from '../components/shell/BottomNavBar';
 import InfoSheet from '../components/trip/InfoSheet';
 import ToastContainer from '../components/shared/Toast';
 import { FooterArt } from '../components/trip/ThemeArt';
@@ -618,7 +618,7 @@ export default function TripPage() {
 
       {/* Mobile bottom tab bar (≤760px) */}
       {!loading && trip && (
-        <MobileBottomNav
+        <BottomNavBar
           tripId={trip.id}
           activeSheet={activeSheet}
           onOpenSheet={setActiveSheet}

--- a/tests/unit/mobile-bottom-nav-active-route.test.tsx
+++ b/tests/unit/mobile-bottom-nav-active-route.test.tsx
@@ -1,6 +1,6 @@
 /**
  * mobile-bottom-nav-active-route.test.tsx — PR3 review fix #2:
- * MobileBottomNav active-tab 路由 regex 精確度測試
+ * BottomNavBar active-tab 路由 regex 精確度測試
  *
  * 確保：
  * - `/manage/maptour-2026` 不應 active「地圖」（舊 includes('/map') 會誤判）
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import MobileBottomNav from '../../src/components/trip/MobileBottomNav';
+import BottomNavBar from '../../src/components/shell/BottomNavBar';
 
 const mockNavigate = vi.fn();
 
@@ -42,7 +42,7 @@ beforeEach(() => {
 function renderNav(tripId = 'test-trip') {
   return render(
     <MemoryRouter initialEntries={[`/trip/${tripId}`]}>
-      <MobileBottomNav
+      <BottomNavBar
         tripId={tripId}
         activeSheet={null}
         onOpenSheet={vi.fn()}
@@ -58,7 +58,7 @@ function getTabBtn(container: HTMLElement, label: string) {
   );
 }
 
-describe('MobileBottomNav — active-tab route regex precision (PR3 fix #2)', () => {
+describe('BottomNavBar — active-tab route regex precision (PR3 fix #2)', () => {
   it('/trip/okinawa-trip-2026-Ray/map → 地圖 tab active', () => {
     mockPathname = '/trip/okinawa-trip-2026-Ray/map';
     const { container } = renderNav('okinawa-trip-2026-Ray');

--- a/tests/unit/mobile-bottom-nav-entries.test.tsx
+++ b/tests/unit/mobile-bottom-nav-entries.test.tsx
@@ -11,9 +11,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import MobileBottomNav from '../../src/components/trip/MobileBottomNav';
+import BottomNavBar from '../../src/components/shell/BottomNavBar';
 
-function renderNav(overrides: Partial<Parameters<typeof MobileBottomNav>[0]> = {}) {
+function renderNav(overrides: Partial<Parameters<typeof BottomNavBar>[0]> = {}) {
   const defaults = {
     tripId: 'test-trip',
     activeSheet: null,
@@ -23,12 +23,12 @@ function renderNav(overrides: Partial<Parameters<typeof MobileBottomNav>[0]> = {
   };
   return render(
     <MemoryRouter initialEntries={['/trip/test-trip']}>
-      <MobileBottomNav {...defaults} {...overrides} />
+      <BottomNavBar {...defaults} {...overrides} />
     </MemoryRouter>,
   );
 }
 
-describe('MobileBottomNav — 4 個 tab 全部存在（PR3）', () => {
+describe('BottomNavBar — 4 個 tab 全部存在（PR3）', () => {
   it('「行程」tab render 且有 aria-label', () => {
     const { getByRole } = renderNav();
     expect(getByRole('button', { name: '行程' })).toBeTruthy();

--- a/tests/unit/mobile-bottom-nav-optional-clear-sheet.test.tsx
+++ b/tests/unit/mobile-bottom-nav-optional-clear-sheet.test.tsx
@@ -1,13 +1,13 @@
 /**
  * mobile-bottom-nav-optional-clear-sheet.test.tsx — F004 TDD red test
  *
- * 驗證：不傳入 onClearSheet prop 的 MobileBottomNav 不 crash 且正常渲染 4 個 tab。
+ * 驗證：不傳入 onClearSheet prop 的 BottomNavBar 不 crash 且正常渲染 4 個 tab。
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import MobileBottomNav from '../../src/components/trip/MobileBottomNav';
+import BottomNavBar from '../../src/components/shell/BottomNavBar';
 
 const mockNavigate = vi.fn();
 let mockPathname = '/trip/test-trip';
@@ -32,12 +32,12 @@ beforeEach(() => {
   mockPathname = '/trip/test-trip';
 });
 
-describe('MobileBottomNav — onClearSheet optional (F004)', () => {
+describe('BottomNavBar — onClearSheet optional (F004)', () => {
   it('不傳 onClearSheet 不 crash，4 個 tab 正常渲染', () => {
     expect(() => {
       render(
         <MemoryRouter initialEntries={['/trip/test-trip']}>
-          <MobileBottomNav
+          <BottomNavBar
             tripId="test-trip"
             activeSheet={null}
             onOpenSheet={vi.fn()}
@@ -51,7 +51,7 @@ describe('MobileBottomNav — onClearSheet optional (F004)', () => {
   it('不傳 onClearSheet：仍 render nav element', () => {
     const { container } = render(
       <MemoryRouter initialEntries={['/trip/test-trip']}>
-        <MobileBottomNav
+        <BottomNavBar
           tripId="test-trip"
           activeSheet={null}
           onOpenSheet={vi.fn()}
@@ -65,7 +65,7 @@ describe('MobileBottomNav — onClearSheet optional (F004)', () => {
   it('不傳 onClearSheet：仍有 4 個 button', () => {
     const { container } = render(
       <MemoryRouter initialEntries={['/trip/test-trip']}>
-        <MobileBottomNav
+        <BottomNavBar
           tripId="test-trip"
           activeSheet={null}
           onOpenSheet={vi.fn()}
@@ -80,7 +80,7 @@ describe('MobileBottomNav — onClearSheet optional (F004)', () => {
     mockPathname = '/trip/test-trip';
     const { container } = render(
       <MemoryRouter initialEntries={['/trip/test-trip']}>
-        <MobileBottomNav
+        <BottomNavBar
           tripId="test-trip"
           activeSheet={null}
           onOpenSheet={vi.fn()}

--- a/tests/unit/mobile-bottom-nav-route.test.tsx
+++ b/tests/unit/mobile-bottom-nav-route.test.tsx
@@ -1,6 +1,6 @@
 /**
  * mobile-bottom-nav-route.test.tsx — TDD tests for Item 1:
- * MobileBottomNav 重構成 4-tab route-based (Q3=B)
+ * BottomNavBar 重構成 4-tab route-based (Q3=B)
  *
  * Covers:
  * - 4 tabs render: 行程 / 地圖 / 助理 / 更多（F009: 訊息 → 助理）
@@ -15,7 +15,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import MobileBottomNav from '../../src/components/trip/MobileBottomNav';
+import BottomNavBar from '../../src/components/shell/BottomNavBar';
 
 /* ===== mock react-router navigate ===== */
 const mockNavigate = vi.fn();
@@ -39,7 +39,7 @@ beforeEach(() => {
 
 const TRIP_ID = 'test-trip';
 
-function renderNav(overrides: Partial<Parameters<typeof MobileBottomNav>[0]> = {}) {
+function renderNav(overrides: Partial<Parameters<typeof BottomNavBar>[0]> = {}) {
   const defaults = {
     tripId: TRIP_ID,
     activeSheet: null,
@@ -49,12 +49,12 @@ function renderNav(overrides: Partial<Parameters<typeof MobileBottomNav>[0]> = {
   };
   return render(
     <MemoryRouter initialEntries={[`/trip/${TRIP_ID}`]}>
-      <MobileBottomNav {...defaults} {...overrides} />
+      <BottomNavBar {...defaults} {...overrides} />
     </MemoryRouter>,
   );
 }
 
-describe('MobileBottomNav — 4-tab route-based (PR3)', () => {
+describe('BottomNavBar — 4-tab route-based (PR3)', () => {
   it('renders exactly 4 tab buttons', () => {
     const { getAllByRole } = renderNav();
     const btns = getAllByRole('button');

--- a/tests/unit/tokens-bottom-nav-sticky.test.ts
+++ b/tests/unit/tokens-bottom-nav-sticky.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit test — tokens.css .ocean-bottom-nav sticky 定位（B-P2 §4.1-4.2）
+ *
+ * Bottom nav 從 position: fixed 改 position: sticky，讓它能在 AppShell
+ * grid 中正確定位（fixed 會逃出 grid cell，sticky 在 scroll container 內 stick 到底）。
+ * 同時保留 safe-area-inset-bottom 處理 iOS home indicator。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const TOKENS_PATH = path.join(__dirname, '..', '..', 'css', 'tokens.css');
+const TOKENS = fs.readFileSync(TOKENS_PATH, 'utf8');
+
+describe('tokens.css — .ocean-bottom-nav sticky positioning (B-P2 §4)', () => {
+  it('§4.1 .ocean-bottom-nav 用 position: sticky', () => {
+    expect(TOKENS).toMatch(/\.ocean-bottom-nav\s*\{[\s\S]*?position:\s*sticky/);
+  });
+
+  it('§4.1 .ocean-bottom-nav 用 inset-block-end: 0', () => {
+    expect(TOKENS).toMatch(/\.ocean-bottom-nav\s*\{[\s\S]*?inset-block-end:\s*0/);
+  });
+
+  it('§4.1 .ocean-bottom-nav 不再使用 position: fixed', () => {
+    // 排除 .ocean-overflow-menu 等其他 fixed 用法 — 聚焦 .ocean-bottom-nav rule
+    const navRule = TOKENS.match(/\.ocean-bottom-nav\s*\{[\s\S]*?\}/);
+    expect(navRule).not.toBeNull();
+    expect(navRule![0]).not.toMatch(/position:\s*fixed/);
+  });
+
+  it('§4.2 .ocean-bottom-nav 保留 padding-bottom: env(safe-area-inset-bottom)', () => {
+    expect(TOKENS).toMatch(
+      /\.ocean-bottom-nav\s*\{[\s\S]*?padding-bottom:\s*env\(safe-area-inset-bottom\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

OpenSpec change `desktop-3pane-and-nav-layout` §4 實作 — 既有 `MobileBottomNav` 改用 `position: sticky` 讓它能在 AppShell grid 中正確定位，並 rename 成 `BottomNavBar` 移到 `src/components/shell/`。

**變更**

- `css/tokens.css`：`.ocean-bottom-nav` 從 `position: fixed; left: 0; right: 0; bottom: 0` 改 `position: sticky; inset-block-end: 0`
  - `fixed` 會逃出 AppShell grid cell（無法正確定位在 main scroll container bottom）
  - `sticky` 在 scroll container 內 stick 到底，跟 grid row 結構相容
  - 保留 `padding-bottom: env(safe-area-inset-bottom)` 處理 iOS home indicator
- `src/components/trip/MobileBottomNav.tsx` → `src/components/shell/BottomNavBar.tsx`（git mv 保留 history）
  - Component + interface rename
  - Props 完全不變（`tripId` / `activeSheet` / `onOpenSheet` / `onClearSheet` / `isOnline`）
  - 5-tab 全站化 + shell-aware active state 留給 §5 page refactor（跟 sidebar 5 nav 整合）
- `src/pages/TripPage.tsx`：update import + JSX 用新 component name
- `tests/unit/mobile-bottom-nav-*.test.tsx`（4 檔）：update import + component name references
- `tests/unit/tokens-bottom-nav-sticky.test.ts`（新）：4 tests 驗 CSS sticky + safe-area rule

## Tasks 進度

- [x] §4.1 position: sticky（CSS rule test）
- [x] §4.2 padding-bottom: env(safe-area-inset-bottom)（保留）
- [x] §4.3 sticky 語意保證滾動時定位不變（CSS rule 驗證）
- [x] §4.4 無 hide-on-scroll 邏輯需刪除（既有實作本來沒有）
- [x] §4.5 rename MobileBottomNav → BottomNavBar + update imports

## Test results

- Bottom-nav 相關：28/28 pass（4 舊 + 1 新 sticky CSS test）
- 全套 unit tests：645/645 pass
- Typecheck：0 error

## Test plan

- [x] 新 CSS test 驗 `.ocean-bottom-nav { position: sticky; inset-block-end: 0 }`
- [x] 新 CSS test 驗保留 `padding-bottom: env(safe-area-inset-bottom)`
- [x] 既有 4 個 bottom-nav tests 全過（4-tab 行為不變）
- [x] TripPage import path 更新，typecheck 0 error
- [ ] 整合測試：§5 page refactor 階段把 BottomNavBar 塞進 AppShell bottomNav slot 後驗 sticky 行為

## Notes

- **Scope 刻意最小**：只做 CSS sticky + rename。5-tab 對齊 sidebar（聊天/行程/地圖/探索/登入）+ 全站 route-based nav + 取消 tripId 綁定，留到 §5 refactor
- 不依賴 #226 (AppShell) 或 #227 (DesktopSidebar)：三個 PR 各自獨立
- CSS class 名稱 `.ocean-bottom-nav` 保留（memory feedback：ocean-* 前綴歷史保留，refactor 成本太高）

🤖 Generated with [Claude Code](https://claude.com/claude-code)