### PR TITLE
feat(layout-p4): Explore page MVP — Nominatim search + saved pool

### DIFF
--- a/functions/api/poi-search.ts
+++ b/functions/api/poi-search.ts
@@ -1,0 +1,86 @@
+/**
+ * GET /api/poi-search?q=<query>&limit=<n>
+ *
+ * Proxy to OSM Nominatim search. Response has `Cache-Control: public, max-age=86400`
+ * so the Cloudflare edge caches identical queries for 24h automatically.
+ *
+ * Response: { results: Array<{ osm_id, name, address, lat, lng, category }> }
+ * On Nominatim failure: 502 (or 503 if upstream 503) with { error: "upstream_failed" }.
+ */
+import { AppError } from './_errors';
+
+interface NominatimResult {
+  place_id: number;
+  osm_id: number;
+  lat: string;
+  lon: string;
+  display_name: string;
+  name?: string;
+  type?: string;
+  class?: string;
+}
+
+export interface PoiSearchResult {
+  osm_id: number;
+  name: string;
+  address: string;
+  lat: number;
+  lng: number;
+  category: string;
+}
+
+function jsonResponse(data: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8', ...extraHeaders },
+  });
+}
+
+export const onRequestGet: PagesFunction = async (context) => {
+  const url = new URL(context.request.url);
+  const q = url.searchParams.get('q')?.trim();
+  const limitParam = url.searchParams.get('limit');
+
+  if (!q || q.length < 2) {
+    throw new AppError('DATA_VALIDATION', 'query (q) 至少 2 個字元');
+  }
+  if (q.length > 200) {
+    throw new AppError('DATA_VALIDATION', 'query (q) 過長（max 200）');
+  }
+
+  const limit = Math.min(Math.max(parseInt(limitParam ?? '10', 10) || 10, 1), 50);
+
+  const nominatimUrl = new URL('https://nominatim.openstreetmap.org/search');
+  nominatimUrl.searchParams.set('q', q);
+  nominatimUrl.searchParams.set('format', 'json');
+  nominatimUrl.searchParams.set('addressdetails', '1');
+  nominatimUrl.searchParams.set('limit', String(limit));
+
+  const upstream = await fetch(nominatimUrl.toString(), {
+    headers: {
+      'User-Agent': 'Tripline/1.0 (https://trip-planner-dby.pages.dev)',
+      'Accept-Language': 'zh-TW, zh, en',
+    },
+  });
+
+  if (!upstream.ok) {
+    return jsonResponse(
+      { error: 'upstream_failed', status: upstream.status },
+      upstream.status === 503 ? 503 : 502,
+    );
+  }
+
+  const raw = await upstream.json<NominatimResult[]>();
+  const results: PoiSearchResult[] = raw.map((r) => ({
+    osm_id: r.osm_id,
+    name: r.name ?? r.display_name.split(',')[0]?.trim() ?? r.display_name,
+    address: r.display_name,
+    lat: parseFloat(r.lat),
+    lng: parseFloat(r.lon),
+    category: r.class ?? r.type ?? 'poi',
+  }));
+
+  return jsonResponse({ results }, 200, {
+    'Cache-Control': `public, max-age=86400`,
+  });
+};

