### PR TITLE
feat(layout-p2): §5+§6 — Pages refactor 套 AppShell + 4 placeholder pages

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -63,6 +63,25 @@ export const APP_SHELL_STYLES = `
     padding-bottom: var(--nav-height-mobile);
   }
 }
+
+/* Print mode：隱藏所有 shell chrome，main 單欄 */
+body.print-mode .app-shell {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+body.print-mode .app-shell-sidebar,
+body.print-mode .app-shell-sheet,
+body.print-mode .app-shell-bottom-nav {
+  display: none;
+}
+body.print-mode .app-shell-main {
+  padding-bottom: 0;
+}
+@media print {
+  .app-shell { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+  .app-shell-sidebar, .app-shell-sheet, .app-shell-bottom-nav { display: none; }
+  .app-shell-main { padding-bottom: 0; }
+}
 `;
 
 export interface AppShellProps {

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -60,6 +60,11 @@ const TripPage = lazyWithRetry(() => import('../pages/TripPage'));
 const TripLayout = lazyWithRetry(() => import('../pages/TripLayout'));
 const StopDetailPage = lazyWithRetry(() => import('../pages/StopDetailPage'));
 const MapPage = lazyWithRetry(() => import('../pages/MapPage'));
+// B-P2 §6 placeholder pages — 視覺對應 docs/design-sessions/mockup-*-v2.html
+const ChatPage = lazyWithRetry(() => import('../pages/ChatPage'));
+const GlobalMapPage = lazyWithRetry(() => import('../pages/GlobalMapPage'));
+const ExplorePage = lazyWithRetry(() => import('../pages/ExplorePage'));
+const LoginPage = lazyWithRetry(() => import('../pages/LoginPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
 const FALLBACK_STYLE = { padding: '2rem', textAlign: 'center' as const };
@@ -88,6 +93,11 @@ if (el) {
               <Route path="/admin/" element={<AdminPage />} />
               <Route path="/manage" element={<ManagePage />} />
               <Route path="/manage/" element={<ManagePage />} />
+              {/* B-P2 §6 placeholder pages — sidebar 5 nav 對應 routes */}
+              <Route path="/chat" element={<ChatPage />} />
+              <Route path="/map" element={<GlobalMapPage />} />
+              <Route path="/explore" element={<ExplorePage />} />
+              <Route path="/login" element={<LoginPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />
                 <Route path="map" element={<MapPage />} />

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,0 +1,47 @@
+/**
+ * ChatPage — B-P2 §6.1 placeholder
+ *
+ * /chat 路由 — 未來全站 AI discovery entry（V2 後實作對話 UI）。
+ * 視覺對應：docs/design-sessions/mockup-chat-v2.html
+ */
+import { Link } from 'react-router-dom';
+
+export default function ChatPage() {
+  return (
+    <div className="tp-placeholder" data-testid="chat-page">
+      <style>{`
+        .tp-placeholder {
+          display: flex; flex-direction: column; align-items: center; justify-content: center;
+          min-height: 60vh; padding: 48px 24px; text-align: center;
+          color: var(--color-foreground);
+        }
+        .tp-placeholder .ph-eyebrow {
+          font-size: var(--font-size-eyebrow); font-weight: 700;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--color-muted); margin-bottom: 12px;
+        }
+        .tp-placeholder h1 {
+          font-size: var(--font-size-title); font-weight: 800;
+          letter-spacing: -0.02em; margin-bottom: 12px;
+        }
+        .tp-placeholder .ph-sub {
+          font-size: var(--font-size-callout); color: var(--color-muted);
+          max-width: 480px; margin-bottom: 28px;
+        }
+        .tp-placeholder .ph-cta {
+          display: inline-flex; align-items: center; gap: 6px;
+          padding: 12px 20px; border-radius: var(--radius-full);
+          background: var(--color-accent); color: var(--color-accent-foreground);
+          text-decoration: none;
+          font: inherit; font-size: 14px; font-weight: 600;
+          min-height: var(--spacing-tap-min);
+        }
+        .tp-placeholder .ph-cta:hover { filter: brightness(0.92); }
+      `}</style>
+      <div className="ph-eyebrow">Coming soon · Phase 3</div>
+      <h1>全站聊天規劃</h1>
+      <p className="ph-sub">AI 對話 entry — 輸入「我想去沖繩」就自動幫你排行程。實作在 Workstream B Phase 3。</p>
+      <Link to="/manage" className="ph-cta">前往行程管理</Link>
+    </div>
+  );
+}

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,0 +1,47 @@
+/**
+ * ExplorePage — B-P2 §6.3 placeholder
+ *
+ * /explore 路由 — 未來 POI 搜尋 + 儲存池 + 加入 trip flow（B-P4）。
+ * 視覺對應：docs/design-sessions/mockup-explore-v2.html
+ */
+import { Link } from 'react-router-dom';
+
+export default function ExplorePage() {
+  return (
+    <div className="tp-placeholder" data-testid="explore-page">
+      <style>{`
+        .tp-placeholder {
+          display: flex; flex-direction: column; align-items: center; justify-content: center;
+          min-height: 60vh; padding: 48px 24px; text-align: center;
+          color: var(--color-foreground);
+        }
+        .tp-placeholder .ph-eyebrow {
+          font-size: var(--font-size-eyebrow); font-weight: 700;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--color-muted); margin-bottom: 12px;
+        }
+        .tp-placeholder h1 {
+          font-size: var(--font-size-title); font-weight: 800;
+          letter-spacing: -0.02em; margin-bottom: 12px;
+        }
+        .tp-placeholder .ph-sub {
+          font-size: var(--font-size-callout); color: var(--color-muted);
+          max-width: 480px; margin-bottom: 28px;
+        }
+        .tp-placeholder .ph-cta {
+          display: inline-flex; align-items: center; gap: 6px;
+          padding: 12px 20px; border-radius: var(--radius-full);
+          background: var(--color-accent); color: var(--color-accent-foreground);
+          text-decoration: none;
+          font: inherit; font-size: 14px; font-weight: 600;
+          min-height: var(--spacing-tap-min);
+        }
+        .tp-placeholder .ph-cta:hover { filter: brightness(0.92); }
+      `}</style>
+      <div className="ph-eyebrow">Coming soon · Phase 4</div>
+      <h1>探索 POI</h1>
+      <p className="ph-sub">搜尋景點、餐廳、飯店 + 儲存池 + 一鍵加入 trip。實作在 Workstream B Phase 4。</p>
+      <Link to="/manage" className="ph-cta">前往行程管理</Link>
+    </div>
+  );
+}

--- a/src/pages/GlobalMapPage.tsx
+++ b/src/pages/GlobalMapPage.tsx
@@ -1,0 +1,48 @@
+/**
+ * GlobalMapPage — B-P2 §6.2 placeholder
+ *
+ * /map 路由 — 全域 cross-trip 地圖（跟 /trip/:tripId/map 不同，後者是 per-trip 的 MapPage）。
+ * view-only：顯示所有 trips 的 polyline + POI marker。未來實作對齊 Mindtrip layout reference。
+ * 視覺對應：docs/design-sessions/mockup-map-v2.html
+ */
+import { Link } from 'react-router-dom';
+
+export default function GlobalMapPage() {
+  return (
+    <div className="tp-placeholder" data-testid="global-map-page">
+      <style>{`
+        .tp-placeholder {
+          display: flex; flex-direction: column; align-items: center; justify-content: center;
+          min-height: 60vh; padding: 48px 24px; text-align: center;
+          color: var(--color-foreground);
+        }
+        .tp-placeholder .ph-eyebrow {
+          font-size: var(--font-size-eyebrow); font-weight: 700;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--color-muted); margin-bottom: 12px;
+        }
+        .tp-placeholder h1 {
+          font-size: var(--font-size-title); font-weight: 800;
+          letter-spacing: -0.02em; margin-bottom: 12px;
+        }
+        .tp-placeholder .ph-sub {
+          font-size: var(--font-size-callout); color: var(--color-muted);
+          max-width: 480px; margin-bottom: 28px;
+        }
+        .tp-placeholder .ph-cta {
+          display: inline-flex; align-items: center; gap: 6px;
+          padding: 12px 20px; border-radius: var(--radius-full);
+          background: var(--color-accent); color: var(--color-accent-foreground);
+          text-decoration: none;
+          font: inherit; font-size: 14px; font-weight: 600;
+          min-height: var(--spacing-tap-min);
+        }
+        .tp-placeholder .ph-cta:hover { filter: brightness(0.92); }
+      `}</style>
+      <div className="ph-eyebrow">Coming soon · Phase 3</div>
+      <h1>所有行程地圖</h1>
+      <p className="ph-sub">跨 trip 的全域地圖 view — 看你所有 trips 的 polyline + POI 分布。跟單一 trip 的地圖（/trip/:id/map）不同。</p>
+      <Link to="/manage" className="ph-cta">前往行程管理</Link>
+    </div>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,48 @@
+/**
+ * LoginPage — B-P2 §6.4 placeholder
+ *
+ * /login 路由 — 現 Phase：導向 Cloudflare Access 認證（既有 /manage 由 Access 保護）。
+ * 未來 V2 OAuth Workstream A 才做完整的 Email + Google/Apple/LINE 登入。
+ * 視覺對應：docs/design-sessions/mockup-login-v2.html（未來實作）
+ */
+import { Link } from 'react-router-dom';
+
+export default function LoginPage() {
+  return (
+    <div className="tp-placeholder" data-testid="login-page">
+      <style>{`
+        .tp-placeholder {
+          display: flex; flex-direction: column; align-items: center; justify-content: center;
+          min-height: 60vh; padding: 48px 24px; text-align: center;
+          color: var(--color-foreground);
+        }
+        .tp-placeholder .ph-eyebrow {
+          font-size: var(--font-size-eyebrow); font-weight: 700;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--color-muted); margin-bottom: 12px;
+        }
+        .tp-placeholder h1 {
+          font-size: var(--font-size-title); font-weight: 800;
+          letter-spacing: -0.02em; margin-bottom: 12px;
+        }
+        .tp-placeholder .ph-sub {
+          font-size: var(--font-size-callout); color: var(--color-muted);
+          max-width: 480px; margin-bottom: 28px;
+        }
+        .tp-placeholder .ph-cta {
+          display: inline-flex; align-items: center; gap: 6px;
+          padding: 12px 20px; border-radius: var(--radius-full);
+          background: var(--color-accent); color: var(--color-accent-foreground);
+          text-decoration: none;
+          font: inherit; font-size: 14px; font-weight: 600;
+          min-height: var(--spacing-tap-min);
+        }
+        .tp-placeholder .ph-cta:hover { filter: brightness(0.92); }
+      `}</style>
+      <div className="ph-eyebrow">Welcome · Tripline</div>
+      <h1>使用 Cloudflare Access 登入</h1>
+      <p className="ph-sub">目前以 Cloudflare Access email 白名單保護 /manage。進入管理頁會觸發 Access 登入 flow。未來 V2 會換成 OAuth（Google / Apple / LINE）。</p>
+      <Link to="/manage" className="ph-cta">前往 /manage 登入</Link>
+    </div>
+  );
+}

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -11,6 +11,8 @@ import { useRequestSSE } from '../hooks/useRequestSSE';
 import { useTripSelector } from '../hooks/useTripSelector';
 import { sanitizeHtml } from '../lib/sanitize';
 import { lsGet, lsSet, LS_KEY_TRIP_PREF } from '../lib/localStorage';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebar from '../components/shell/DesktopSidebar';
 
 import { marked } from 'marked';
 
@@ -596,12 +598,15 @@ export default function ManagePage() {
 
   /* ===== Render ===== */
   return (
-    <div className="manage-wrap">
-      <style>{MANAGE_SCOPED_STYLES}</style>
-      <ManageTopbar
-        onBack={handleClose}
-        tripSelector={tripSelector}
-      />
+    <AppShell
+      sidebar={<DesktopSidebar user={null} />}
+      main={
+        <div className="manage-wrap">
+          <style>{MANAGE_SCOPED_STYLES}</style>
+          <ManageTopbar
+            onBack={handleClose}
+            tripSelector={tripSelector}
+          />
 
         <ToastContainer />
 
@@ -746,7 +751,9 @@ export default function ManagePage() {
             </div>
           )}
         </main>
-    </div>
+        </div>
+      }
+    />
   );
 }
 

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -22,6 +22,8 @@ const TripMapRail = lazy(() => import('../components/trip/TripMapRail'));
 import Footer, { type FooterData } from '../components/trip/Footer';
 import OverflowMenu from '../components/trip/OverflowMenu';
 import BottomNavBar from '../components/shell/BottomNavBar';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebar from '../components/shell/DesktopSidebar';
 import InfoSheet from '../components/trip/InfoSheet';
 import ToastContainer from '../components/shared/Toast';
 import { FooterArt } from '../components/trip/ThemeArt';
@@ -318,6 +320,20 @@ export default function TripPage() {
     [days],
   );
 
+  /* --- Pins for TripMapRail (hoisted out of JSX IIFE for AppShell sheet slot) --- */
+  const mapRailData = useMemo(() => {
+    const allPins = dayNums.flatMap((n) => {
+      const day = allDays[n];
+      return day ? extractPinsFromDay(day).pins : [];
+    });
+    const pinsByDay = new Map<number, typeof allPins>();
+    for (const n of dayNums) {
+      const day = allDays[n];
+      if (day) pinsByDay.set(n, extractPinsFromDay(day).pins);
+    }
+    return { allPins, pinsByDay };
+  }, [dayNums, allDays]);
+
   /* --- Trip start/end scalars for HourlyWeather (T3) --- */
   const tripStart = autoScrollDates[0] ?? null;
   const tripEnd = autoScrollDates[autoScrollDates.length - 1] ?? null;
@@ -511,7 +527,32 @@ export default function TripPage() {
     );
   }
 
+  const sheetContent = !loading && trip ? (
+    <Suspense fallback={null}>
+      <TripMapRail
+        key={trip.id}
+        pins={mapRailData.allPins}
+        tripId={trip.id}
+        pinsByDay={mapRailData.pinsByDay}
+        dark={isDark}
+      />
+    </Suspense>
+  ) : undefined;
+
+  const bottomNavContent = !loading && trip ? (
+    <BottomNavBar
+      tripId={trip.id}
+      activeSheet={activeSheet}
+      onOpenSheet={setActiveSheet}
+      onClearSheet={() => setActiveSheet(null)}
+      isOnline={isOnline}
+    />
+  ) : undefined;
+
   return (
+    <AppShell
+      sidebar={<DesktopSidebar user={null} />}
+      main={
     <div className="ocean-shell">
       <style>{SCOPED_STYLES}</style>
 
@@ -569,63 +610,28 @@ export default function TripPage() {
           </div>
         )}
 
-        {/* Body: 2-col grid (≥1024px: content + sticky map rail; <1024px: single col) */}
-        {!loading && trip && (() => {
-          const allPins = dayNums.flatMap((n) => {
-            const day = allDays[n];
-            return day ? extractPinsFromDay(day).pins : [];
-          });
-          const pinsByDay = new Map<number, typeof allPins>();
-          for (const n of dayNums) {
-            const day = allDays[n];
-            if (day) pinsByDay.set(n, extractPinsFromDay(day).pins);
-          }
-          return (
-            <div className="trip-body">
-              <div className="trip-content" id="tripContent">
-                {dayNums.map((dayNum) => (
-                  <DaySection
-                    key={dayNum}
-                    dayNum={dayNum}
-                    day={allDays[dayNum]}
-                    daySummary={daySummaryMap.get(dayNum)}
-                    tripStart={tripStart}
-                    tripEnd={tripEnd}
-                    themeArt={themeArt}
-                    localToday={localToday}
-                    isActive={dayNum === currentDayNum}
-                    timezone={weatherTimezone}
-                  />
-                ))}
-                <FooterArt dark={isDark} />
-                {footerData && <Footer footer={footerData} />}
-              </div>
-              {/* Desktop Map Rail — right column, sticky, ≥1024px only */}
-              {/* key={trip.id} 確保切換行程時重掛（fitDoneRef reset） */}
-              <Suspense fallback={null}>
-                <TripMapRail
-                  key={trip.id}
-                  pins={allPins}
-                  tripId={trip.id}
-                  pinsByDay={pinsByDay}
-                  dark={isDark}
-                />
-              </Suspense>
-            </div>
-          );
-        })()}
+        {/* Trip content — AppShell main slot（TripMapRail 已移至 sheet slot，BottomNavBar 移至 bottomNav slot）*/}
+        {!loading && trip && (
+          <div className="trip-content" id="tripContent">
+            {dayNums.map((dayNum) => (
+              <DaySection
+                key={dayNum}
+                dayNum={dayNum}
+                day={allDays[dayNum]}
+                daySummary={daySummaryMap.get(dayNum)}
+                tripStart={tripStart}
+                tripEnd={tripEnd}
+                themeArt={themeArt}
+                localToday={localToday}
+                isActive={dayNum === currentDayNum}
+                timezone={weatherTimezone}
+              />
+            ))}
+            <FooterArt dark={isDark} />
+            {footerData && <Footer footer={footerData} />}
+          </div>
+        )}
       </main>
-
-      {/* Mobile bottom tab bar (≤760px) */}
-      {!loading && trip && (
-        <BottomNavBar
-          tripId={trip.id}
-          activeSheet={activeSheet}
-          onOpenSheet={setActiveSheet}
-          onClearSheet={() => setActiveSheet(null)}
-          isOnline={isOnline}
-        />
-      )}
 
       {/* InfoSheet (mobile bottom sheet) */}
       <InfoSheet
@@ -661,5 +667,9 @@ export default function TripPage() {
         </button>
       )}
     </div>
+      }
+      sheet={sheetContent}
+      bottomNav={bottomNavContent}
+    />
   );
 }

--- a/tests/unit/placeholder-pages.test.tsx
+++ b/tests/unit/placeholder-pages.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Placeholder pages smoke tests — B-P2 §6.1-6.4
+ *
+ * 4 個 sidebar nav 對應的 placeholder pages：ChatPage / GlobalMapPage / ExplorePage / LoginPage
+ * 驗證 render 不 crash + 主要 heading + CTA link to /manage
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ChatPage from '../../src/pages/ChatPage';
+import GlobalMapPage from '../../src/pages/GlobalMapPage';
+import ExplorePage from '../../src/pages/ExplorePage';
+import LoginPage from '../../src/pages/LoginPage';
+
+function renderWithRouter(node: React.ReactNode) {
+  return render(<MemoryRouter>{node}</MemoryRouter>);
+}
+
+describe('§6.1 ChatPage placeholder', () => {
+  it('render heading + CTA link to /manage', () => {
+    const { getByTestId, getByRole } = renderWithRouter(<ChatPage />);
+    expect(getByTestId('chat-page')).toBeTruthy();
+    expect(getByRole('heading', { level: 1 }).textContent).toContain('聊天');
+    const cta = getByRole('link') as HTMLAnchorElement;
+    expect(cta.getAttribute('href')).toBe('/manage');
+  });
+});
+
+describe('§6.2 GlobalMapPage placeholder（/map 全域，非 per-trip）', () => {
+  it('render heading + CTA link to /manage', () => {
+    const { getByTestId, getByRole } = renderWithRouter(<GlobalMapPage />);
+    expect(getByTestId('global-map-page')).toBeTruthy();
+    expect(getByRole('heading', { level: 1 }).textContent).toContain('地圖');
+    const cta = getByRole('link') as HTMLAnchorElement;
+    expect(cta.getAttribute('href')).toBe('/manage');
+  });
+});
+
+describe('§6.3 ExplorePage placeholder', () => {
+  it('render heading + CTA link to /manage', () => {
+    const { getByTestId, getByRole } = renderWithRouter(<ExplorePage />);
+    expect(getByTestId('explore-page')).toBeTruthy();
+    expect(getByRole('heading', { level: 1 }).textContent).toContain('探索');
+    const cta = getByRole('link') as HTMLAnchorElement;
+    expect(cta.getAttribute('href')).toBe('/manage');
+  });
+});
+
+describe('§6.4 LoginPage placeholder (Cloudflare Access 過渡期)', () => {
+  it('render 「使用 Cloudflare Access 登入」heading + CTA link to /manage', () => {
+    const { getByTestId, getByRole } = renderWithRouter(<LoginPage />);
+    expect(getByTestId('login-page')).toBeTruthy();
+    const heading = getByRole('heading', { level: 1 }).textContent ?? '';
+    expect(heading).toContain('Cloudflare Access');
+    const cta = getByRole('link') as HTMLAnchorElement;
+    expect(cta.getAttribute('href')).toBe('/manage');
+  });
+});


### PR DESCRIPTION
## Summary

OpenSpec change `desktop-3pane-and-nav-layout` §5 + §6 實作。完成 B-P2 layout refactor 的最後兩步 — 把既有 pages wrap 進 AppShell，並建立 4 個 sidebar nav 對應的 placeholder route。

## Commits（2 個邏輯單元）

### 🔹 Commit 1 · §6 placeholder pages + routes（`b6fd2bf`）

- `src/pages/ChatPage.tsx` — `/chat` placeholder (Phase 3 實作)
- `src/pages/GlobalMapPage.tsx` — `/map` 全域地圖 placeholder (Phase 3 實作)
  - 既有 `src/pages/MapPage.tsx` 保留給 `/trip/:id/map`（per-trip map），不衝突
- `src/pages/ExplorePage.tsx` — `/explore` placeholder (Phase 4 實作)
- `src/pages/LoginPage.tsx` — `/login` placeholder（過渡期 Cloudflare Access CTA，V2 OAuth 做完整 UI）
- `src/entries/main.tsx` — 註冊 4 個 routes
- `tests/unit/placeholder-pages.test.tsx` — 4 smoke tests（render + CTA link to `/manage`）

### 🔹 Commit 2 · §5 Pages 套 AppShell + print mode（`418c529`）

- `src/pages/TripPage.tsx` — wrap in AppShell
  - `sidebar`: `<DesktopSidebar user={null} />`
  - `main`: 既有 `.ocean-shell` 內容（topbar + ocean-page + DayNav + trip-content）
  - `sheet`: `<TripMapRail />` — 從 `.trip-body` 2-col grid 抽到 sheet slot（過渡方案，對齊 mockup 3-pane）
  - `bottomNav`: `<BottomNavBar />`
  - 移除 `.trip-body` 2-col div（AppShell 的 3-pane/2-pane grid 接管）
  - pins 計算 hoist 成 `useMemo mapRailData`（原本 JSX IIFE）
- `src/pages/ManagePage.tsx` — wrap in AppShell
  - `sidebar`: `<DesktopSidebar user={null} />`
  - `main`: 既有 `.manage-wrap` 內容
  - 不傳 sheet / bottomNav（過渡期 ManagePage 無 tripId）
- `src/components/shell/AppShell.tsx` — 補 print mode CSS
  - `body.print-mode` 下隱藏 sidebar/sheet/bottomNav，main `padding-bottom: 0`
  - `@media print` 同上

## Design ref

- `docs/design-sessions/mockup-trip-v2.html`（3-pane sidebar + main + sheet）
- `docs/design-sessions/mockup-chat-v2.html` / `mockup-map-v2.html` / `mockup-explore-v2.html` / `mockup-login-v2.html`

## Test results

- Unit tests: **676/676 pass**（既有 + 4 新 placeholder smoke）
- Typecheck: **0 error**
- Build: **success**（vite build + workbox sw）

## Tasks 進度

- [x] §5.1 TripPage render 於 AppShell 內，sheet slot 傳 TripMapRail（既有 trip-page tests 全過驗證）
- [x] §5.2 ManagePage render 於 AppShell 內，sheet slot null
- [x] §5.3 TripPage.tsx refactor 套 AppShell
- [x] §5.4 ManagePage.tsx refactor 套 AppShell
- [x] §5.5 .trip-body CSS grid 移除，AppShell 接管 layout
- [x] §6.1 ChatPage placeholder
- [x] §6.2 GlobalMapPage placeholder（/map 全域，非 per-trip）
- [x] §6.3 ExplorePage placeholder
- [x] §6.4 LoginPage placeholder（Cloudflare Access 過渡 CTA）
- [x] §6.5 main.tsx 4 routes

## 剩下（§7 驗證 + ship 收尾）

- [ ] §7.1 所有 unit / integration / E2E 測試綠燈 ← unit ✓，E2E 要手動跑 Playwright
- [x] §7.2 typecheck 0 error
- [ ] §7.3 Playwright E2E：桌機 1440px / 平板 1024px / 手機 375px / iOS Safari bottom nav safe area 驗證
- [ ] §7.4 `/design-review` screenshot audit 比對 DESIGN.md + mockup-trip-v2.html
- [ ] §7.5 `/tp-team` pipeline pass（此 PR 走 Build 階段；Review/Test/Ship 走 /ship workflow）
- [ ] §7.6 Staging → prod deploy；若 visual regression flag 需補先 rollback

## Test plan

- [x] Unit tests pass（676/676）
- [x] Typecheck pass（0 error）
- [x] Build pass（vite + workbox）
- [ ] `npm run dev` → 桌機瀏覽 `/manage`、`/trip/:id` 確認 AppShell sidebar 出現、TripMapRail 在 sheet
- [ ] 手機 viewport 375px 瀏覽確認 sidebar / sheet 隱藏，bottom nav 常駐
- [ ] Print mode（`?print=1` 或按 `/tp-team` 指令）確認 sidebar/sheet/nav 隱藏

## Notes

- 同一 PR 放兩個 commit（§6 先、§5 後）— `git bisect` 可隔離問題
- 基於已 merge 的 #226 AppShell / #227 DesktopSidebar / #228 BottomNavBar sticky
- 未來工作：
  1. BottomNavBar 5-tab 全站化（拿掉 tripId binding）→ 可用於 ChatPage/ExplorePage 等
  2. ManagePage DesktopSidebar 傳 user prop（等 V2 auth）
  3. Sheet tabs（想法/地圖/聊天）等功能由 `/opsx:apply url-driven-sheet-state` 處理

🤖 Generated with [Claude Code](https://claude.com/claude-code)