### PR TITLE
feat(ci): bundle size gate ≤ 300KB gzipped（B-P6 task 11.3 / 6.4）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,8 @@ jobs:
 
       - name: Verify Service Worker
         run: node scripts/verify-sw.js
+
+      - name: Bundle size gate (B-P6 task 11.3 / 6.4)
+        run: bash scripts/bundle-size-check.sh
+        env:
+          THRESHOLD_KB: 300

--- a/openspec/changes/layout-refactor-polish-qa/tasks.md
+++ b/openspec/changes/layout-refactor-polish-qa/tasks.md
@@ -78,7 +78,7 @@
 
 - [ ] 11.1 Full Playwright E2E matrix green — blocked by 7.x deferred
 - [ ] 11.2 Lighthouse CI green — blocked by 6.1 deferred
-- [ ] 11.3 Bundle size gate pass — partial（6.4 baseline recorded，gate 待 6.1 CI 整合）
+- [x] 11.3 Bundle size gate pass — `scripts/bundle-size-check.sh` 算 dist/assets/\*.js gzipped size，threshold 300KB，超出 exit 1。`.github/workflows/ci.yml` 加 step 在 Build 之後跑（pass 條件：32 chunks 全 ≤ 300KB gzipped；最大 html2pdf 262KB lazy chunk）。
 - [x] 11.4 `/tp-team` full pipeline — 已走（10 個 PR through pipeline，含 /tp-code-verify, /review, /cso 等等價步驟透過 PR review + CI）
 - [x] 11.5 Staging → prod ship — Cloudflare Pages auto-deploy on master merge（staging = prod since master deploys directly）
 - [ ] 11.6 Post-ship 監控 24h（Sentry / daily-check 無異常）— blocked by 10.x deferred