--- a/functions/api/pois/find-or-create.ts
+++ b/functions/api/pois/find-or-create.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/pois/find-or-create
+ *
+ * Takes POI data (from Nominatim search result or manual form), upserts into
+ * `pois` table via shared findOrCreatePoi helper, returns the poi id.
+ *
+ * Used by /explore save button flow: search → pick → find-or-create → saved-pois POST.
+ */
+import { AppError } from '../_errors';
+import { requireAuth } from '../_auth';
+import { json, parseJsonBody } from '../_utils';
+import { findOrCreatePoi, type FindOrCreatePoiData } from '../_poi';
+import type { Env } from '../_types';
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  requireAuth(context);
+
+  const body = await parseJsonBody<Partial<FindOrCreatePoiData>>(context.request);
+
+  if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+    throw new AppError('DATA_VALIDATION', '缺少或無效的 name');
+  }
+  if (!body.type || typeof body.type !== 'string') {
+    throw new AppError('DATA_VALIDATION', '缺少或無效的 type');
+  }
+
+  const data: FindOrCreatePoiData = {
+    name: body.name.trim(),
+    type: body.type.trim(),
+    description: body.description ?? null,
+    lat: body.lat ?? null,
+    lng: body.lng ?? null,
+    address: body.address ?? null,
+    category: body.category ?? null,
+    source: body.source ?? 'user-explore',
+    country: body.country ?? null,
+  };
+
+  const poiId = await findOrCreatePoi(context.env.DB, data);
+
+  return json({ id: poiId });
+};

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,12 +1,266 @@
-import Placeholder from '../components/shared/Placeholder';
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../lib/apiClient';
+import Icon from '../components/shared/Icon';
+import ToastContainer, { showToast } from '../components/shared/Toast';
+
+interface PoiSearchResult {
+  osm_id: number;
+  name: string;
+  address: string;
+  lat: number;
+  lng: number;
+  category: string;
+}
+
+interface SavedPoiRow {
+  id: number;
+  poiId: number;
+  poiName: string;
+  poiAddress: string | null;
+  poiType: string;
+  savedAt: string;
+  note: string | null;
+}
+
+const SCOPED_STYLES = `
+.explore-wrap {
+  padding: 24px 24px 48px;
+  max-width: 960px; margin: 0 auto;
+  display: flex; flex-direction: column; gap: 24px;
+  color: var(--color-foreground);
+}
+.explore-header h1 {
+  font-size: var(--font-size-title); font-weight: 800;
+  letter-spacing: -0.02em; margin-bottom: 8px;
+}
+.explore-header p { color: var(--color-muted); font-size: var(--font-size-callout); }
+
+.explore-search {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border); border-radius: var(--radius-full);
+  padding: 8px 16px; min-height: 48px;
+  box-shadow: var(--shadow-sm);
+}
+.explore-search:focus-within { border-color: var(--color-accent); }
+.explore-search .search-icon { width: 18px; height: 18px; color: var(--color-muted); flex-shrink: 0; }
+.explore-search input {
+  flex: 1; border: none; background: transparent;
+  font: inherit; font-size: 15px; color: var(--color-foreground);
+  outline: none;
+}
+.explore-search input::placeholder { color: var(--color-muted); }
+.explore-search button {
+  padding: 8px 16px; border-radius: var(--radius-full);
+  background: var(--color-accent); color: var(--color-accent-foreground);
+  border: none; cursor: pointer;
+  font: inherit; font-size: 14px; font-weight: 600;
+  min-height: 36px;
+}
+.explore-search button:hover { filter: brightness(var(--hover-brightness)); }
+.explore-search button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.explore-section h2 {
+  font-size: var(--font-size-title3); font-weight: 700;
+  letter-spacing: -0.01em; margin-bottom: 12px;
+}
+.explore-section .section-meta {
+  font-size: var(--font-size-footnote); color: var(--color-muted); margin-bottom: 12px;
+}
+
+.explore-poi-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px;
+}
+.explore-poi-card {
+  background: var(--color-background); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.explore-poi-card .poi-category {
+  font-size: var(--font-size-eyebrow); font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--color-muted);
+}
+.explore-poi-card .poi-name {
+  font-size: var(--font-size-headline); font-weight: 700;
+  letter-spacing: -0.005em; color: var(--color-foreground);
+}
+.explore-poi-card .poi-address {
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.explore-poi-card .poi-actions { display: flex; gap: 8px; margin-top: 6px; }
+.explore-poi-card button {
+  padding: 6px 12px; border-radius: var(--radius-full);
+  border: 1px solid var(--color-border); background: var(--color-background);
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--color-foreground); cursor: pointer;
+  min-height: 32px;
+}
+.explore-poi-card button:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.explore-poi-card button.saved { background: var(--color-accent); color: var(--color-accent-foreground); border-color: var(--color-accent); }
+.explore-poi-card button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.explore-empty {
+  padding: 24px; text-align: center; color: var(--color-muted);
+  background: var(--color-secondary); border-radius: var(--radius-md);
+  font-size: var(--font-size-callout);
+}
+`;
 
 export default function ExplorePage() {
+  const [query, setQuery] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [results, setResults] = useState<PoiSearchResult[]>([]);
+  const [saved, setSaved] = useState<SavedPoiRow[]>([]);
+  const [savingIds, setSavingIds] = useState<Set<number>>(new Set());
+
+  const loadSaved = useCallback(async () => {
+    try {
+      const rows = await apiFetch<SavedPoiRow[]>('/saved-pois');
+      setSaved(rows);
+    } catch {
+      // silent — could be 401 未登入
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSaved();
+  }, [loadSaved]);
+
+  const savedOsmIds = new Set<string>(saved.map((r) => `${r.poiType}::${r.poiName}`));
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    if (q.length < 2) {
+      showToast('至少輸入 2 個字', 'error', 2000);
+      return;
+    }
+    setSearching(true);
+    try {
+      const resp = await fetch(`/api/poi-search?q=${encodeURIComponent(q)}&limit=20`);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const body = await resp.json() as { results: PoiSearchResult[] };
+      setResults(body.results);
+    } catch (err) {
+      showToast('搜尋失敗（Nominatim 暫時無法連線）', 'error', 3000);
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSave = async (poi: PoiSearchResult) => {
+    setSavingIds((s) => new Set(s).add(poi.osm_id));
+    try {
+      const createResp = await apiFetch<{ id: number }>('/pois/find-or-create', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: poi.name,
+          type: poi.category || 'poi',
+          lat: poi.lat,
+          lng: poi.lng,
+          address: poi.address,
+          category: poi.category,
+          source: 'user-explore',
+        }),
+      });
+      await apiFetch('/saved-pois', {
+        method: 'POST',
+        body: JSON.stringify({ poiId: createResp.id }),
+      });
+      showToast(`已儲存「${poi.name}」`, 'success', 2000);
+      await loadSaved();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '未知錯誤';
+      showToast(`儲存失敗：${msg}`, 'error', 3000);
+    } finally {
+      setSavingIds((s) => {
+        const next = new Set(s);
+        next.delete(poi.osm_id);
+        return next;
+      });
+    }
+  };
+
   return (
-    <Placeholder
-      testId="explore-page"
-      eyebrow="Coming soon · Phase 4"
-      title="探索 POI"
-      body="搜尋景點、餐廳、飯店 + 儲存池 + 一鍵加入 trip。"
-    />
+    <div className="explore-wrap" data-testid="explore-page">
+      <style>{SCOPED_STYLES}</style>
+      <ToastContainer />
+      <header className="explore-header">
+        <h1>探索 POI</h1>
+        <p>搜尋景點、餐廳、飯店（資料來源：OpenStreetMap Nominatim），儲存到池裡下次規劃 trip 一鍵加入。</p>
+      </header>
+
+      <form className="explore-search" onSubmit={handleSearch}>
+        <span className="search-icon">
+          <Icon name="search" />
+        </span>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="搜尋 POI（例：沖繩水族館、首爾燒肉）"
+          data-testid="explore-search-input"
+        />
+        <button type="submit" disabled={searching} data-testid="explore-search-submit">
+          {searching ? '搜尋中...' : '搜尋'}
+        </button>
+      </form>
+
+      {results.length > 0 && (
+        <section className="explore-section" data-testid="explore-results">
+          <h2>搜尋結果</h2>
+          <p className="section-meta">{results.length} 個 POI · 點「+ 儲存」加入儲存池</p>
+          <div className="explore-poi-grid">
+            {results.map((poi) => {
+              const key = `${poi.category || 'poi'}::${poi.name}`;
+              const isSaved = savedOsmIds.has(key);
+              const isSaving = savingIds.has(poi.osm_id);
+              return (
+                <article className="explore-poi-card" key={poi.osm_id}>
+                  <div className="poi-category">{poi.category || 'POI'}</div>
+                  <div className="poi-name">{poi.name}</div>
+                  <div className="poi-address">{poi.address}</div>
+                  <div className="poi-actions">
+                    <button
+                      type="button"
+                      className={isSaved ? 'saved' : ''}
+                      onClick={() => !isSaved && handleSave(poi)}
+                      disabled={isSaving || isSaved}
+                      data-testid={`explore-save-btn-${poi.osm_id}`}
+                    >
+                      {isSaved ? '✓ 已儲存' : isSaving ? '儲存中...' : '+ 儲存'}
+                    </button>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {results.length === 0 && query && !searching && (
+        <div className="explore-empty">沒有找到「{query}」的結果。換個關鍵字試試？</div>
+      )}
+
+      <section className="explore-section" data-testid="explore-saved">
+        <h2>儲存池</h2>
+        <p className="section-meta">{saved.length} 個已儲存 POI</p>
+        {saved.length === 0 ? (
+          <div className="explore-empty">還沒有儲存任何 POI。搜尋上面的關鍵字試試。</div>
+        ) : (
+          <div className="explore-poi-grid">
+            {saved.map((row) => (
+              <article className="explore-poi-card" key={row.id}>
+                <div className="poi-category">{row.poiType}</div>
+                <div className="poi-name">{row.poiName}</div>
+                {row.poiAddress && <div className="poi-address">{row.poiAddress}</div>}
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
   );
 }

--- a/tests/unit/explore-page.test.tsx
+++ b/tests/unit/explore-page.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ExplorePage smoke tests — B-P4 search + saved pool.
+ *
+ * Mock fetch + apiFetch to avoid network calls.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const apiFetchMock = vi.fn<(path: string, init?: RequestInit) => Promise<unknown>>();
+vi.mock('../../src/lib/apiClient', () => ({
+  apiFetch: (path: string, init?: RequestInit) => apiFetchMock(path, init),
+}));
+
+vi.mock('../../src/components/shared/Toast', () => ({
+  default: () => null,
+  showToast: vi.fn(),
+}));
+
+import ExplorePage from '../../src/pages/ExplorePage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ExplorePage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ExplorePage', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path === '/saved-pois') return Promise.resolve([]);
+      return Promise.resolve({});
+    });
+    global.fetch = vi.fn();
+  });
+
+  it('renders search input + empty saved pool initially', async () => {
+    const { getByTestId, findByText } = renderPage();
+    expect(getByTestId('explore-page')).toBeTruthy();
+    expect(getByTestId('explore-search-input')).toBeTruthy();
+    expect(await findByText(/還沒有儲存任何 POI/)).toBeTruthy();
+  });
+
+  it('shows error toast when search query < 2 chars', () => {
+    const { getByTestId } = renderPage();
+    const input = getByTestId('explore-search-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.click(getByTestId('explore-search-submit'));
+    // showToast is mocked — assertion via no network call
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('calls /api/poi-search on valid submit + renders results', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [
+          { osm_id: 1, name: '沖繩水族館', address: 'Japan', lat: 26.6941, lng: 127.8778, category: 'tourism' },
+        ],
+      }),
+    });
+    const { getByTestId, findByText } = renderPage();
+    const input = getByTestId('explore-search-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '沖繩' } });
+    fireEvent.click(getByTestId('explore-search-submit'));
+    expect(await findByText('沖繩水族館')).toBeTruthy();
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/poi-search?q='));
+  });
+
+  it('save button triggers find-or-create + saved-pois POST', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{ osm_id: 99, name: 'Test POI', address: 'Addr', lat: 25, lng: 121, category: 'food' }],
+      }),
+    });
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path === '/saved-pois') return Promise.resolve([]);
+      if (path === '/pois/find-or-create') return Promise.resolve({ id: 42 });
+      return Promise.resolve({});
+    });
+
+    const { getByTestId, findByTestId } = renderPage();
+    const input = getByTestId('explore-search-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Test' } });
+    fireEvent.click(getByTestId('explore-search-submit'));
+
+    const saveBtn = await findByTestId('explore-save-btn-99');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/pois/find-or-create',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/saved-pois',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+});

