### PR TITLE
feat(layout-p3): URL-driven sheet state — ?sheet=itinerary|ideas|map|chat

### DIFF
--- a/src/components/trip/TripSheet.tsx
+++ b/src/components/trip/TripSheet.tsx
@@ -1,0 +1,142 @@
+/**
+ * TripSheet — URL-driven right sheet for /trip/:id route.
+ *
+ * Reads `?sheet=itinerary|ideas|map|chat` and renders the matching tab content.
+ * Default tab is `map` (matches B-P2 transitional behavior where sheet slot
+ * held TripMapRail directly).
+ */
+import { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  parseSheetParam,
+  setSheetParam,
+  closeSheet,
+  type SheetTab,
+} from '../../lib/trip-url';
+import TripSheetTabs from './TripSheetTabs';
+import type { MapPin } from '../../hooks/useMapData';
+
+const TripMapRail = lazy(() => import('./TripMapRail'));
+
+const DEFAULT_TAB: SheetTab = 'map';
+
+const SCOPED_STYLES = `
+.trip-sheet {
+  display: flex; flex-direction: column;
+  height: 100%;
+  background: var(--color-background);
+  border-left: 1px solid var(--color-border);
+}
+.trip-sheet-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+.trip-sheet-close {
+  width: 32px; height: 32px; border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-muted);
+  display: grid; place-items: center; cursor: pointer;
+  font: inherit; font-size: 14px;
+}
+.trip-sheet-close:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.trip-sheet-body { flex: 1; min-height: 0; overflow: hidden; display: flex; flex-direction: column; }
+.trip-sheet-placeholder {
+  flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 48px 24px; text-align: center; color: var(--color-muted);
+  gap: 8px;
+}
+.trip-sheet-placeholder .eyebrow {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.22em; text-transform: uppercase;
+}
+.trip-sheet-placeholder h3 {
+  font-size: var(--font-size-title3); font-weight: 700; letter-spacing: -0.01em;
+  color: var(--color-foreground);
+}
+.trip-sheet-placeholder p { font-size: var(--font-size-callout); max-width: 320px; }
+`;
+
+export interface TripSheetProps {
+  /** Trip ID for TripMapRail key + data. */
+  tripId: string;
+  /** All pins across days (for map overview). */
+  allPins: MapPin[];
+  /** Per-day pins map. */
+  pinsByDay: Map<number, MapPin[]>;
+  dark?: boolean;
+}
+
+export default function TripSheet({ tripId, allPins, pinsByDay, dark }: TripSheetProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const currentTab: SheetTab = useMemo(() => {
+    return parseSheetParam(location.search) ?? DEFAULT_TAB;
+  }, [location.search]);
+
+  const handleTabChange = useCallback(
+    (tab: SheetTab) => {
+      setSheetParam(navigate, location.pathname, location.search, tab);
+    },
+    [navigate, location.pathname, location.search],
+  );
+
+  const handleClose = useCallback(() => {
+    closeSheet(navigate, location.pathname, location.search);
+  }, [navigate, location.pathname, location.search]);
+
+  return (
+    <div className="trip-sheet" data-testid="trip-sheet">
+      <style>{SCOPED_STYLES}</style>
+      <div className="trip-sheet-header">
+        <button
+          type="button"
+          className="trip-sheet-close"
+          onClick={handleClose}
+          aria-label="關閉 sheet"
+          data-testid="trip-sheet-close"
+        >
+          ✕
+        </button>
+        <TripSheetTabs currentTab={currentTab} onChange={handleTabChange} />
+      </div>
+      <div className="trip-sheet-body">
+        {currentTab === 'map' && (
+          <Suspense fallback={null}>
+            <TripMapRail
+              key={tripId}
+              pins={allPins}
+              tripId={tripId}
+              pinsByDay={pinsByDay}
+              dark={dark}
+            />
+          </Suspense>
+        )}
+        {currentTab === 'itinerary' && (
+          <div className="trip-sheet-placeholder" data-testid="tab-itinerary">
+            <div className="eyebrow">Itinerary</div>
+            <h3>行程已顯示在左側</h3>
+            <p>Timeline 在 main 區已展開，未來會搬到這個 tab（Mindtrip 3-pane 模式）。</p>
+          </div>
+        )}
+        {currentTab === 'ideas' && (
+          <div className="trip-sheet-placeholder" data-testid="tab-ideas">
+            <div className="eyebrow">Coming soon · Phase 4</div>
+            <h3>Ideas layer</h3>
+            <p>POI 儲存池 + drag 進行程。實作在 B-P4 Explore + B-P5 Drag。</p>
+          </div>
+        )}
+        {currentTab === 'chat' && (
+          <div className="trip-sheet-placeholder" data-testid="tab-chat">
+            <div className="eyebrow">Coming soon · Phase 3</div>
+            <h3>Per-trip chat</h3>
+            <p>針對這趟 trip 的 AI 對話。實作在 Workstream V2。</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/trip/TripSheetTabs.tsx
+++ b/src/components/trip/TripSheetTabs.tsx
@@ -1,0 +1,62 @@
+/**
+ * TripSheetTabs — underline tab header for TripSheet.
+ */
+import clsx from 'clsx';
+import { SHEET_TABS, type SheetTab } from '../../lib/trip-url';
+
+const TAB_LABELS: Record<SheetTab, string> = {
+  itinerary: '行程',
+  ideas: '想法',
+  map: '地圖',
+  chat: '聊天',
+};
+
+const SCOPED_STYLES = `
+.trip-sheet-tabs {
+  display: flex; gap: 2px; flex: 1;
+  overflow-x: auto; scrollbar-width: none;
+}
+.trip-sheet-tabs::-webkit-scrollbar { display: none; }
+.trip-sheet-tab {
+  padding: 8px 14px; border: none; background: transparent;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+  font: inherit; font-size: 13px; font-weight: 500;
+  color: var(--color-muted); cursor: pointer;
+  white-space: nowrap; min-height: var(--spacing-tap-min);
+  transition: color 150ms, border-bottom-color 150ms;
+}
+.trip-sheet-tab:hover:not(.is-active) { color: var(--color-foreground); }
+.trip-sheet-tab.is-active {
+  color: var(--color-foreground);
+  border-bottom-color: var(--color-accent);
+  font-weight: 600;
+}
+`;
+
+export interface TripSheetTabsProps {
+  currentTab: SheetTab;
+  onChange: (tab: SheetTab) => void;
+}
+
+export default function TripSheetTabs({ currentTab, onChange }: TripSheetTabsProps) {
+  return (
+    <>
+      <style>{SCOPED_STYLES}</style>
+      <div className="trip-sheet-tabs" role="tablist">
+        {SHEET_TABS.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={currentTab === tab}
+            className={clsx('trip-sheet-tab', currentTab === tab && 'is-active')}
+            onClick={() => onChange(tab)}
+            data-testid={`trip-sheet-tab-${tab}`}
+          >
+            {TAB_LABELS[tab]}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -12,7 +12,7 @@ if ('serviceWorker' in navigator) {
 }
 
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom';
 import { ErrorBoundary } from '../components/shared/ErrorBoundary';
 import { lazy, Suspense, StrictMode } from 'react';
 
@@ -75,6 +75,16 @@ function LegacyRedirect() {
   return <Navigate to={`/trip/${tripId}`} replace />;
 }
 
+/** /trip/:tripId/map → /trip/:tripId?sheet=map（保留其他 query params）*/
+function TripMapRedirect() {
+  const { tripId } = useParams<{ tripId: string }>();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  params.set('sheet', 'map');
+  const query = params.toString();
+  return <Navigate to={`/trip/${tripId ?? ''}${query ? `?${query}` : ''}`} replace />;
+}
+
 const el = document.getElementById('reactRoot');
 if (el) {
   // Reuse existing root on Vite HMR to avoid "createRoot on same container" error
@@ -98,7 +108,7 @@ if (el) {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />
-                <Route path="map" element={<MapPage />} />
+                <Route path="map" element={<TripMapRedirect />} />
                 <Route path="stop/:entryId" element={<StopDetailPage />} />
                 <Route path="stop/:entryId/map" element={<MapPage />} />
               </Route>

--- a/src/lib/trip-url.ts
+++ b/src/lib/trip-url.ts
@@ -1,0 +1,51 @@
+/**
+ * trip-url.ts — per-trip sheet URL driver.
+ *
+ * Sheet state lives in `?sheet=itinerary|ideas|map|chat` so the tab is deep-linkable,
+ * browser back/forward works, and sharing a URL lands on the right pane.
+ *
+ * Invalid `?sheet=` values degrade to `null` (fallback = closed) so URL injection
+ * or stale links can't throw.
+ */
+
+import type { NavigateFunction } from 'react-router-dom';
+
+export const SHEET_TABS = ['itinerary', 'ideas', 'map', 'chat'] as const;
+export type SheetTab = typeof SHEET_TABS[number];
+
+const SHEET_TAB_SET = new Set<string>(SHEET_TABS);
+
+/** Read `?sheet=` from a search string, URLSearchParams, or full URL. */
+export function parseSheetParam(
+  input: string | URLSearchParams,
+): SheetTab | null {
+  const params = typeof input === 'string' ? new URLSearchParams(input.startsWith('?') ? input.slice(1) : input) : input;
+  const raw = params.get('sheet');
+  if (!raw) return null;
+  return SHEET_TAB_SET.has(raw) ? (raw as SheetTab) : null;
+}
+
+/** Push tab to URL via `replace` so tab-switching doesn't bloat history. */
+export function setSheetParam(
+  navigate: NavigateFunction,
+  pathname: string,
+  search: string,
+  tab: SheetTab,
+): void {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  params.set('sheet', tab);
+  const query = params.toString();
+  navigate(query ? `${pathname}?${query}` : pathname, { replace: true });
+}
+
+/** Remove `?sheet=` via `replace`. Preserves other params. */
+export function closeSheet(
+  navigate: NavigateFunction,
+  pathname: string,
+  search: string,
+): void {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  params.delete('sheet');
+  const query = params.toString();
+  navigate(query ? `${pathname}?${query}` : pathname, { replace: true });
+}

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -17,8 +17,8 @@ import DayNav from '../components/trip/DayNav';
 import DaySection from '../components/trip/DaySection';
 import TripSheetContent, { SHEET_TITLES } from '../components/trip/TripSheetContent';
 import { extractPinsFromDay } from '../hooks/useMapData';
-/* F005: lazy load TripMapRail — Leaflet 是重型套件，避免影響首頁 bundle */
-const TripMapRail = lazy(() => import('../components/trip/TripMapRail'));
+/* F005: TripSheet 延遲載（內部 lazy load TripMapRail 以避免 Leaflet 進首頁 bundle）*/
+const TripSheet = lazy(() => import('../components/trip/TripSheet'));
 import Footer, { type FooterData } from '../components/trip/Footer';
 import OverflowMenu from '../components/trip/OverflowMenu';
 import BottomNavBar from '../components/shell/BottomNavBar';
@@ -511,10 +511,9 @@ export default function TripPage() {
 
   const sheetContent = !loading && trip ? (
     <Suspense fallback={null}>
-      <TripMapRail
-        key={trip.id}
-        pins={mapRailData.allPins}
+      <TripSheet
         tripId={trip.id}
+        allPins={mapRailData.allPins}
         pinsByDay={mapRailData.pinsByDay}
         dark={isDark}
       />

--- a/tests/unit/trip-map-rail-fit-reset.test.tsx
+++ b/tests/unit/trip-map-rail-fit-reset.test.tsx
@@ -1,23 +1,22 @@
 /**
  * trip-map-rail-fit-reset.test.tsx — F002 TDD test
  *
- * 策略：用 source-code 驗證 TripPage 對 TripMapRail 加了 key={trip.id}。
- * key={trip.id} 是保證 React 在行程切換時重掛 TripMapRail 的機制，
+ * 策略：用 source-code 驗證 TripSheet 對 TripMapRail 加了 key={tripId}。
+ * key={tripId} 是保證 React 在行程切換時重掛 TripMapRail 的機制，
  * 重掛後 fitDoneRef 從 false 開始，下次 map + pins ready 時 fitBounds 再觸發。
  *
- * 這是 structural guarantee test：若有人移除 key prop，測試立刻失敗。
+ * B-P3 後 TripMapRail 從 TripPage 搬到 TripSheet（sheet slot 的 map tab）。
  */
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-const TRIP_PAGE_SRC = resolve(__dirname, '../../src/pages/TripPage.tsx');
-const source = readFileSync(TRIP_PAGE_SRC, 'utf-8');
+const TRIP_SHEET_SRC = resolve(__dirname, '../../src/components/trip/TripSheet.tsx');
+const source = readFileSync(TRIP_SHEET_SRC, 'utf-8');
 
 describe('F002 — TripMapRail fitDoneRef 跨行程 reset（via key prop）', () => {
-  it('TripPage 對 TripMapRail 設定 key={trip.id} 確保切換行程時重掛', () => {
-    // TripMapRail 需要有 key prop（使用 trip.id）
-    expect(source).toMatch(/TripMapRail[^>]*key=\{[^}]*trip\.id[^}]*\}/s);
+  it('TripSheet 對 TripMapRail 設定 key={tripId} 確保切換行程時重掛', () => {
+    expect(source).toMatch(/TripMapRail[\s\S]*?key=\{tripId\}/);
   });
 });

--- a/tests/unit/trip-sheet.test.tsx
+++ b/tests/unit/trip-sheet.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * TripSheet — URL-driven tab content tests.
+ *
+ * Mock TripMapRail to avoid Leaflet dependency in jsdom.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('../../src/components/trip/TripMapRail', () => ({
+  default: (props: { tripId: string }) => (
+    <div data-testid="mock-trip-map-rail">Mocked TripMapRail for {props.tripId}</div>
+  ),
+}));
+
+import TripSheet from '../../src/components/trip/TripSheet';
+
+function LocationSpy({ onChange }: { onChange: (loc: { pathname: string; search: string }) => void }) {
+  const loc = useLocation();
+  React.useEffect(() => {
+    onChange({ pathname: loc.pathname, search: loc.search });
+  }, [loc.pathname, loc.search, onChange]);
+  return null;
+}
+
+function renderSheet(initialPath: string, onLocChange: (loc: { pathname: string; search: string }) => void = vi.fn()) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/trip/:tripId"
+          element={
+            <>
+              <LocationSpy onChange={onLocChange} />
+              <TripSheet tripId="abc" allPins={[]} pinsByDay={new Map()} />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('TripSheet — URL-driven tab', () => {
+  it('?sheet=ideas renders Ideas placeholder', () => {
+    const { getByTestId } = renderSheet('/trip/abc?sheet=ideas');
+    expect(getByTestId('tab-ideas')).toBeTruthy();
+  });
+
+  it('no sheet param defaults to Map tab (過渡方案，對齊 B-P2 行為)', async () => {
+    const { findByTestId } = renderSheet('/trip/abc');
+    expect(await findByTestId('mock-trip-map-rail')).toBeTruthy();
+  });
+
+  it('?sheet=foo invalid value degrades to default (map) without throwing', async () => {
+    const { findByTestId } = renderSheet('/trip/abc?sheet=haxxor');
+    expect(await findByTestId('mock-trip-map-rail')).toBeTruthy();
+  });
+
+  it('?sheet=itinerary renders Itinerary placeholder', () => {
+    const { getByTestId } = renderSheet('/trip/abc?sheet=itinerary');
+    expect(getByTestId('tab-itinerary')).toBeTruthy();
+  });
+
+  it('?sheet=chat renders Chat placeholder', () => {
+    const { getByTestId } = renderSheet('/trip/abc?sheet=chat');
+    expect(getByTestId('tab-chat')).toBeTruthy();
+  });
+
+  it('clicking a tab updates URL query param (via replace)', () => {
+    const locs: Array<{ pathname: string; search: string }> = [];
+    const { getByTestId } = renderSheet('/trip/abc?sheet=map', (loc) => {
+      locs.push(loc);
+    });
+    fireEvent.click(getByTestId('trip-sheet-tab-ideas'));
+    const last = locs[locs.length - 1];
+    expect(last.search).toContain('sheet=ideas');
+  });
+
+  it('close button clears sheet param', () => {
+    const locs: Array<{ pathname: string; search: string }> = [];
+    const { getByTestId } = renderSheet('/trip/abc?sheet=ideas', (loc) => {
+      locs.push(loc);
+    });
+    fireEvent.click(getByTestId('trip-sheet-close'));
+    const last = locs[locs.length - 1];
+    expect(last.search).not.toContain('sheet=');
+  });
+
+  it('renders 4 tabs with expected labels', () => {
+    const { getByTestId } = renderSheet('/trip/abc?sheet=map');
+    expect(getByTestId('trip-sheet-tab-itinerary').textContent).toBe('行程');
+    expect(getByTestId('trip-sheet-tab-ideas').textContent).toBe('想法');
+    expect(getByTestId('trip-sheet-tab-map').textContent).toBe('地圖');
+    expect(getByTestId('trip-sheet-tab-chat').textContent).toBe('聊天');
+  });
+});

--- a/tests/unit/trip-url.test.ts
+++ b/tests/unit/trip-url.test.ts
@@ -1,0 +1,93 @@
+/**
+ * trip-url.ts — parseSheetParam / setSheetParam / closeSheet tests
+ *
+ * URL query param driver for per-trip right sheet (`?sheet=itinerary|ideas|map|chat`).
+ * Invalid values degrade to null so URL injection can't crash the page.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseSheetParam,
+  setSheetParam,
+  closeSheet,
+  SHEET_TABS,
+  type SheetTab,
+} from '../../src/lib/trip-url';
+
+describe('parseSheetParam', () => {
+  it('returns tab when valid', () => {
+    expect(parseSheetParam('?sheet=ideas')).toBe('ideas');
+    expect(parseSheetParam('?sheet=map')).toBe('map');
+    expect(parseSheetParam('?sheet=itinerary')).toBe('itinerary');
+    expect(parseSheetParam('?sheet=chat')).toBe('chat');
+  });
+
+  it('returns null when param absent', () => {
+    expect(parseSheetParam('')).toBeNull();
+    expect(parseSheetParam('?foo=bar')).toBeNull();
+  });
+
+  it('returns null for invalid value (degrade, not throw)', () => {
+    expect(parseSheetParam('?sheet=haxxor')).toBeNull();
+    expect(parseSheetParam('?sheet=')).toBeNull();
+    expect(parseSheetParam('?sheet=undefined')).toBeNull();
+  });
+
+  it('accepts URLSearchParams instance', () => {
+    const p = new URLSearchParams('sheet=ideas');
+    expect(parseSheetParam(p)).toBe('ideas');
+  });
+});
+
+describe('setSheetParam', () => {
+  it('calls navigate with ?sheet=tab replace:true', () => {
+    const navigate = vi.fn();
+    setSheetParam(navigate, '/trip/abc', '', 'ideas');
+    expect(navigate).toHaveBeenCalledWith('/trip/abc?sheet=ideas', { replace: true });
+  });
+
+  it('preserves existing unrelated query params', () => {
+    const navigate = vi.fn();
+    setSheetParam(navigate, '/trip/abc', '?day=3', 'map');
+    expect(navigate).toHaveBeenCalledWith('/trip/abc?day=3&sheet=map', { replace: true });
+  });
+
+  it('replaces existing sheet param', () => {
+    const navigate = vi.fn();
+    setSheetParam(navigate, '/trip/abc', '?sheet=ideas&day=2', 'map');
+    expect(navigate).toHaveBeenCalledWith(
+      '/trip/abc?sheet=map&day=2',
+      { replace: true },
+    );
+  });
+});
+
+describe('closeSheet', () => {
+  it('removes sheet param via replace', () => {
+    const navigate = vi.fn();
+    closeSheet(navigate, '/trip/abc', '?sheet=ideas');
+    expect(navigate).toHaveBeenCalledWith('/trip/abc', { replace: true });
+  });
+
+  it('preserves other params when removing sheet', () => {
+    const navigate = vi.fn();
+    closeSheet(navigate, '/trip/abc', '?sheet=ideas&day=2');
+    expect(navigate).toHaveBeenCalledWith('/trip/abc?day=2', { replace: true });
+  });
+
+  it('noop navigate when sheet param not present', () => {
+    const navigate = vi.fn();
+    closeSheet(navigate, '/trip/abc', '?day=2');
+    expect(navigate).toHaveBeenCalledWith('/trip/abc?day=2', { replace: true });
+  });
+});
+
+describe('SHEET_TABS constant', () => {
+  it('has exactly 4 tabs in expected order', () => {
+    expect(SHEET_TABS).toEqual(['itinerary', 'ideas', 'map', 'chat']);
+  });
+
+  it('SheetTab type matches tab values', () => {
+    const tab: SheetTab = 'itinerary';
+    expect(SHEET_TABS).toContain(tab);
+  });
+});


### PR DESCRIPTION
## Summary

OpenSpec change `url-driven-sheet-state` 實作。把 per-trip 右側 sheet state 移到 URL query param，可 deep-link / 回上一頁 / 分享特定 tab。

## Changes

**lib/trip-url.ts — URL driver**

- `parseSheetParam` — 從 search string / URLSearchParams 讀 tab，invalid 降 `null`
- `setSheetParam` — 用 `replace:true` 切 tab（tab switch 不 push history）
- `closeSheet` — 移除 sheet param
- Constants: `SHEET_TABS = ['itinerary', 'ideas', 'map', 'chat'] as const`

**components/trip/TripSheet.tsx + TripSheetTabs.tsx**

- Reads `?sheet=` via `useLocation`
- Default tab = `map`（對齊 B-P2 過渡期 sheet 直接放 TripMapRail 的行為）
- Close X 清 sheet param
- Tab content:
  - `map` — wrap 既有 `<TripMapRail>`，保留 `key={tripId}` 跨行程 reset
  - `itinerary` / `ideas` / `chat` — placeholder（timeline 仍在 main；ideas 等 B-P4/P5；chat 等 V2）

**entries/main.tsx — 301 redirect**

- 新增 `<TripMapRedirect />`：`/trip/:id/map` → `/trip/:id?sheet=map`，用 `useParams` + `useLocation` 保留其他 query params
- `/trip/:id/stop/:entryId/map` 仍用 `MapPage`（per-stop 獨立 context）

**pages/TripPage.tsx**

- Sheet slot 改傳 `<TripSheet>`，不再直接 render `TripMapRail`
- `TripMapRail` import 從 TripPage 移除（現在只由 TripSheet 用）

## Tests

- `tests/unit/trip-url.test.ts` — 12 tests（parse / set / close / 邊界）
- `tests/unit/trip-sheet.test.tsx` — 8 tests（4 tab render + click + close + invalid）
- 更新 `trip-map-rail-fit-reset.test.tsx` 檢查 TripSheet.tsx 而非 TripPage.tsx（`key={tripId}` 在 TripSheet 內保留）

**Full suite: 696/696 pass · typecheck 0 error · build success**

## 已知 UX 缺口（留給 B-P6 Polish）

Mobile bottom nav 的「地圖」tab 目前 navigate to `/trip/:id/map` → 被 redirect 到 `?sheet=map`，但 mobile sheet 由 CSS hide — 使用者看不到 map。

可能 fix：
- Mobile 改 open full-screen map modal
- 或 BottomNavBar 5-tab 全站化時「地圖」改跳 `/map`（cross-trip global）

## Tasks 完成度

- [x] §1 URL param helper（1.1-1.4）
- [x] §2 TripSheet component（2.1-2.7 簡化版 — 6/7，§2.5 close 由 TripSheet 內建）
- [x] §3 各 tab content（3.5 Map tab wrap ✓；3.1/3.2-3.4/3.6 placeholder 過渡）
- [x] §4 /trip/:id/map 301 redirect
- [x] §5 TripPage 整合
- [ ] §6 E2E + /design-review（留 B-P6）

## 過渡期 deliberate scope

- Ideas tab full UI（Add modal + 排入行程 PATCH）— 留 B-P4/B-P5 做，現 placeholder
- Itinerary tab content — timeline 仍在 main，tab 顯示提示（Mindtrip 式「main 是 trip list / sheet 是 detail」要等 /manage refactor）

🤖 Generated with [Claude Code](https://claude.com/claude-code)