--- a/scripts/bundle-size-check.sh
+++ b/scripts/bundle-size-check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# bundle-size-check.sh — 驗 dist/assets/*.js gzipped size 全部 ≤ THRESHOLD_KB
+# B-P6 task 11.3 / 6.4 ship gate
+#
+# Usage: bash scripts/bundle-size-check.sh
+# Env:   THRESHOLD_KB (default 300)
+#
+# Exit codes:
+#   0 — all chunks within threshold
+#   1 — at least one chunk exceeds threshold (報告超出 chunks）
+#   2 — dist/assets 不存在（需先 npm run build）
+
+set -euo pipefail
+
+THRESHOLD_KB="${THRESHOLD_KB:-300}"
+THRESHOLD_BYTES=$((THRESHOLD_KB * 1024))
+ASSETS_DIR="dist/assets"
+
+if [ ! -d "$ASSETS_DIR" ]; then
+  echo "ERROR: $ASSETS_DIR 不存在 — 請先 npm run build" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC2207
+JS_FILES=($(find "$ASSETS_DIR" -name '*.js' -type f))
+
+if [ ${#JS_FILES[@]} -eq 0 ]; then
+  echo "ERROR: $ASSETS_DIR 內找不到任何 .js — build 可能 fail" >&2
+  exit 2
+fi
+
+OVER=()
+TOTAL_OK=0
+TOTAL_OVER=0
+
+for f in "${JS_FILES[@]}"; do
+  GZ=$(gzip -c "$f" | wc -c | tr -d ' ')
+  if [ "$GZ" -gt "$THRESHOLD_BYTES" ]; then
+    OVER+=("$(basename "$f"): $((GZ / 1024))KB gzipped")
+    TOTAL_OVER=$((TOTAL_OVER + 1))
+  else
+    TOTAL_OK=$((TOTAL_OK + 1))
+  fi
+done
+
+echo "Bundle size check (threshold: ${THRESHOLD_KB}KB gzipped)"
+echo "  Within threshold: ${TOTAL_OK} chunks"
+
+if [ ${#OVER[@]} -gt 0 ]; then
+  echo "  Over threshold:   ${TOTAL_OVER} chunks"
+  printf '    - %s\n' "${OVER[@]}"
+  echo ""
+  echo "FAIL: bundle size gate"
+  exit 1
+fi
+
+echo "  Over threshold:   0 chunks"
+echo ""
+echo "OK: bundle size gate passed"

--- a/tests/unit/bundle-size-check-script.test.ts
+++ b/tests/unit/bundle-size-check-script.test.ts
@@ -1,0 +1,58 @@
+/**
+ * scripts/bundle-size-check.sh + ci.yml 結構測試（B-P6 task 11.3 / 6.4）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = fs.readFileSync(
+  path.resolve(__dirname, '../../scripts/bundle-size-check.sh'),
+  'utf8',
+);
+const CI_YML = fs.readFileSync(
+  path.resolve(__dirname, '../../.github/workflows/ci.yml'),
+  'utf8',
+);
+
+describe('bundle-size-check.sh — script contract', () => {
+  it('shebang bash + set -euo pipefail（fail-loud）', () => {
+    expect(SCRIPT).toMatch(/^#!\/usr\/bin\/env bash/);
+    expect(SCRIPT).toMatch(/set -euo pipefail/);
+  });
+
+  it('THRESHOLD_KB env 預設 300（task 6.4 / 11.3 spec）', () => {
+    expect(SCRIPT).toMatch(/THRESHOLD_KB:?-?300/);
+  });
+
+  it('掃 dist/assets/*.js 全部', () => {
+    expect(SCRIPT).toMatch(/dist\/assets/);
+    expect(SCRIPT).toMatch(/-name\s+['"]\*\.js['"]/);
+  });
+
+  it('用 gzip -c | wc -c 算 gzipped size（不是 raw size）', () => {
+    expect(SCRIPT).toMatch(/gzip\s+-c.*wc\s+-c/);
+  });
+
+  it('Exit 1 when over threshold, 2 when dist missing', () => {
+    expect(SCRIPT).toMatch(/exit 1/);
+    expect(SCRIPT).toMatch(/exit 2/);
+  });
+});
+
+describe('ci.yml — bundle size gate step', () => {
+  it('包含 Bundle size gate step', () => {
+    expect(CI_YML).toMatch(/Bundle size gate/);
+    expect(CI_YML).toMatch(/bash scripts\/bundle-size-check\.sh/);
+  });
+
+  it('在 Build step 之後（dist/ 才存在）', () => {
+    const buildIdx = CI_YML.indexOf('Build');
+    const gateIdx = CI_YML.indexOf('Bundle size gate');
+    expect(buildIdx).toBeGreaterThan(0);
+    expect(gateIdx).toBeGreaterThan(buildIdx);
+  });
+
+  it('傳 THRESHOLD_KB env (300)', () => {
+    expect(CI_YML).toMatch(/THRESHOLD_KB:\s*300/);
+  });
+});


### PR DESCRIPTION
## Summary

CI 加 bundle size gate — 任何 \`dist/assets/*.js\` chunk gzipped 超 300KB 即 fail build。對應 \`layout-refactor-polish-qa\` task 11.3。

## Current baseline (post-#251 master)

```
Bundle size check (threshold: 300KB gzipped)
  Within threshold: 32 chunks
  Over threshold:   0 chunks

OK: bundle size gate passed
```

最大 chunks (gzipped)：

| Chunk | Gzipped | 用途 |
|-------|--------:|------|
| html2pdf | 262KB | PDF export (lazy on demand) |
| vendor | 71KB | React + libs |
| OceanMap | 52KB | Leaflet (lazy on map tab) |
| sentry | 46KB | Error tracking |
| TripPage | 24KB | (lazy) |
| 其他 27 chunks | < 13KB | UI components / pages (lazy) |

## Why 300KB threshold

跟 task 6.4 spec align：「各 chunk < 300 KB gzipped」。html2pdf 262KB 是 PDF export library lazy-loaded，是當前 cold-start 不會碰到的 chunk。Initial bundle (vendor + index) ~ 100KB gzipped → 良好。

## Implementation

\`scripts/bundle-size-check.sh\` 用 \`gzip -c | wc -c\` 算 gzipped size（不只是 \`stat\` raw size）。Threshold 從 \`THRESHOLD_KB\` env 配置，CI 傳 300。

\`.github/workflows/ci.yml\` 加 step 在 Build + Verify SW 之後（\`dist/\` 必須存在）。

## Test plan

- [x] Local run \`bash scripts/bundle-size-check.sh\` 32 ok / 0 over
- [x] tests/unit/bundle-size-check-script.test.ts 8 cases pass
- [x] full vitest + tsc clean
- [ ] Post-merge：watch CI run 確認新 step 執行 + pass

## Future regression

- 若新增大型 deps（e.g. PDF lib 升級 / 新增 chart library），gate 會 catch
- 若 chunk 拆得太細導致 30+ small chunks，gate 不檢查總 size — 留給 task 6.5 lazy load 已 ship

## OpenSpec progress

\`layout-refactor-polish-qa\` 43/53 → 44/53 (83%)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)