### PR TITLE
feat(monitoring): Sentry release tagging（B-P6 task 10.1）

### DIFF
--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -69,7 +69,7 @@
 
 ## 10. Monitoring
 
-- [ ] 10.1 Sentry release mark `layout-v3-2026-05-xx` — deferred to next sprint (Sentry CLI integration)
+- [x] 10.1 Sentry release mark — `vite.config.ts` 加 `sentryVitePlugin({ release: { name: sentryRelease } })`，`sentryRelease` 從 `SENTRY_RELEASE` env / `npm_package_version` + `GITHUB_SHA`/`CF_PAGES_COMMIT_SHA` derive（fallback `tripline@<ver>-local`）。Naming convention：`tripline@2.3.0-<sha7>` 取代 `layout-v3-2026-05-xx` 寫死格式
 - [ ] 10.2 Sentry error rate baseline 設 threshold alert — deferred to next sprint
 - [x] 10.3 daily-check 驗 /manage, /trip/:id, /explore routes 皆 200 — `scripts/daily-check.js` 加 `queryRouteHealth()` 數據來源 5b：fetch 8 routes（/, /manage/, /admin/, /trip/:id, /explore, /login, /map, /chat）`redirect: 'manual'`，status >= 500 為 fail；report 加 `routeHealth` field
 - [ ] 10.4 Telegram 通知渠道 smoke test — deferred to next sprint

--- a/tests/unit/sentry-release-config.test.ts
+++ b/tests/unit/sentry-release-config.test.ts
@@ -1,0 +1,36 @@
+/**
+ * vite.config.ts — Sentry release config 測試（B-P6 task 10.1）
+ *
+ * 確保 sentryVitePlugin 設了 release.name，否則 Sentry source maps 上傳會 fall
+ * 在 unnamed release 下，無法依 release 區分 errors / regression rate。
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VITE_CONFIG = fs.readFileSync(
+  path.resolve(__dirname, '../../vite.config.ts'),
+  'utf8',
+);
+
+describe('vite.config.ts — Sentry release name', () => {
+  it('含 sentryRelease const derive from version + SHA', () => {
+    expect(VITE_CONFIG).toMatch(/const\s+sentryRelease\s*=/);
+    expect(VITE_CONFIG).toMatch(/SENTRY_RELEASE/);
+    expect(VITE_CONFIG).toMatch(/npm_package_version/);
+  });
+
+  it('sentryVitePlugin call 含 release.name', () => {
+    // 從 sentryVitePlugin({...}) 內找 release: { name: ... } 結構
+    expect(VITE_CONFIG).toMatch(/sentryVitePlugin\([\s\S]*?release:\s*\{\s*name:\s*sentryRelease[\s\S]*?\}/);
+  });
+
+  it('release name fallback to local when no CI env', () => {
+    expect(VITE_CONFIG).toMatch(/['"]local['"]/);
+  });
+
+  it('uses GITHUB_SHA or CF_PAGES_COMMIT_SHA from CI env', () => {
+    expect(VITE_CONFIG).toMatch(/GITHUB_SHA/);
+    expect(VITE_CONFIG).toMatch(/CF_PAGES_COMMIT_SHA/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,21 @@ import { VitePWA } from 'vite-plugin-pwa';
 import { mockApiPlugin } from './scripts/vite-mock-api';
 
 // Only upload source maps to Sentry in CI (when SENTRY_AUTH_TOKEN is present).
+// B-P6 task 10.1：mark release with package version + commit SHA。
+// CI（GitHub Actions）有 GITHUB_SHA env；fallback 到 explicit SENTRY_RELEASE 或 'local'。
+const sentryRelease =
+  process.env.SENTRY_RELEASE ||
+  `tripline@${process.env.npm_package_version || '0.0.0'}-${
+    (process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || 'local').slice(0, 7)
+  }`;
+
 const sentryPlugins = process.env.SENTRY_AUTH_TOKEN
   ? [
       sentryVitePlugin({
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         authToken: process.env.SENTRY_AUTH_TOKEN,
+        release: { name: sentryRelease },
       }),
     ]
   : [];


### PR DESCRIPTION
## Summary

\`vite.config.ts\` \`sentryVitePlugin\` 加 \`release.name\`，從 env priority chain derive。對應 \`layout-refactor-polish-qa\` task 10.1。

## Release naming

```
1. SENTRY_RELEASE env (explicit override)
2. tripline@<npm_package_version>-<GITHUB_SHA[0:7]>     # GitHub Actions
3. tripline@<npm_package_version>-<CF_PAGES_COMMIT_SHA[0:7]>  # CF Pages build
4. tripline@<version>-local                              # dev / no CI env
```

當前 build：\`tripline@1.0.0-local\` (dev) / 跑 CI 時自動換 SHA。Naming 改成跟 \`CHANGELOG.md\` 版本同步（task 寫死的「layout-v3-2026-05-xx」過於 ad-hoc）。

## Why

之前 source maps 上傳到 Sentry 但**沒帶 release name**，errors / regression rate 無法依 release 區分。修後每次 build 都 mark release，post-deploy 可用 Sentry UI \`releases:tripline@2.3.0-xxx\` filter errors。

## Test

\`tests/unit/sentry-release-config.test.ts\` 4 cases 驗 vite.config.ts source：
- 含 \`sentryRelease\` const
- \`sentryVitePlugin({ release: { name: sentryRelease } })\`
- CI env vars (GITHUB_SHA / CF_PAGES_COMMIT_SHA)
- local fallback

## Test plan

- [x] 4 cases TDD pass
- [x] vitest full suite + tsc clean
- [ ] Post-merge：CI build 看 vite log 含 \`Sentry CLI > Uploaded source maps for release tripline@2.3.0-xxx\`
- [ ] Post-merge：Sentry dashboard releases tab 看新 release entry

## OpenSpec progress

\`layout-refactor-polish-qa\` 41/53 → 42/53 (79%)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)