### PR TITLE
fix(trip-sheet): map tab 高度只佔 1/4 — sticky 在 sheet 內失效

### DIFF
--- a/src/components/trip/TripSheet.tsx
+++ b/src/components/trip/TripSheet.tsx
@@ -57,6 +57,16 @@ const SCOPED_STYLES = `
   color: var(--color-foreground);
 }
 .trip-sheet-placeholder p { font-size: var(--font-size-callout); max-width: 320px; }
+
+/* TripMapRail 預設 .trip-map-rail 是給 main column scroll context 用：
+   position:sticky + height:calc(100dvh - var(--spacing-nav-h))。
+   放進 sheet 後 sticky 失效，且 100dvh 不等於 sheet 可用高度 → map 視覺只佔約 1/4。
+   用 specificity (0,2,0) 覆蓋成 static + 撐滿 sheet body。 */
+.trip-sheet-body .trip-map-rail {
+  position: static;
+  top: auto;
+  height: 100%;
+}
 `;
 
 export interface TripSheetProps {

--- a/tests/unit/trip-sheet-map-height-override.test.tsx
+++ b/tests/unit/trip-sheet-map-height-override.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * TripSheet — sheet map height override 測試
+ *
+ * Bug：TripMapRail root .trip-map-rail 用 position:sticky + height:calc(100dvh - var(--spacing-nav-h))，
+ * 此 CSS 假設 parent 是 main column scroll context。放進 TripSheet 後：
+ * - sticky 在 sheet 內失效（sheet 是 grid cell，沒有 scrolling ancestor 提供 sticky 容器）
+ * - calc(100dvh - nav-h) 是相對 viewport，不是 sheet 可用高度 → map 視覺上只佔約 1/4
+ *
+ * Fix：TripSheet SCOPED_STYLES 加 `.trip-sheet-body .trip-map-rail` override，
+ * specificity (0,2,0) > .trip-map-rail (0,1,0)，覆蓋成 position:static + height:100%。
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TripSheet from '../../src/components/trip/TripSheet';
+
+function renderSheet(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <TripSheet tripId="test-trip" allPins={[]} pinsByDay={new Map()} />
+    </MemoryRouter>,
+  );
+}
+
+describe('TripSheet — sheet body 對 .trip-map-rail 的高度 override', () => {
+  it('SCOPED_STYLES 應包含 .trip-sheet-body .trip-map-rail position:static 覆蓋（撤掉 sticky）', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    const styleNode = container.querySelector('style');
+    expect(styleNode, '應有 inline <style>').toBeTruthy();
+    const css = styleNode!.textContent ?? '';
+    expect(css, '需有 .trip-sheet-body .trip-map-rail 選擇器（specificity > .trip-map-rail）').toMatch(
+      /\.trip-sheet-body\s+\.trip-map-rail/,
+    );
+    expect(css).toMatch(/position:\s*static/);
+  });
+
+  it('SCOPED_STYLES 應將 .trip-map-rail 高度覆蓋為 100%（取代 calc(100dvh - nav-h)）', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    const css = container.querySelector('style')?.textContent ?? '';
+    expect(css).toMatch(/\.trip-sheet-body\s+\.trip-map-rail[^}]*height:\s*100%/);
+  });
+
+  it('SCOPED_STYLES 應將 .trip-map-rail 的 top sticky offset 重設為 auto', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    const css = container.querySelector('style')?.textContent ?? '';
+    expect(css).toMatch(/\.trip-sheet-body\s+\.trip-map-rail[^}]*top:\s*auto/);
+  });
+});


### PR DESCRIPTION
## Summary

`TripSheet` 的 `?sheet=map` tab 視覺上只佔 sheet 上 1/4，剩下都是空白。

### Root cause

`TripMapRail` 的 root `.trip-map-rail` 預設 CSS：

```css
.trip-map-rail {
  position: sticky;
  top: var(--spacing-nav-h);
  height: calc(100dvh - var(--spacing-nav-h));
}
```

是給 **main column scroll context** 設計的（左欄 timeline scrollable、右欄 map sticky 跟著 scroll）。B-P3 (#231) 把 `TripMapRail` 從 `TripPage` main 移進 `TripSheet` 後：

1. `position: sticky` 在 sheet 裡**沒有 scrolling ancestor** → 退化成 static，但 `top: var(--spacing-nav-h)` 仍是 offset
2. `height: calc(100dvh - var(--spacing-nav-h))` ≠ sheet 可用高度（sheet 用 flex，不是 viewport）→ map 容器算出來的高度跟 sheet body 不對齊，視覺上只填 1/4

### Fix

`TripSheet` `SCOPED_STYLES` 加 specificity `(0,2,0)` 的 override（高於 singleton 的 `(0,1,0)`）：

```css
.trip-sheet-body .trip-map-rail {
  position: static;
  top: auto;
  height: 100%;
}
```

`TripMapRail` 自己不動 — 在 main column 的舊用法（如果還有）不受影響。

## Test plan

- [x] `tests/unit/trip-sheet-map-height-override.test.tsx` 3 cases TDD red→green
- [x] `npx vitest run` 712 pass（+3）
- [x] `npm run typecheck` clean
- [ ] Post-merge：本機 dev server 開 `?sheet=map` 視覺確認 map 撐滿 sheet body（map tile 應從 header 下緣到 sheet 底部）

🤖 Generated with [Claude Code](https://claude.com/claude-code)