### PR TITLE
feat(b-p5): dnd-kit drag-to-promote — Sprint A part 2/4（task 6.6）

### DIFF
--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -42,7 +42,7 @@
 - [x] 6.3 新 page 必達標；legacy page 列 open issue 不 block — `lighthouserc.json` URL 加 `/explore` + `/login`（task 9.3 起的新 IA 含 5 nav routes，public routes 全測；`/manage` 因 Cloudflare Access 擋 unauthenticated lighthouse run，留 staging headless 用 service token bypass 是 next sprint）
 - [x] 6.4 Bundle analyzer：各 chunk < 300 KB gzipped — baseline recorded in CHANGELOG 2.3.0：html2pdf 914K (lazy on PDF export), vendor 219K, OceanMap 168K (lazy), sentry 134K, TripPage 79K (lazy)。Page-level chunks 全 < 300K raw（gzipped ~ raw/3）
 - [x] 6.5 Code split：Explore / Map / Chat lazy load — `src/entries/main.tsx:57-66` 全部 page 走 `lazyWithRetry()`
-- [ ] 6.6 dnd-kit lazy load（只 Ideas/Itinerary tab 需要時載入）— N/A（`@dnd-kit/*` 未安裝；屬 B-P5 Ideas drag scope，本 workstream 不做）
+- [x] 6.6 dnd-kit lazy load（只 Ideas/Itinerary tab 需要時載入）— `npm i @dnd-kit/core@^6.3.1 @dnd-kit/sortable@^10 @dnd-kit/modifiers@^9`；IdeasTabContent 是 `lazy(() => import('./IdeasTabContent'))` (TripSheet)，dnd-kit 透過 IdeasTabContent transitive lazy import — chrome devtools Network 確認只在 `?sheet=ideas` active 時 chunk load
 
 ## 7. Playwright E2E matrix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tripline",
       "version": "1.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@sentry/react": "^10.45.0",
         "@sentry/vite-plugin": "^5.1.1",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1867,6 +1870,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -10141,7 +10211,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "wrangler": "^4.80.0"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@sentry/react": "^10.45.0",
     "@sentry/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^6.0.1",