--- a/tests/unit/placeholder-pages.test.tsx
+++ b/tests/unit/placeholder-pages.test.tsx
@@ -9,7 +9,6 @@ import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ChatPage from '../../src/pages/ChatPage';
 import GlobalMapPage from '../../src/pages/GlobalMapPage';
-import ExplorePage from '../../src/pages/ExplorePage';
 import LoginPage from '../../src/pages/LoginPage';
 
 function renderWithRouter(node: React.ReactNode) {
@@ -31,16 +30,6 @@ describe('GlobalMapPage placeholder（/map 全域，非 per-trip）', () => {
     const { getByTestId, getByRole } = renderWithRouter(<GlobalMapPage />);
     expect(getByTestId('global-map-page')).toBeTruthy();
     expect(getByRole('heading', { level: 1 }).textContent).toContain('地圖');
-    const cta = getByRole('link') as HTMLAnchorElement;
-    expect(cta.getAttribute('href')).toBe('/manage');
-  });
-});
-
-describe('ExplorePage placeholder', () => {
-  it('render heading + CTA link to /manage', () => {
-    const { getByTestId, getByRole } = renderWithRouter(<ExplorePage />);
-    expect(getByTestId('explore-page')).toBeTruthy();
-    expect(getByRole('heading', { level: 1 }).textContent).toContain('探索');
     const cta = getByRole('link') as HTMLAnchorElement;
     expect(cta.getAttribute('href')).toBe('/manage');
   });


### PR DESCRIPTION
## Summary

OpenSpec change `explore-nav-with-poi-search` **MVP**。搜尋 POI + 儲存池功能。

## Changes

- `functions/api/poi-search.ts` — `GET /api/poi-search?q=&limit=` Nominatim proxy
- `functions/api/pois/find-or-create.ts` — `POST` upsert，用既有 race-safe helper
- `src/pages/ExplorePage.tsx` — 取代 placeholder：search bar + results grid + saved pool
  - Save flow: find-or-create → saved-pois POST
  - Mount 時自動載儲存池

## Tests

- `tests/unit/explore-page.test.tsx` — 4 tests（render / guard / search / save flow）
- Full suite: **679/679 pass** · typecheck 0 error · build success

## Deliberate MVP scope cut（留 iteration）

- Category chips (Nominatim 原 category 顯示)
- Multi-select + 批次加到 trip
- TripPickerModal（「加到 trip」button 暫不接）
- 3-column 桌機 / 手機 tab 切換
- Playwright E2E（留 B-P6）

## Known deps

- Nominatim 中文品質未實測（留 B-P6 spike）— CF edge 24h cache 減輕 upstream 負擔

🤖 Generated with [Claude Code](https://claude.com/claude-code)