### PR TITLE
fix(a11y): TripSheet 補完 ARIA tabs pattern 關聯（B-P6 task 5.4）

### DIFF
--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -31,7 +31,7 @@
 - [ ] 5.1 安裝 axe-core / playwright-axe
 - [ ] 5.2 跑 axe 驗所有 page，修 violation
 - [ ] 5.3 鍵盤 tab order 驗證（手動 + Playwright test）
-- [ ] 5.4 ARIA labels 補齊 sidebar / bottom nav / sheet tabs
+- [x] 5.4 ARIA labels 補齊 sidebar / bottom nav / sheet tabs
 - [ ] 5.5 Focus trap in modal / sheet 正確
 - [ ] 5.6 Color contrast 對照 Terracotta palette（用 Chrome DevTools Lighthouse 驗）
 

--- a/src/components/trip/TripSheet.tsx
+++ b/src/components/trip/TripSheet.tsx
@@ -11,6 +11,8 @@ import {
   parseSheetParam,
   setSheetParam,
   closeSheet,
+  sheetPanelId,
+  sheetTabId,
   type SheetTab,
 } from '../../lib/trip-url';
 import TripSheetTabs from './TripSheetTabs';
@@ -114,38 +116,63 @@ export default function TripSheet({ tripId, allPins, pinsByDay, dark }: TripShee
         <TripSheetTabs currentTab={currentTab} onChange={handleTabChange} />
       </div>
       <div className="trip-sheet-body">
-        {currentTab === 'map' && (
-          <Suspense fallback={null}>
-            <TripMapRail
-              key={tripId}
-              pins={allPins}
-              tripId={tripId}
-              pinsByDay={pinsByDay}
-              dark={dark}
-            />
-          </Suspense>
-        )}
-        {currentTab === 'itinerary' && (
-          <div className="trip-sheet-placeholder" data-testid="tab-itinerary">
-            <div className="eyebrow">Itinerary</div>
-            <h3>行程已顯示在左側</h3>
-            <p>Timeline 在 main 區已展開，未來會搬到這個 tab（Mindtrip 3-pane 模式）。</p>
-          </div>
-        )}
-        {currentTab === 'ideas' && (
-          <div className="trip-sheet-placeholder" data-testid="tab-ideas">
-            <div className="eyebrow">Coming soon · Phase 4</div>
-            <h3>Ideas layer</h3>
-            <p>POI 儲存池 + drag 進行程。實作在 B-P4 Explore + B-P5 Drag。</p>
-          </div>
-        )}
-        {currentTab === 'chat' && (
-          <div className="trip-sheet-placeholder" data-testid="tab-chat">
-            <div className="eyebrow">Coming soon · Phase 3</div>
-            <h3>Per-trip chat</h3>
-            <p>針對這趟 trip 的 AI 對話。實作在 Workstream V2。</p>
-          </div>
-        )}
+        {/* ARIA tabs pattern: 4 個 tabpanel 都 in DOM 用 hidden 切換，
+            這樣每個 tab 的 aria-controls 永遠 resolve 到實際 element。
+            map tab 內仍 conditional mount 維持 lazy + key={tripId} 重 init 行為。 */}
+        <div
+          role="tabpanel"
+          id={sheetPanelId('itinerary')}
+          aria-labelledby={sheetTabId('itinerary')}
+          hidden={currentTab !== 'itinerary'}
+          className="trip-sheet-placeholder"
+          data-testid="tab-itinerary"
+        >
+          <div className="eyebrow">Itinerary</div>
+          <h3>行程已顯示在左側</h3>
+          <p>Timeline 在 main 區已展開，未來會搬到這個 tab（Mindtrip 3-pane 模式）。</p>
+        </div>
+        <div
+          role="tabpanel"
+          id={sheetPanelId('ideas')}
+          aria-labelledby={sheetTabId('ideas')}
+          hidden={currentTab !== 'ideas'}
+          className="trip-sheet-placeholder"
+          data-testid="tab-ideas"
+        >
+          <div className="eyebrow">Coming soon · Phase 4</div>
+          <h3>Ideas layer</h3>
+          <p>POI 儲存池 + drag 進行程。實作在 B-P4 Explore + B-P5 Drag。</p>
+        </div>
+        <div
+          role="tabpanel"
+          id={sheetPanelId('map')}
+          aria-labelledby={sheetTabId('map')}
+          hidden={currentTab !== 'map'}
+        >
+          {currentTab === 'map' && (
+            <Suspense fallback={null}>
+              <TripMapRail
+                key={tripId}
+                pins={allPins}
+                tripId={tripId}
+                pinsByDay={pinsByDay}
+                dark={dark}
+              />
+            </Suspense>
+          )}
+        </div>
+        <div
+          role="tabpanel"
+          id={sheetPanelId('chat')}
+          aria-labelledby={sheetTabId('chat')}
+          hidden={currentTab !== 'chat'}
+          className="trip-sheet-placeholder"
+          data-testid="tab-chat"
+        >
+          <div className="eyebrow">Coming soon · Phase 3</div>
+          <h3>Per-trip chat</h3>
+          <p>針對這趟 trip 的 AI 對話。實作在 Workstream V2。</p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/trip/TripSheetTabs.tsx
+++ b/src/components/trip/TripSheetTabs.tsx
@@ -2,7 +2,7 @@
  * TripSheetTabs — underline tab header for TripSheet.
  */
 import clsx from 'clsx';
-import { SHEET_TABS, type SheetTab } from '../../lib/trip-url';
+import { SHEET_TABS, sheetPanelId, sheetTabId, type SheetTab } from '../../lib/trip-url';
 
 const TAB_LABELS: Record<SheetTab, string> = {
   itinerary: '行程',
@@ -46,9 +46,12 @@ export default function TripSheetTabs({ currentTab, onChange }: TripSheetTabsPro
         {SHEET_TABS.map((tab) => (
           <button
             key={tab}
+            id={sheetTabId(tab)}
             type="button"
             role="tab"
             aria-selected={currentTab === tab}
+            aria-controls={sheetPanelId(tab)}
+            tabIndex={currentTab === tab ? 0 : -1}
             className={clsx('trip-sheet-tab', currentTab === tab && 'is-active')}
             onClick={() => onChange(tab)}
             data-testid={`trip-sheet-tab-${tab}`}

--- a/src/lib/trip-url.ts
+++ b/src/lib/trip-url.ts
@@ -15,6 +15,11 @@ export type SheetTab = typeof SHEET_TABS[number];
 
 const SHEET_TAB_SET = new Set<string>(SHEET_TABS);
 
+/** ARIA tabs pattern：tab `id` 與 tabpanel `aria-labelledby` 配對。 */
+export const sheetTabId = (tab: SheetTab): string => `trip-sheet-tab-${tab}`;
+/** ARIA tabs pattern：tabpanel `id` 與 tab `aria-controls` 配對。 */
+export const sheetPanelId = (tab: SheetTab): string => `trip-sheet-panel-${tab}`;
+
 /** Read `?sheet=` from a search string, URLSearchParams, or full URL. */
 export function parseSheetParam(
   input: string | URLSearchParams,

--- a/tests/unit/trip-sheet-tabs-aria.test.tsx
+++ b/tests/unit/trip-sheet-tabs-aria.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * TripSheet — ARIA tabs pattern 完整關聯測試（B-P6 task 5.4）
+ *
+ * WCAG ARIA tabs pattern 要求：
+ * - 每個 [role=tab] 需 unique `id` + `aria-controls` 指向對應 tabpanel
+ * - 每個 [role=tabpanel] 需 unique `id` + `aria-labelledby` 指回對應 tab
+ * - 全部 4 個 tabpanel 都該存在 DOM 用 `hidden` 切換（不能 conditional unmount，否則 aria-controls 指向不存在的 element）
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TripSheet from '../../src/components/trip/TripSheet';
+import { SHEET_TABS, sheetTabId, sheetPanelId } from '../../src/lib/trip-url';
+
+function renderSheet(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <TripSheet tripId="test-trip" allPins={[]} pinsByDay={new Map()} />
+    </MemoryRouter>,
+  );
+}
+
+describe('TripSheet — ARIA tabs pattern 完整關聯', () => {
+  it('每個 role=tab 都有 id + aria-controls 指向對應 tabpanel', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs.length).toBe(SHEET_TABS.length);
+    SHEET_TABS.forEach((tab) => {
+      const el = container.querySelector(`#${sheetTabId(tab)}`);
+      expect(el, `tab ${tab} 必須有 id=${sheetTabId(tab)}`).toBeTruthy();
+      expect(el?.getAttribute('aria-controls')).toBe(sheetPanelId(tab));
+    });
+  });
+
+  it('每個 role=tabpanel 都有 id + aria-labelledby 指回對應 tab', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    const panels = container.querySelectorAll('[role="tabpanel"]');
+    expect(panels.length, '4 個 tabpanel 都要 in DOM (用 hidden 切換)').toBe(SHEET_TABS.length);
+    SHEET_TABS.forEach((tab) => {
+      const el = container.querySelector(`#${sheetPanelId(tab)}`);
+      expect(el, `panel ${tab} 必須有 id=${sheetPanelId(tab)}`).toBeTruthy();
+      expect(el?.getAttribute('role')).toBe('tabpanel');
+      expect(el?.getAttribute('aria-labelledby')).toBe(sheetTabId(tab));
+    });
+  });
+
+  it('當 ?sheet=map 時 only map panel 不 hidden，其他 3 個 hidden', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=map');
+    SHEET_TABS.forEach((tab) => {
+      const el = container.querySelector(`#${sheetPanelId(tab)}`);
+      const hidden = el?.hasAttribute('hidden');
+      if (tab === 'map') {
+        expect(hidden, 'active panel (map) 不該 hidden').toBe(false);
+      } else {
+        expect(hidden, `inactive panel (${tab}) 該 hidden`).toBe(true);
+      }
+    });
+  });
+
+  it('aria-selected 對應當前 tab', () => {
+    const { container } = renderSheet('/trip/test-trip?sheet=ideas');
+    const ideasTab = container.querySelector(`#${sheetTabId('ideas')}`);
+    expect(ideasTab?.getAttribute('aria-selected')).toBe('true');
+    const mapTab = container.querySelector(`#${sheetTabId('map')}`);
+    expect(mapTab?.getAttribute('aria-selected')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

修 \`TripSheetTabs\` + \`TripSheet\` 的 ARIA tabs pattern 關聯，補齊 [WCAG ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) 完整契約。

對應 \`layout-refactor-polish-qa\` task 5.4 — sheet tabs 部分（sidebar / bottom nav 之前已 OK）。

## Before

- ✅ \`role="tablist"\` / \`role="tab"\` / \`aria-selected\`
- ❌ tab 缺 \`id\`
- ❌ tab 缺 \`aria-controls\` 指向 tabpanel
- ❌ 4 個 tab content 用 conditional render（\`{currentTab === X && ...}\`），inactive panel 不在 DOM
- ❌ 缺 \`role="tabpanel"\` + \`aria-labelledby\` 回指 tab

## After

- ✅ \`src/lib/trip-url.ts\` export \`sheetTabId(tab)\` / \`sheetPanelId(tab)\` helper（共用 ID convention）
- ✅ tab：加 \`id\` + \`aria-controls\` + \`tabIndex\` (-1 for inactive，roving tabindex)
- ✅ TripSheet body：4 個 tabpanel 都 in DOM 用 \`hidden\` 切換，aria-controls 永遠 resolve 到實際 element
- ✅ map tab 內仍 conditional mount \`<Suspense>\`+\`<TripMapRail>\` 維持 lazy load + \`key={tripId}\` 重 init

## Test plan

- [x] \`tests/unit/trip-sheet-tabs-aria.test.tsx\` 4 cases TDD red→green：
  - tab id + aria-controls 配對
  - tabpanel id + aria-labelledby 配對
  - hidden 屬性正確切換（active panel 不 hidden）
  - aria-selected 對應當前 tab
- [x] Full suite \`npx vitest run\` 718 pass，無 regression
- [x] \`tsc --noEmit\` clean
- [ ] Post-merge：用 axe-core 跑 \`/trip/:id?sheet=map\` 驗無 ARIA violation

## OpenSpec

\`openspec/changes/layout-refactor-polish-qa/tasks.md\` 5.4 mark [x]。

🤖 Generated with [Claude Code](https://claude.com/claude-code)