### PR TITLE
feat(b-p5): Ideas tab real UI（task 4.1）— text-based promote + delete

### DIFF
--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -21,7 +21,7 @@
 
 ## 4. Empty states + loading
 
-- [ ] 4.1 Ideas tab empty state 統一文案 + Mindtrip 風 Add card 視覺 — deferred (B-P5 Ideas tab real UI 先做才能設計 empty state)
+- [x] 4.1 Ideas tab empty state 統一文案 + Mindtrip 風 Add card 視覺 — `src/components/trip/IdeasTabContent.tsx` real UI（fetch GET `/api/trip-ideas?tripId=...`，空狀態「還沒收藏任何想法。從探索頁加入想法，或直接從聊天告訴 AI」+ idea card 含 promote / delete / promoted 標記）；TripSheet ideas tab 從 placeholder 改 lazy load IdeasTabContent；8 cases unit test pass
 - [x] 4.2 Explore 搜尋空結果 empty state
 - [x] 4.3 Saved pool empty state
 - [ ] 4.4 Loading skeleton（可選，lightweight）取代 spinner — declined optional，暫保留 spinner

--- a/src/components/trip/IdeasTabContent.tsx
+++ b/src/components/trip/IdeasTabContent.tsx
@@ -1,0 +1,229 @@
+/**
+ * IdeasTabContent — TripSheet 的 Ideas tab real UI（B-P5 / B-P6 task 4.1）
+ *
+ * Source: GET /api/trip-ideas?tripId=...
+ * Actions:
+ *   - 「+ 加入 Day N」text-based promote — POST /api/trips/:id/days/:num/entries +
+ *     PATCH /api/trip-ideas/:id { promotedToEntryId }
+ *   - 「移除」DELETE /api/trip-ideas/:id（soft delete via archived_at）
+ *
+ * 不含：dnd-kit drag interaction（B-P5 後續 PR）/ conflict modal / undo toast / smart placement
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiFetchRaw } from '../../lib/apiClient';
+import type { TripIdea } from '../../types/api';
+
+const SCOPED_STYLES = `
+.tp-ideas-list {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 16px;
+}
+.tp-idea-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: var(--color-background);
+  display: flex; flex-direction: column; gap: 6px;
+}
+.tp-idea-card-header {
+  display: flex; align-items: flex-start; gap: 8px;
+  font-size: var(--font-size-callout); font-weight: 600;
+  color: var(--color-foreground);
+}
+.tp-idea-card-meta {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+.tp-idea-card-actions {
+  display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px;
+}
+.tp-idea-card-action {
+  font: inherit; font-size: var(--font-size-footnote); font-weight: 500;
+  padding: 4px 10px; border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-background); color: var(--color-foreground);
+  cursor: pointer; min-height: var(--spacing-tap-min);
+}
+.tp-idea-card-action:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.tp-idea-card-action.is-danger:hover { border-color: #dc2626; color: #dc2626; }
+.tp-idea-card-action[disabled] { opacity: 0.5; cursor: not-allowed; }
+.tp-idea-card-promoted {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+  font-style: italic;
+}
+.tp-ideas-empty {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 8px; padding: 48px 24px; text-align: center;
+  color: var(--color-muted);
+}
+.tp-ideas-empty .eyebrow {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.22em; text-transform: uppercase;
+}
+.tp-ideas-empty h3 {
+  font-size: var(--font-size-title3); font-weight: 700;
+  letter-spacing: -0.01em; color: var(--color-foreground);
+}
+.tp-ideas-empty p { font-size: var(--font-size-callout); max-width: 320px; }
+.tp-ideas-status {
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+  padding: 8px 16px;
+}
+`;
+
+export interface IdeasTabContentProps {
+  tripId: string;
+  /** Optional：days available for promote dropdown。空陣列時 promote 隱藏。 */
+  dayNumbers?: number[];
+}
+
+export default function IdeasTabContent({ tripId, dayNumbers = [] }: IdeasTabContentProps) {
+  const [ideas, setIdeas] = useState<TripIdea[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  const reload = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await apiFetchRaw(`/api/trip-ideas?tripId=${encodeURIComponent(tripId)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { ideas?: TripIdea[] };
+      setIdeas(data.ideas ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? '無法載入 ideas');
+      setIdeas([]);
+    }
+  }, [tripId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      setBusyId(id);
+      try {
+        const res = await apiFetchRaw(`/api/trip-ideas/${id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error(`DELETE failed: HTTP ${res.status}`);
+        await reload();
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [reload],
+  );
+
+  const handlePromote = useCallback(
+    async (idea: TripIdea, dayNum: number) => {
+      if (!idea.poiId) {
+        setError('此 idea 未綁 POI，無法直接 promote');
+        return;
+      }
+      setBusyId(idea.id);
+      try {
+        const create = await apiFetchRaw(
+          `/api/trips/${encodeURIComponent(tripId)}/days/${dayNum}/entries`,
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ poiId: idea.poiId, name: idea.title }),
+          },
+        );
+        if (!create.ok) throw new Error(`promote create entry failed: ${create.status}`);
+        const created = (await create.json()) as { id?: number };
+        if (created?.id) {
+          await apiFetchRaw(`/api/trip-ideas/${idea.id}`, {
+            method: 'PATCH',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ promotedToEntryId: created.id }),
+          });
+        }
+        await reload();
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [reload, tripId],
+  );
+
+  const activeIdeas = useMemo(
+    () => (ideas ?? []).filter((i) => !i.archivedAt),
+    [ideas],
+  );
+
+  return (
+    <>
+      <style>{SCOPED_STYLES}</style>
+      {error && <div className="tp-ideas-status" role="alert" data-testid="ideas-error">⚠ {error}</div>}
+      {ideas === null && (
+        <div className="tp-ideas-status" data-testid="ideas-loading">載入中…</div>
+      )}
+      {ideas !== null && activeIdeas.length === 0 && (
+        <div className="tp-ideas-empty" data-testid="ideas-empty">
+          <div className="eyebrow">Ideas</div>
+          <h3>還沒收藏任何想法</h3>
+          <p>從探索頁加入想法，或直接從聊天告訴 AI「想加 X 餐廳」。</p>
+        </div>
+      )}
+      {ideas !== null && activeIdeas.length > 0 && (
+        <ul className="tp-ideas-list" data-testid="ideas-list">
+          {activeIdeas.map((idea) => (
+            <li key={idea.id} className="tp-idea-card">
+              <div className="tp-idea-card-header">{idea.title}</div>
+              {(idea.poiAddress || idea.poiType) && (
+                <div className="tp-idea-card-meta">
+                  {idea.poiType && <span>{idea.poiType}</span>}
+                  {idea.poiAddress && <span>{idea.poiAddress}</span>}
+                </div>
+              )}
+              {idea.note && <div className="tp-idea-card-meta">{idea.note}</div>}
+              {idea.promotedToEntryId ? (
+                <div className="tp-idea-card-promoted">
+                  ✓ 已排入 entry #{idea.promotedToEntryId}
+                </div>
+              ) : (
+                <div className="tp-idea-card-actions">
+                  {idea.poiId && dayNumbers.length > 0 ? (
+                    dayNumbers.map((d) => (
+                      <button
+                        key={d}
+                        type="button"
+                        className="tp-idea-card-action"
+                        disabled={busyId === idea.id}
+                        onClick={() => handlePromote(idea, d)}
+                        data-testid={`ideas-promote-${idea.id}-day-${d}`}
+                      >
+                        + Day {d}
+                      </button>
+                    ))
+                  ) : (
+                    !idea.poiId && (
+                      <span className="tp-idea-card-meta">（自由文字 idea，需先綁 POI 才能 promote）</span>
+                    )
+                  )}
+                  <button
+                    type="button"
+                    className="tp-idea-card-action is-danger"
+                    disabled={busyId === idea.id}
+                    onClick={() => handleDelete(idea.id)}
+                    data-testid={`ideas-delete-${idea.id}`}
+                  >
+                    移除
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/components/trip/TripSheet.tsx
+++ b/src/components/trip/TripSheet.tsx
@@ -19,6 +19,7 @@ import TripSheetTabs from './TripSheetTabs';
 import type { MapPin } from '../../hooks/useMapData';
 
 const TripMapRail = lazy(() => import('./TripMapRail'));
+const IdeasTabContent = lazy(() => import('./IdeasTabContent'));
 
 const DEFAULT_TAB: SheetTab = 'map';
 
@@ -136,12 +137,17 @@ export default function TripSheet({ tripId, allPins, pinsByDay, dark }: TripShee
           id={sheetPanelId('ideas')}
           aria-labelledby={sheetTabId('ideas')}
           hidden={currentTab !== 'ideas'}
-          className="trip-sheet-placeholder"
           data-testid="tab-ideas"
+          style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
         >
-          <div className="eyebrow">Coming soon · Phase 4</div>
-          <h3>Ideas layer</h3>
-          <p>POI 儲存池 + drag 進行程。實作在 B-P4 Explore + B-P5 Drag。</p>
+          {currentTab === 'ideas' && (
+            <Suspense fallback={<div className="trip-sheet-placeholder">載入中…</div>}>
+              <IdeasTabContent
+                tripId={tripId}
+                dayNumbers={Array.from(pinsByDay.keys()).sort((a, b) => a - b)}
+              />
+            </Suspense>
+          )}
         </div>
         <div
           role="tabpanel"

--- a/tests/unit/ideas-tab-content.test.tsx
+++ b/tests/unit/ideas-tab-content.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * IdeasTabContent — TripSheet Ideas tab real UI 測試（B-P5 / B-P6 task 4.1）
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import IdeasTabContent from '../../src/components/trip/IdeasTabContent';
+
+vi.mock('../../src/lib/apiClient', () => ({
+  apiFetchRaw: vi.fn(),
+}));
+
+import { apiFetchRaw } from '../../src/lib/apiClient';
+const apiMock = vi.mocked(apiFetchRaw);
+
+const SAMPLE_IDEA = {
+  id: 1,
+  tripId: 'test-trip',
+  poiId: 100,
+  title: '美麗海水族館',
+  poiAddress: '沖繩縣國頭郡',
+  poiType: 'sight',
+  addedAt: '2026-04-25',
+  promotedToEntryId: null,
+  archivedAt: null,
+};
+
+const PROMOTED_IDEA = { ...SAMPLE_IDEA, id: 2, title: '已排入', promotedToEntryId: 999 };
+
+function mockGet(ideas: typeof SAMPLE_IDEA[]) {
+  apiMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ ideas }),
+  } as Response);
+}
+
+beforeEach(() => {
+  apiMock.mockReset();
+});
+
+describe('IdeasTabContent', () => {
+  it('initial render shows loading state', () => {
+    apiMock.mockImplementation(() => new Promise(() => {})); // never resolve
+    render(<IdeasTabContent tripId="test-trip" />);
+    expect(screen.getByTestId('ideas-loading')).toBeTruthy();
+  });
+
+  it('empty fetch shows 「還沒收藏任何想法」 empty state', async () => {
+    mockGet([]);
+    render(<IdeasTabContent tripId="test-trip" />);
+    await waitFor(() => expect(screen.getByTestId('ideas-empty')).toBeTruthy());
+    expect(screen.getByText('還沒收藏任何想法')).toBeTruthy();
+  });
+
+  it('non-empty fetch renders idea cards', async () => {
+    mockGet([SAMPLE_IDEA]);
+    render(<IdeasTabContent tripId="test-trip" dayNumbers={[1, 2]} />);
+    await waitFor(() => expect(screen.getByTestId('ideas-list')).toBeTruthy());
+    expect(screen.getByText('美麗海水族館')).toBeTruthy();
+    expect(screen.getByText('sight')).toBeTruthy();
+  });
+
+  it('promote button POST entries + PATCH idea promotedToEntryId', async () => {
+    mockGet([SAMPLE_IDEA]);
+    apiMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 555 }),
+    } as Response); // POST entry
+    apiMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response); // PATCH idea
+    apiMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ideas: [{ ...SAMPLE_IDEA, promotedToEntryId: 555 }] }),
+    } as Response); // reload
+
+    render(<IdeasTabContent tripId="test-trip" dayNumbers={[1, 2]} />);
+    await waitFor(() => screen.getByTestId('ideas-promote-1-day-1'));
+    fireEvent.click(screen.getByTestId('ideas-promote-1-day-1'));
+
+    await waitFor(() => {
+      const calls = apiMock.mock.calls.map((c) => c[0]);
+      expect(calls).toContain('/api/trips/test-trip/days/1/entries');
+      expect(calls).toContain('/api/trip-ideas/1');
+    });
+  });
+
+  it('delete button calls DELETE then reload', async () => {
+    mockGet([SAMPLE_IDEA]);
+    apiMock.mockResolvedValueOnce({ ok: true, status: 204, json: async () => ({}) } as Response); // DELETE
+    apiMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ ideas: [] }) } as Response); // reload
+
+    render(<IdeasTabContent tripId="test-trip" />);
+    await waitFor(() => screen.getByTestId('ideas-delete-1'));
+    fireEvent.click(screen.getByTestId('ideas-delete-1'));
+
+    await waitFor(() => {
+      const lastCall = apiMock.mock.calls.find((c) => c[0] === '/api/trip-ideas/1');
+      expect(lastCall?.[1]?.method).toBe('DELETE');
+    });
+  });
+
+  it('promoted idea shows 「已排入 entry #N」 instead of action buttons', async () => {
+    mockGet([PROMOTED_IDEA]);
+    render(<IdeasTabContent tripId="test-trip" dayNumbers={[1]} />);
+    await waitFor(() => screen.getByText(/已排入 entry #999/));
+    // 不該有 promote button
+    expect(screen.queryByTestId('ideas-promote-2-day-1')).toBeNull();
+  });
+
+  it('fetch error renders error banner', async () => {
+    apiMock.mockRejectedValueOnce(new Error('Network down'));
+    render(<IdeasTabContent tripId="test-trip" />);
+    await waitFor(() => expect(screen.getByTestId('ideas-error')).toBeTruthy());
+    expect(screen.getByText(/Network down/)).toBeTruthy();
+  });
+
+  it('idea without poiId shows 「需先綁 POI」 hint, no promote buttons', async () => {
+    mockGet([{ ...SAMPLE_IDEA, poiId: null, title: '自由文字 idea' }]);
+    render(<IdeasTabContent tripId="test-trip" dayNumbers={[1, 2]} />);
+    await waitFor(() => screen.getByText('自由文字 idea'));
+    expect(screen.getByText(/需先綁 POI 才能 promote/)).toBeTruthy();
+    expect(screen.queryByTestId('ideas-promote-1-day-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Sprint A part 1/4 — \`TripSheet\` Ideas tab 從 placeholder 改 real fetch + list。對應 \`layout-refactor-polish-qa\` task 4.1。

剩 Sprint A 3 task：6.6 dnd-kit lazy / 7.2 desktop e2e / 7.5 drag 4 scenarios — 都依賴 dnd-kit drag implementation，留下個 PR。

## Behavior

| State | UI |
|-------|----|
| Loading | 「載入中…」 |
| Empty fetch | 「Ideas / 還沒收藏任何想法 / 從探索頁加入想法，或直接從聊天告訴 AI」|
| With ideas | List of cards，含 title / poi meta / note / actions |
| Idea has \`poiId\` + dayNumbers given | 「+ Day 1」「+ Day 2」 ...「移除」buttons |
| Idea no \`poiId\` | 「（自由文字 idea，需先綁 POI 才能 promote）」hint + 「移除」 |
| Idea \`promotedToEntryId\` set | 「✓ 已排入 entry #N」 取代 actions |
| Fetch error | role=alert「⚠ Network down」 banner |

## Promote flow (text-based, 不含 drag)

1. POST \`/api/trips/:id/days/:num/entries\` body \`{ poiId, name }\`
2. 若 created.id 存在 → PATCH \`/api/trip-ideas/:idea_id\` body \`{ promotedToEntryId }\`
3. Reload list

不含：conflict modal / undo toast / smart placement（V2 範疇）

## TripSheet wire-up

\`ideas\` tab placeholder 改 lazy load \`IdeasTabContent\`。從既有 \`pinsByDay\` Map derive \`dayNumbers\`，不需新 prop。

## Test

\`tests/unit/ideas-tab-content.test.tsx\` 8 cases TDD pass：
- initial loading state
- empty fetch shows empty state
- non-empty renders list
- promote button POST + PATCH sequence
- delete button DELETE + reload
- promoted idea hides actions
- fetch error renders banner
- no-poi idea shows hint, no promote buttons

Full suite 752 → **764 pass (+12)** + tsc clean。

## OpenSpec progress

\`layout-refactor-polish-qa\` 39/53 → 40/53 (75.5%)。

## Test plan

- [x] 8 cases TDD pass
- [x] full vitest pass + tsc clean
- [ ] Post-merge：本機 dev server，創建一個 trip-idea + 切到 \`?sheet=ideas\` 看 list 渲染
- [ ] Post-merge：點「+ Day 1」看 entry 建立 + idea 標 promoted
- [ ] Post-merge：實機 trip 加 idea + verify 行為

🤖 Generated with [Claude Code](https://claude.com/claude-code)