### PR TITLE
fix(routing): /manage redirects 跳 default trip — 移除 public/_redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,0 @@
-/manage   /index.html  200
-/manage/  /index.html  200
-/admin    /index.html  200
-/admin/   /index.html  200

--- a/tests/unit/build-script-manage-admin-folders.test.ts
+++ b/tests/unit/build-script-manage-admin-folders.test.ts
@@ -1,0 +1,38 @@
+/**
+ * package.json `build` script invariant test
+ *
+ * /manage 和 /admin 是 SPA route，但 server 看到 `/manage`（沒 trailing slash）
+ * 時會走 standard "directory canonical 308" 行為 → 必須有 `dist/manage/`
+ * directory 存在才會 308 to `/manage/`（而不是 308 to `/` → SPA LegacyRedirect
+ * → default trip）。
+ *
+ * 修復脈絡：PR #239 移除 public/_redirects 後，唯一保證 `/manage` 不再
+ * 跳 default trip 的條件是 build 必須複製 dist/index.html 到 dist/manage/
+ * 和 dist/admin/。本 test 防止未來重構 build script 時誤刪此段。
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('build script — dist/manage and dist/admin folder creation', () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'),
+  ) as { scripts: { build: string } };
+
+  it('build script 必須在 vite build 後複製 index.html 到 dist/manage 和 dist/admin', () => {
+    const script = pkg.scripts.build;
+    // 要含 manage 和 admin 兩個目錄名
+    expect(script, 'build script 缺 manage 目錄複製').toContain("'manage'");
+    expect(script, 'build script 缺 admin 目錄複製').toContain("'admin'");
+    // 要含 copyFileSync + index.html
+    expect(script, 'build script 缺 index.html 複製邏輯').toMatch(/copyFileSync.*index\.html/);
+  });
+
+  it('public/_redirects 必須不存在（會引發 wrangler canonical-strip → 308 to /）', () => {
+    const p = path.resolve(__dirname, '../../public/_redirects');
+    expect(
+      fs.existsSync(p),
+      'public/_redirects 被加回會破壞 /manage redirect — 詳見 PR #239 commit message',
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

修長期存在的 `/manage` redirect bug：本機 + production 上 `/manage` 都被 server 308 to `/`，瀏覽器 follow 後 SPA `<LegacyRedirect>` 把 `/` 轉 `/trip/${DEFAULT_TRIP}` — 使用者**完全看不到 ManagePage**。

## Root cause

`public/_redirects` 寫的是 200 rewrite：

```
/manage   /index.html  200
/manage/  /index.html  200
/admin    /index.html  200
/admin/   /index.html  200
```

但 wrangler / CF Pages 對這 4 條的處理：

1. **Line 2 + 4**（trailing-slash）— 被識別為 infinite-loop（target `/index.html` 會被 canonical-strip 變回 `/manage/`，撞同一條），**ignored**
2. **Line 1 + 3**（no slash）— `parsed valid`，但 rewrite 到 `/index.html` 後 wrangler 對 `/index.html` 做 canonical-strip → `/` → 結果是 **308 → /**（不是 200 + index.html content）

→ `/manage` HTTP 308 + Location: `/` → SPA `<LegacyRedirect>` (`<Route path="*">`) → `/trip/${DEFAULT_TRIP}`

## Fix

移除 `public/_redirects`。`build` script 仍會 `copy dist/index.html → dist/{manage,admin}/index.html`，wrangler 對 `/manage`（沒 trailing slash）走 **standard directory canonical 308 → `/manage/`** → serve dir index.html 200 OK → React Router render `<ManagePage>`。

## Verified（local wrangler pages dev）

```
=== route smoke ===
  /                                             200
  /manage                                       308 → /manage/   ← was: 308 → /
  /manage/                                      200              ← reachable now
  /admin                                        308 → /admin/    ← was: 308 → /
  /admin/                                       200
  /chat                                         200 (unchanged)
  /explore                                      200 (unchanged)
  /login                                        200 (unchanged)
  /map                                          200 (unchanged)
  /trip/okinawa-trip-2026-Ray                   200 (unchanged)
  /trip/okinawa-trip-2026-Ray/map               200 (unchanged)
  /api/oauth/spike                              200 (unchanged)
  /api/poi-search?q=test                        200 (unchanged)
  /api/my-trips                                 200 (unchanged)
```

## Test plan

- [x] `npx vitest run` 712 pass，無 regression
- [x] `npx wrangler pages dev` 本機 13 routes smoke test 全綠（見上）
- [ ] **Post-merge 重要**：preview deploy URL 確認 `/manage` 真的 render ManagePage（不是 跳 default trip）—— prod CF Pages 對 directory canonical redirect 行為若跟 wrangler dev 不同，要 follow-up
- [ ] Post-merge：實機在 `https://trip-planner-dby.pages.dev/manage` 觀察（會被 Cloudflare Access 擋下來 → 登入後應 render ManagePage real UI）

## 相關

- 本 session retro `docs/2026-04-25-session-retro.md` 把這個列為 environmental note；本 PR fix 之
- 第三輪 QA 用 prod data 跑時發現

🤖 Generated with [Claude Code](https://claude.com/claude-code)