--- a/src/components/trip/IdeasTabContent.tsx
+++ b/src/components/trip/IdeasTabContent.tsx
@@ -1,15 +1,30 @@
 /**
- * IdeasTabContent — TripSheet 的 Ideas tab real UI（B-P5 / B-P6 task 4.1）
+ * IdeasTabContent — TripSheet 的 Ideas tab real UI（B-P5 / B-P6 task 4.1 + 6.6）
  *
  * Source: GET /api/trip-ideas?tripId=...
  * Actions:
- *   - 「+ 加入 Day N」text-based promote — POST /api/trips/:id/days/:num/entries +
+ *   - 「+ Day N」text-based promote — POST /api/trips/:id/days/:num/entries +
  *     PATCH /api/trip-ideas/:id { promotedToEntryId }
+ *   - **Drag-to-promote**（B-P5 Phase 2）— 拖 idea card 到頂部 Day badge 觸發同樣
+ *     promote API；drop targets 只在拖動時顯示
  *   - 「移除」DELETE /api/trip-ideas/:id（soft delete via archived_at）
  *
- * 不含：dnd-kit drag interaction（B-P5 後續 PR）/ conflict modal / undo toast / smart placement
+ * dnd-kit lazy load via React.lazy on this file (TripSheet wraps in lazy())。
+ * 不含：reorder ideas / cross-day move / demote / conflict modal / undo toast / smart placement
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
 import { apiFetchRaw } from '../../lib/apiClient';
 import type { TripIdea } from '../../types/api';
 
@@ -25,7 +40,11 @@ const SCOPED_STYLES = `
   padding: 12px 14px;
   background: var(--color-background);
   display: flex; flex-direction: column; gap: 6px;
+  cursor: grab;
+  user-select: none;
 }
+.tp-idea-card:active { cursor: grabbing; }
+.tp-idea-card.is-dragging { opacity: 0.4; }
 .tp-idea-card-header {
   display: flex; align-items: flex-start; gap: 8px;
   font-size: var(--font-size-callout); font-weight: 600;
@@ -73,11 +92,84 @@ const SCOPED_STYLES = `
   font-size: var(--font-size-footnote); color: var(--color-muted);
   padding: 8px 16px;
 }
+.tp-ideas-drop-row {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  padding: 12px 16px;
+  background: var(--color-accent-subtle);
+  border-bottom: 1px solid var(--color-border);
+  position: sticky; top: 0; z-index: 5;
+}
+.tp-ideas-drop-row > .label {
+  font-size: var(--font-size-footnote); font-weight: 600;
+  color: var(--color-accent); align-self: center;
+}
+.tp-day-drop-badge {
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  border: 2px dashed var(--color-accent);
+  font-size: var(--font-size-callout); font-weight: 600;
+  color: var(--color-accent);
+  transition: background-color 120ms;
+}
+.tp-day-drop-badge.is-over {
+  background: var(--color-accent);
+  color: var(--color-accent-foreground);
+}
 `;
+
+function ideaDragId(id: number): string { return `idea-${id}`; }
+function dayDropId(num: number): string { return `day-${num}`; }
+function parseIdeaDragId(id: string): number | null {
+  const m = id.match(/^idea-(\d+)$/);
+  return m ? Number(m[1]) : null;
+}
+function parseDayDropId(id: string): number | null {
+  const m = id.match(/^day-(\d+)$/);
+  return m ? Number(m[1]) : null;
+}
+
+interface DraggableIdeaCardProps {
+  idea: TripIdea;
+  busy: boolean;
+  isDragging: boolean;
+  children: React.ReactNode;
+}
+
+function DraggableIdeaCard({ idea, busy, isDragging, children }: DraggableIdeaCardProps) {
+  const { attributes, listeners, setNodeRef } = useDraggable({
+    id: ideaDragId(idea.id),
+    disabled: busy || !!idea.promotedToEntryId || !idea.poiId,
+  });
+  return (
+    <li
+      ref={setNodeRef}
+      className={`tp-idea-card${isDragging ? ' is-dragging' : ''}`}
+      {...attributes}
+      {...listeners}
+      data-testid={`idea-card-${idea.id}`}
+    >
+      {children}
+    </li>
+  );
+}
+
+function DroppableDayBadge({ num }: { num: number }) {
+  const { isOver, setNodeRef } = useDroppable({ id: dayDropId(num) });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`tp-day-drop-badge${isOver ? ' is-over' : ''}`}
+      data-testid={`day-drop-${num}`}
+    >
+      Day {num}
+    </div>
+  );
+}
 
 export interface IdeasTabContentProps {
   tripId: string;
-  /** Optional：days available for promote dropdown。空陣列時 promote 隱藏。 */
+  /** Optional：days available for promote dropdown / drop targets。空陣列時 promote 隱藏。 */
   dayNumbers?: number[];
 }
 
@@ -85,6 +177,12 @@ export default function IdeasTabContent({ tripId, dayNumbers = [] }: IdeasTabCon
   const [ideas, setIdeas] = useState<TripIdea[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor),
+  );
 
   const reload = useCallback(async () => {
     setError(null);
@@ -99,69 +197,96 @@ export default function IdeasTabContent({ tripId, dayNumbers = [] }: IdeasTabCon
     }
   }, [tripId]);
 
