### PR TITLE
feat(monitoring): Telegram smoke test script + workflow（B-P6 task 10.4）

### DIFF
--- a/.github/workflows/telegram-smoke.yml
+++ b/.github/workflows/telegram-smoke.yml
@@ -1,0 +1,29 @@
+name: Telegram smoke test
+
+# Manual trigger only — Telegram channel sanity check（B-P6 task 10.4）
+# 每月跑一次或在改 daily-check Telegram 部分後 manual 跑驗證。
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 每月 1 日 UTC 22:00 = 台灣 06:00 跑一次 sanity
+    - cron: '0 22 1 * *'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run Telegram smoke test
+        run: bash scripts/telegram-smoke.sh
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_BOT_HOME_TOKEN: ${{ secrets.TELEGRAM_BOT_HOME_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}

--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -72,7 +72,7 @@
 - [x] 10.1 Sentry release mark — `vite.config.ts` 加 `sentryVitePlugin({ release: { name: sentryRelease } })`，`sentryRelease` 從 `SENTRY_RELEASE` env / `npm_package_version` + `GITHUB_SHA`/`CF_PAGES_COMMIT_SHA` derive（fallback `tripline@<ver>-local`）。Naming convention：`tripline@2.3.0-<sha7>` 取代 `layout-v3-2026-05-xx` 寫死格式
 - [ ] 10.2 Sentry error rate baseline 設 threshold alert — deferred to next sprint
 - [x] 10.3 daily-check 驗 /manage, /trip/:id, /explore routes 皆 200 — `scripts/daily-check.js` 加 `queryRouteHealth()` 數據來源 5b：fetch 8 routes（/, /manage/, /admin/, /trip/:id, /explore, /login, /map, /chat）`redirect: 'manual'`，status >= 500 為 fail；report 加 `routeHealth` field
-- [ ] 10.4 Telegram 通知渠道 smoke test — deferred to next sprint
+- [x] 10.4 Telegram 通知渠道 smoke test — `scripts/telegram-smoke.sh` (bash + JSON.stringify escape + exit code semantics 0/1/2) + `.github/workflows/telegram-smoke.yml` (workflow_dispatch + 月初 cron schedule，用既有 TELEGRAM_BOT_TOKEN secrets)；`tests/unit/telegram-smoke-script.test.ts` 12 cases 驗 script + workflow contract
 
 ## 11. Ship
 

--- a/scripts/telegram-smoke.sh
+++ b/scripts/telegram-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# telegram-smoke.sh — Telegram 通知渠道 smoke test（B-P6 task 10.4）
+#
+# 驗 TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID 能成功 sendMessage。
+# 用 hostname + ISO timestamp 當 message body 確認 routing 正確。
+#
+# Usage:
+#   TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... bash scripts/telegram-smoke.sh
+#
+# Exit codes:
+#   0 — 成功 (Telegram API 200 + ok=true)
+#   1 — env 未設
+#   2 — Telegram API 失敗（HTTP 非 200 或 ok=false）
+
+set -euo pipefail
+
+TOKEN="${TELEGRAM_BOT_HOME_TOKEN:-${TELEGRAM_BOT_TOKEN:-}}"
+CHAT_ID="${TELEGRAM_CHAT_ID:-6527604594}"
+
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: TELEGRAM_BOT_TOKEN / TELEGRAM_BOT_HOME_TOKEN 未設定" >&2
+  exit 1
+fi
+
+HOSTNAME_VAL="$(hostname)"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+MSG="🟢 Tripline Telegram smoke test
+host: ${HOSTNAME_VAL}
+time: ${TIMESTAMP}
+source: ${GITHUB_REF_NAME:-${BRANCH:-local}}@${GITHUB_SHA:-${COMMIT_SHA:-unknown}}"
+
+# 用 node JSON.stringify 安全 escape（避免 shell quote 問題）
+BODY=$(node -e "console.log(JSON.stringify({chat_id: process.argv[1], text: process.argv[2]}))" "$CHAT_ID" "$MSG")
+
+RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST \
+  "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+  -H 'Content-Type: application/json' \
+  -d "$BODY")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "ERROR: Telegram API HTTP $HTTP_CODE" >&2
+  echo "$RESPONSE_BODY" >&2
+  exit 2
+fi
+
+# verify ok:true
+if ! echo "$RESPONSE_BODY" | grep -q '"ok":true'; then
+  echo "ERROR: Telegram API responded but ok != true" >&2
+  echo "$RESPONSE_BODY" >&2
+  exit 2
+fi
+
+echo "OK: Telegram smoke test passed (chat_id=${CHAT_ID})"
+echo "$RESPONSE_BODY"

--- a/tests/unit/telegram-smoke-script.test.ts
+++ b/tests/unit/telegram-smoke-script.test.ts
@@ -1,0 +1,78 @@
+/**
+ * scripts/telegram-smoke.sh + .github/workflows/telegram-smoke.yml 結構測試
+ * （B-P6 task 10.4）
+ *
+ * 驗 smoke script 的 contract：
+ * - TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID env 名稱不變
+ * - Exit code semantics（0 ok / 1 env / 2 API fail）
+ * - workflow yml schedule + dispatch + secrets reference 正確
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = fs.readFileSync(
+  path.resolve(__dirname, '../../scripts/telegram-smoke.sh'),
+  'utf8',
+);
+const WORKFLOW = fs.readFileSync(
+  path.resolve(__dirname, '../../.github/workflows/telegram-smoke.yml'),
+  'utf8',
+);
+
+describe('telegram-smoke.sh — script contract', () => {
+  it('shebang 用 bash + set -euo pipefail（fail-loud）', () => {
+    expect(SCRIPT).toMatch(/^#!\/usr\/bin\/env bash/);
+    expect(SCRIPT).toMatch(/set -euo pipefail/);
+  });
+
+  it('讀 TELEGRAM_BOT_HOME_TOKEN 或 TELEGRAM_BOT_TOKEN env（與 daily-check-scheduler 一致）', () => {
+    expect(SCRIPT).toMatch(/TELEGRAM_BOT_HOME_TOKEN/);
+    expect(SCRIPT).toMatch(/TELEGRAM_BOT_TOKEN/);
+  });
+
+  it('讀 TELEGRAM_CHAT_ID env，預設 6527604594（與 daily-check-scheduler 一致）', () => {
+    expect(SCRIPT).toMatch(/TELEGRAM_CHAT_ID/);
+    expect(SCRIPT).toMatch(/6527604594/);
+  });
+
+  it('No-token exit code 1', () => {
+    expect(SCRIPT).toMatch(/exit 1/);
+  });
+
+  it('Telegram API fail exit code 2', () => {
+    expect(SCRIPT).toMatch(/exit 2/);
+  });
+
+  it('呼叫 Telegram sendMessage endpoint', () => {
+    expect(SCRIPT).toMatch(/api\.telegram\.org\/bot\$\{TOKEN\}\/sendMessage/);
+  });
+
+  it('verify response ok:true（不只看 HTTP 200）', () => {
+    expect(SCRIPT).toMatch(/['"]ok['"]:true/);
+  });
+
+  it('用 node JSON.stringify 安全 escape message body（避免 shell quote 問題）', () => {
+    expect(SCRIPT).toMatch(/JSON\.stringify/);
+  });
+});
+
+describe('telegram-smoke.yml — workflow contract', () => {
+  it('on workflow_dispatch（manual trigger）', () => {
+    expect(WORKFLOW).toMatch(/workflow_dispatch:/);
+  });
+
+  it('on schedule monthly cron', () => {
+    expect(WORKFLOW).toMatch(/cron:.*1 \*/);
+  });
+
+  it('reference secrets.TELEGRAM_BOT_TOKEN / TELEGRAM_BOT_HOME_TOKEN / TELEGRAM_CHAT_ID', () => {
+    expect(WORKFLOW).toMatch(/secrets\.TELEGRAM_BOT_TOKEN/);
+    expect(WORKFLOW).toMatch(/secrets\.TELEGRAM_BOT_HOME_TOKEN/);
+    expect(WORKFLOW).toMatch(/secrets\.TELEGRAM_CHAT_ID/);
+  });
+
+  it('runs bash scripts/telegram-smoke.sh', () => {
+    expect(WORKFLOW).toMatch(/bash scripts\/telegram-smoke\.sh/);
+  });
+});