-  useEffect(() => {
-    void reload();
+  useEffect(() => { void reload(); }, [reload]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    setBusyId(id);
+    try {
+      const res = await apiFetchRaw(`/api/trip-ideas/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(`DELETE failed: HTTP ${res.status}`);
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
   }, [reload]);
 
-  const handleDelete = useCallback(
-    async (id: number) => {
-      setBusyId(id);
-      try {
-        const res = await apiFetchRaw(`/api/trip-ideas/${id}`, { method: 'DELETE' });
-        if (!res.ok) throw new Error(`DELETE failed: HTTP ${res.status}`);
-        await reload();
-      } catch (e) {
-        setError((e as Error).message);
-      } finally {
-        setBusyId(null);
+  const handlePromote = useCallback(async (idea: TripIdea, dayNum: number) => {
+    if (!idea.poiId) {
+      setError('此 idea 未綁 POI，無法直接 promote');
+      return;
+    }
+    setBusyId(idea.id);
+    try {
+      const create = await apiFetchRaw(
+        `/api/trips/${encodeURIComponent(tripId)}/days/${dayNum}/entries`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ poiId: idea.poiId, name: idea.title }),
+        },
+      );
+      if (!create.ok) throw new Error(`promote create entry failed: ${create.status}`);
+      const created = (await create.json()) as { id?: number };
+      if (created?.id) {
+        await apiFetchRaw(`/api/trip-ideas/${idea.id}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ promotedToEntryId: created.id }),
+        });
       }
-    },
-    [reload],
-  );
-
-  const handlePromote = useCallback(
-    async (idea: TripIdea, dayNum: number) => {
-      if (!idea.poiId) {
-        setError('此 idea 未綁 POI，無法直接 promote');
-        return;
-      }
-      setBusyId(idea.id);
-      try {
-        const create = await apiFetchRaw(
-          `/api/trips/${encodeURIComponent(tripId)}/days/${dayNum}/entries`,
-          {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ poiId: idea.poiId, name: idea.title }),
-          },
-        );
-        if (!create.ok) throw new Error(`promote create entry failed: ${create.status}`);
-        const created = (await create.json()) as { id?: number };
-        if (created?.id) {
-          await apiFetchRaw(`/api/trip-ideas/${idea.id}`, {
-            method: 'PATCH',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ promotedToEntryId: created.id }),
-          });
-        }
-        await reload();
-      } catch (e) {
-        setError((e as Error).message);
-      } finally {
-        setBusyId(null);
-      }
-    },
-    [reload, tripId],
-  );
+      await reload();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  }, [reload, tripId]);
 
   const activeIdeas = useMemo(
     () => (ideas ?? []).filter((i) => !i.archivedAt),
     [ideas],
   );
 