### PR DESCRIPTION
## Summary

Telegram 通知渠道 smoke test，對應 \`layout-refactor-polish-qa\` task 10.4。

## Deliverables

| File | 內容 |
|------|------|
| \`scripts/telegram-smoke.sh\` | bash script 跑 sendMessage with hostname + ISO timestamp，exit 0/1/2 semantics |
| \`.github/workflows/telegram-smoke.yml\` | workflow_dispatch (manual) + 月初 cron schedule |
| \`tests/unit/telegram-smoke-script.test.ts\` | 12 cases 驗 script + workflow contract |

## Script behavior

```
$ TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... bash scripts/telegram-smoke.sh
OK: Telegram smoke test passed (chat_id=6527604594)
{"ok":true,"result":{"message_id":123,"date":1714003200,...}}
```

Telegram channel 收到：
```
🟢 Tripline Telegram smoke test
host: github-actions-runner-...
time: 2026-04-25T01:00:00Z
source: master@abc1234
```

## Exit codes

| Code | 意義 |
|------|------|
| 0 | OK — Telegram API 200 + ok:true |
| 1 | Missing env — 沒設 BOT_TOKEN |
| 2 | API fail — HTTP 非 200 OR ok:false |

## Workflow trigger

- **Manual**：CI / Actions tab → telegram-smoke → Run workflow（user-triggered sanity check）
- **Monthly cron**：每月 1 日 UTC 22:00 = 台灣 06:00（自動 sanity，failure 會 GitHub Actions email user）

## Why fail-loud

跟 daily-check 共用 Telegram channel — 如果 channel 壞了 daily-check 也會 silent fail。Smoke test 主動驗證 channel + bot health，不依賴 daily-check 出問題才發現。

## Test plan

- [x] 12 cases TDD pass
- [x] tsc clean + full vitest pass
- [ ] Post-merge：Actions tab → Run workflow telegram-smoke → 看 Telegram channel 收到 🟢 訊息

## OpenSpec progress

\`layout-refactor-polish-qa\` 42/53 → 43/53 (81%)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)