+  const handleDragStart = useCallback((e: DragStartEvent) => {
+    setActiveDragId(String(e.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback((e: DragEndEvent) => {
+    setActiveDragId(null);
+    if (!e.over) return;
+    const ideaId = parseIdeaDragId(String(e.active.id));
+    const dayNum = parseDayDropId(String(e.over.id));
+    if (ideaId === null || dayNum === null) return;
+    const idea = activeIdeas.find((i) => i.id === ideaId);
+    if (!idea) return;
+    void handlePromote(idea, dayNum);
+  }, [activeIdeas, handlePromote]);
+
+  const draggedIdea = useMemo(
+    () => {
+      if (!activeDragId) return null;
+      const id = parseIdeaDragId(activeDragId);
+      return id !== null ? activeIdeas.find((i) => i.id === id) ?? null : null;
+    },
+    [activeDragId, activeIdeas],
+  );
+
   return (
-    <>
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveDragId(null)}
+    >
       <style>{SCOPED_STYLES}</style>
+      {activeDragId && dayNumbers.length > 0 && (
+        <div className="tp-ideas-drop-row" data-testid="ideas-drop-row">
+          <span className="label">拖到日次以加入：</span>
+          {dayNumbers.map((d) => <DroppableDayBadge key={d} num={d} />)}
+        </div>
+      )}
       {error && <div className="tp-ideas-status" role="alert" data-testid="ideas-error">⚠ {error}</div>}
       {ideas === null && (
         <div className="tp-ideas-status" data-testid="ideas-loading">載入中…</div>
@@ -176,7 +301,12 @@ export default function IdeasTabContent({ tripId, dayNumbers = [] }: IdeasTabCon
       {ideas !== null && activeIdeas.length > 0 && (
         <ul className="tp-ideas-list" data-testid="ideas-list">
           {activeIdeas.map((idea) => (
-            <li key={idea.id} className="tp-idea-card">
+            <DraggableIdeaCard
+              key={idea.id}
+              idea={idea}
+              busy={busyId === idea.id}
+              isDragging={activeDragId === ideaDragId(idea.id)}
+            >
               <div className="tp-idea-card-header">{idea.title}</div>
               {(idea.poiAddress || idea.poiType) && (
                 <div className="tp-idea-card-meta">
@@ -220,10 +350,20 @@ export default function IdeasTabContent({ tripId, dayNumbers = [] }: IdeasTabCon
                   </button>
                 </div>
               )}
-            </li>
+            </DraggableIdeaCard>
           ))}
         </ul>
       )}
-    </>
+      <DragOverlay>
+        {draggedIdea ? (
+          <div className="tp-idea-card" style={{ cursor: 'grabbing' }}>
+            <div className="tp-idea-card-header">{draggedIdea.title}</div>
+            {draggedIdea.poiType && (
+              <div className="tp-idea-card-meta"><span>{draggedIdea.poiType}</span></div>
+            )}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 }


### PR DESCRIPTION
## Summary

Sprint A part 2/4 — IdeasTabContent 加 dnd-kit drag-to-promote。對應 \`layout-refactor-polish-qa\` task 6.6。

剩 Sprint A 2 task：7.2 desktop e2e + 7.5 drag 4 scenarios e2e — 都需要 Playwright fixtures，獨立 PR。

## Behavior

```
[Sticky drop row — only visible during drag]
   拖到日次以加入：[Day 1] [Day 2] [Day 3] ...
   
┌─────────────────────────┐
│ Idea card (draggable)   │ ← cursor: grab
│   美麗海水族館            │
│   sight · 沖繩縣          │
│   + Day 1  + Day 2  移除 │ ← text fallback 仍在
└─────────────────────────┘
```

**Drag flow**：
1. User press card 4px+ → drag start, drop row appears at top
2. Hover Day badge → badge highlight (background → accent)
3. Drop on Day badge → promote API call (POST entry + PATCH idea promotedToEntryId)
4. Reload list, idea now shows 「✓ 已排入 entry #N」

**Text-based 「+ Day N」 button 保留** — 鍵盤使用者 / accessibility fallback / drag 失敗替代。

## Disabled state

- Promoted idea (\`promotedToEntryId\` set) → \`useDraggable disabled\`
- No \`poiId\` (free-text idea) → \`useDraggable disabled\`
- Busy (in-flight API call) → \`useDraggable disabled\`

## task 6.6 Lazy load 確認

\`IdeasTabContent\` 在 \`TripSheet\` 用 \`lazy(() => import('./IdeasTabContent'))\` (TripSheet 既有 lazy)。dnd-kit 透過 \`IdeasTabContent\` transitive import — 只在 \`?sheet=ideas\` active 時 vite 切 chunk + load。

## Sensors

- \`PointerSensor\` with \`activationConstraint: { distance: 4 }\` — 避免誤觸
- \`KeyboardSensor\` — Tab 進 card 後 Space/Enter 拾起，方向鍵移動，再 Space/Enter 放下（a11y）

## Test plan

- [x] Existing 8 unit tests still pass（refactor 沒退步）
- [x] tsc clean + full vitest pass
- [ ] Post-merge：本機 dev server，創 idea + 切 \`?sheet=ideas\` + 拖卡片到 Day badge → 看 entry 建立
- [ ] Future：Playwright e2e (task 7.5) 自動驗 drag-to-promote scenario

## OpenSpec progress

\`layout-refactor-polish-qa\` 40/53 → 41/53 (77.4%)。Sprint A: 2/4 done。

🤖 Generated with [Claude Code](https://claude.com/claude-code)