### PR TITLE
feat(v2-p1): identity core schema + D1 adapter — first slice

### DIFF
--- a/migrations/0031_oauth_models.sql
+++ b/migrations/0031_oauth_models.sql
@@ -1,0 +1,33 @@
+-- Migration 0031: oauth_models — Panva oidc-provider D1 adapter storage
+--
+-- V2-P1 schema (per docs/v2-oauth-server-plan.md)。Generic key-value store for
+-- oidc-provider 的所有 model types：Session / AuthorizationCode / AccessToken /
+-- RefreshToken / Grant / Interaction / DeviceCode / RegistrationAccessToken / etc.
+--
+-- 設計取捨：
+--   - 用 single table generic store 而非 per-model table — Panva oidc-provider
+--     的 Adapter interface 對所有 model 用同一套 API（upsert/find/destroy 等），
+--     且不同 model 的 fields 變動大，generic JSON payload 較 maintainable
+--   - PRIMARY KEY (name, id) — name 是 model class name (e.g. 'Session')，
+--     id 是 model 的 jti / code / token 字串。複合 key 確保跨 model 不撞
+--   - expires_at INTEGER unix ms — 比 SQLite datetime() 字串好做數字比較；
+--     find() 內 inline 過期檢查（lazy delete on read）
+--   - JSON payload 用 SQLite json_extract() 索引特定欄位（grantId / uid）
+--   - **不用 FK to users** — oauth_models 生命週期短（minutes-hours），
+--     user 被刪時 access_token 過期即可，不需 cascade
+--
+-- 索引：
+--   - idx_oauth_models_expires：cron job DELETE WHERE expires_at < now() 用
+--   - idx_oauth_models_grant：revokeByGrantId() 用 json_extract index
+
+CREATE TABLE oauth_models (
+  name        TEXT NOT NULL,
+  id          TEXT NOT NULL,
+  payload     TEXT NOT NULL,        -- JSON serialized AdapterPayload
+  expires_at  INTEGER NOT NULL,     -- unix ms
+  PRIMARY KEY (name, id)
+);
+
+CREATE INDEX idx_oauth_models_expires ON oauth_models(expires_at);
+CREATE INDEX idx_oauth_models_grant ON oauth_models(json_extract(payload, '$.grantId'));
+CREATE INDEX idx_oauth_models_uid ON oauth_models(json_extract(payload, '$.uid'));

--- a/migrations/0032_users_auth_identities.sql
+++ b/migrations/0032_users_auth_identities.sql
@@ -1,0 +1,57 @@
+-- Migration 0032: users + auth_identities — V2-P1 identity core
+--
+-- Provider-agnostic schema (per docs/v2-oauth-server-plan.md V2-P1 spec)。
+-- 預留 Apple / LINE / local password / Google 等多 provider，每 user 多 identity。
+--
+-- ## users
+--
+-- - id: uuid string (32 char) — generate at app layer, not autoincrement, 因
+--   分散式 ID 預留（V2-P4 OAuth Server 階段 federated user 可帶外部 ID）
+-- - email: 主 email，UNIQUE — 用作 display + recovery contact
+-- - email_verified_at: nullable，verified flow 才填（V2-P2 spec）
+-- - created_at / updated_at: 對齊既有 table convention
+-- - status: active / suspended — admin 後續可 ban
+--
+-- ## auth_identities
+--
+-- - 一個 user 可有多個 identities（Apple + LINE + email/password）
+-- - provider: 'google' / 'apple' / 'line' / 'local' / etc.
+-- - provider_user_id: 該 provider 給的 unique ID (Google sub / Apple sub / etc.)
+-- - UNIQUE (provider, provider_user_id) — 同 provider 同 ID 只 link 一個 user
+-- - password_hash / password_algo: 只 'local' provider 用（argon2id hash）
+-- - last_used_at: track 最近用哪個 identity 登入
+--
+-- ## Backfill 策略（V2-P1 後）
+--
+-- 既有 saved_pois.email / trip_permissions.email / trip_ideas.added_by 等
+-- email column → 在 V2-P1 migration 後跑 backfill script 建 users row +
+-- update FK to user_id。本 migration 不改既有 table（避免 breaking change）。
+
+CREATE TABLE users (
+  id                 TEXT PRIMARY KEY,           -- uuid (32 char hex)
+  email              TEXT NOT NULL UNIQUE,
+  email_verified_at  TEXT,                       -- ISO datetime, NULL = unverified
+  display_name       TEXT,
+  avatar_url         TEXT,
+  status             TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended')),
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_status ON users(status);
+
+CREATE TABLE auth_identities (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider          TEXT NOT NULL,               -- 'google' | 'apple' | 'line' | 'local' | future
+  provider_user_id  TEXT NOT NULL,               -- google sub / apple sub / line userId / email for local
+  password_hash     TEXT,                        -- only for provider='local'
+  password_algo     TEXT,                        -- 'argon2id' (V2-P2 spec)
+  last_used_at      TEXT,                        -- ISO datetime, updated on each login
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (provider, provider_user_id)
+);
+
+CREATE INDEX idx_auth_identities_user ON auth_identities(user_id);
+CREATE INDEX idx_auth_identities_provider ON auth_identities(provider);

--- a/src/server/oauth-d1-adapter.ts
+++ b/src/server/oauth-d1-adapter.ts
@@ -1,0 +1,111 @@
+/**
+ * D1 Adapter for Panva oidc-provider — V2-P1 (per docs/v2-oauth-server-plan.md)
+ *
+ * Implements the [Adapter interface](https://github.com/panva/node-oidc-provider/blob/main/lib/models/adapter.js)
+ * over Cloudflare D1。Generic single-table key-value store (oauth_models)，
+ * complex queries 用 SQLite json_extract() 索引。
+ *
+ * Lifecycle 模式：
+ *   - upsert(id, payload, expiresIn): INSERT OR REPLACE，expires_at = now + ms
+ *   - find(id): SELECT，過期 row 視為不存在（lazy delete on read）
+ *   - destroy(id): DELETE
+ *   - 過期 row cleanup 由 cron job 跑 `DELETE WHERE expires_at < now()`（V2-P6）
+ *
+ * 不做（留 next sprint）：
+ *   - findByUserCode：device flow（V2-P5 排程）
+ *   - 加密 payload at rest（敏感 token 已 short-lived，明文 acceptable）
+ */
+import type { D1Database } from '@cloudflare/workers-types';
+
+/** Panva oidc-provider 的 AdapterPayload contract（subset，含常用欄位）。 */
+export interface AdapterPayload {
+  [key: string]: unknown;
+  jti?: string;
+  iat?: number;
+  exp?: number;
+  /** 用於 findByUid (Session model) */
+  uid?: string;
+  /** 用於 revokeByGrantId */
+  grantId?: string;
+  /** consume() 標記為 used（authorization_code one-shot） */
+  consumed?: number;
+}
+
+export class D1Adapter {
+  constructor(private db: D1Database, private name: string) {
+    // name = 'Session' | 'AuthorizationCode' | 'AccessToken' | 'RefreshToken' | ...
+  }
+
+  async upsert(id: string, payload: AdapterPayload, expiresIn: number): Promise<void> {
+    await this.db
+      .prepare(
+        'INSERT OR REPLACE INTO oauth_models (name, id, payload, expires_at) VALUES (?, ?, ?, ?)',
+      )
+      .bind(this.name, id, JSON.stringify(payload), Date.now() + expiresIn * 1000)
+      .run();
+  }
+
+  async find(id: string): Promise<AdapterPayload | undefined> {
+    const row = await this.db
+      .prepare('SELECT payload, expires_at FROM oauth_models WHERE name = ? AND id = ?')
+      .bind(this.name, id)
+      .first<{ payload: string; expires_at: number }>();
+    if (!row) return undefined;
+    if (row.expires_at < Date.now()) return undefined; // lazy delete
+    return JSON.parse(row.payload) as AdapterPayload;
+  }
+
+  /**
+   * Device flow lookup — V2-P5 才實作。throw 讓 oidc-provider 把 device flow
+   * grant 全 disable（library 在 init 期 detect adapter capability）。
+   */
+  async findByUserCode(_userCode: string): Promise<AdapterPayload | undefined> {
+    throw new Error('D1Adapter: device flow (findByUserCode) not implemented (V2-P5)');
+  }
+
+  async findByUid(uid: string): Promise<AdapterPayload | undefined> {
+    const row = await this.db
+      .prepare(
+        'SELECT payload, expires_at FROM oauth_models WHERE name = ? AND json_extract(payload, ?) = ?',
+      )
+      .bind(this.name, '$.uid', uid)
+      .first<{ payload: string; expires_at: number }>();
+    if (!row) return undefined;
+    if (row.expires_at < Date.now()) return undefined;
+    return JSON.parse(row.payload) as AdapterPayload;
+  }
+
+  async consume(id: string): Promise<void> {
+    // Mark authorization_code as used (one-shot guard against replay)
+    await this.db
+      .prepare(
+        'UPDATE oauth_models SET payload = json_set(payload, ?, ?) WHERE name = ? AND id = ?',
+      )
+      .bind('$.consumed', Date.now(), this.name, id)
+      .run();
+  }
+
+  async destroy(id: string): Promise<void> {
+    await this.db
+      .prepare('DELETE FROM oauth_models WHERE name = ? AND id = ?')
+      .bind(this.name, id)
+      .run();
+  }
+
+  async revokeByGrantId(grantId: string): Promise<void> {
+    // 跨所有 name 刪 — grantId 是跨 model 的 link key（一個 grant 含多個 access_token / refresh_token）
+    await this.db
+      .prepare('DELETE FROM oauth_models WHERE json_extract(payload, ?) = ?')
+      .bind('$.grantId', grantId)
+      .run();
+  }
+
+  /** Maintenance: 清掉過期 row，cron job 用。回傳清掉幾 row。 */
+  static async sweepExpired(db: D1Database): Promise<number> {
+    const result = await db
+      .prepare('DELETE FROM oauth_models WHERE expires_at < ?')
+      .bind(Date.now())
+      .run();
+    return (result.meta?.changes as number | undefined) ?? 0;
+  }
+}

--- a/tests/unit/oauth-d1-adapter.test.ts
+++ b/tests/unit/oauth-d1-adapter.test.ts
@@ -1,0 +1,163 @@
+/**
+ * D1Adapter unit test — V2-P1 (per docs/v2-oauth-server-plan.md)
+ *
+ * Mock D1Database 接口，驗 SQL string + bind params + lazy expiration check。
+ * 不跑真 SQLite，純 contract test：upsert/find/findByUid/consume/destroy/revokeByGrantId/sweepExpired。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { D1Adapter } from '../../src/server/oauth-d1-adapter';
+import type { D1Database } from '@cloudflare/workers-types';
+
+interface MockStmt {
+  bind: ReturnType<typeof vi.fn>;
+  first: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+  all?: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDb(firstResult: unknown = null, runMeta: { changes?: number } = {}): { db: D1Database; stmt: MockStmt; prepare: ReturnType<typeof vi.fn> } {
+  const stmt: MockStmt = {
+    bind: vi.fn(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: runMeta }),
+  };
+  stmt.bind.mockReturnValue(stmt); // chain
+  const prepare = vi.fn().mockReturnValue(stmt);
+  const db = { prepare } as unknown as D1Database;
+  return { db, stmt, prepare };
+}
+
+describe('D1Adapter — Panva oidc-provider Adapter contract', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+  });
+
+  describe('upsert', () => {
+    it('INSERT OR REPLACE with name + id + JSON payload + expires_at = now + ms', async () => {
+      const { db, stmt, prepare } = makeMockDb();
+      const adapter = new D1Adapter(db, 'Session');
+      await adapter.upsert('jti-123', { uid: 'u1', exp: 999 }, 600);
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT OR REPLACE INTO oauth_models'));
+      expect(stmt.bind).toHaveBeenCalledWith(
+        'Session',
+        'jti-123',
+        JSON.stringify({ uid: 'u1', exp: 999 }),
+        Date.now() + 600 * 1000,
+      );
+      expect(stmt.run).toHaveBeenCalled();
+    });
+  });
+
+  describe('find', () => {
+    it('returns parsed payload when found and not expired', async () => {
+      const future = Date.now() + 1000;
+      const { db } = makeMockDb({ payload: '{"uid":"u1"}', expires_at: future });
+      const adapter = new D1Adapter(db, 'Session');
+      const result = await adapter.find('jti-123');
+      expect(result).toEqual({ uid: 'u1' });
+    });
+
+    it('returns undefined when row not found', async () => {
+      const { db } = makeMockDb(null);
+      const adapter = new D1Adapter(db, 'Session');
+      expect(await adapter.find('missing')).toBeUndefined();
+    });
+
+    it('returns undefined when expired (lazy delete on read)', async () => {
+      const past = Date.now() - 1000;
+      const { db } = makeMockDb({ payload: '{"uid":"u1"}', expires_at: past });
+      const adapter = new D1Adapter(db, 'Session');
+      expect(await adapter.find('jti-expired')).toBeUndefined();
+    });
+
+    it('SQL filters by name + id', async () => {
+      const { db, stmt, prepare } = makeMockDb({ payload: '{}', expires_at: Date.now() + 1000 });
+      const adapter = new D1Adapter(db, 'AccessToken');
+      await adapter.find('token-abc');
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('WHERE name = ? AND id = ?'));
+      expect(stmt.bind).toHaveBeenCalledWith('AccessToken', 'token-abc');
+    });
+  });
+
+  describe('findByUserCode', () => {
+    it('throws not-implemented (V2-P5 device flow)', async () => {
+      const { db } = makeMockDb();
+      const adapter = new D1Adapter(db, 'DeviceCode');
+      await expect(adapter.findByUserCode('user-code')).rejects.toThrow(/not implemented/);
+    });
+  });
+
+  describe('findByUid', () => {
+    it('uses json_extract(payload, $.uid) filter', async () => {
+      const future = Date.now() + 1000;
+      const { db, stmt, prepare } = makeMockDb({ payload: '{"uid":"sess-u1"}', expires_at: future });
+      const adapter = new D1Adapter(db, 'Session');
+      const result = await adapter.findByUid('sess-u1');
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('json_extract(payload, ?)'));
+      expect(stmt.bind).toHaveBeenCalledWith('Session', '$.uid', 'sess-u1');
+      expect(result).toEqual({ uid: 'sess-u1' });
+    });
+
+    it('returns undefined when expired', async () => {
+      const past = Date.now() - 1000;
+      const { db } = makeMockDb({ payload: '{"uid":"u1"}', expires_at: past });
+      const adapter = new D1Adapter(db, 'Session');
+      expect(await adapter.findByUid('u1')).toBeUndefined();
+    });
+  });
+
+  describe('consume', () => {
+    it('UPDATE payload set $.consumed = now() (authorization_code one-shot)', async () => {
+      const { db, stmt, prepare } = makeMockDb();
+      const adapter = new D1Adapter(db, 'AuthorizationCode');
+      await adapter.consume('code-xyz');
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('UPDATE oauth_models'));
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('json_set(payload, ?'));
+      expect(stmt.bind).toHaveBeenCalledWith('$.consumed', Date.now(), 'AuthorizationCode', 'code-xyz');
+    });
+  });
+
+  describe('destroy', () => {
+    it('DELETE by name + id', async () => {
+      const { db, stmt, prepare } = makeMockDb();
+      const adapter = new D1Adapter(db, 'RefreshToken');
+      await adapter.destroy('rt-123');
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM oauth_models WHERE name = ? AND id = ?'));
+      expect(stmt.bind).toHaveBeenCalledWith('RefreshToken', 'rt-123');
+      expect(stmt.run).toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeByGrantId', () => {
+    it('DELETE across all names by json_extract($.grantId)', async () => {
+      const { db, stmt, prepare } = makeMockDb();
+      const adapter = new D1Adapter(db, 'AccessToken');
+      await adapter.revokeByGrantId('grant-xyz');
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM oauth_models WHERE json_extract(payload, ?)'));
+      expect(stmt.bind).toHaveBeenCalledWith('$.grantId', 'grant-xyz');
+    });
+  });
+
+  describe('sweepExpired (static maintenance)', () => {
+    it('DELETE all expired rows + return count', async () => {
+      const { db, stmt, prepare } = makeMockDb(null, { changes: 42 });
+      const count = await D1Adapter.sweepExpired(db);
+
+      expect(prepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM oauth_models WHERE expires_at < ?'));
+      expect(stmt.bind).toHaveBeenCalledWith(Date.now());
+      expect(count).toBe(42);
+    });
+
+    it('returns 0 when meta.changes missing', async () => {
+      const { db } = makeMockDb(null, {});
+      const count = await D1Adapter.sweepExpired(db);
+      expect(count).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 OAuth Server **first slice**（per \`docs/v2-oauth-server-plan.md\` Week 1-2 deliverables）：D1 schema + D1Adapter for Panva oidc-provider。HTTP endpoints (Koa↔Fetch bridge) + Google OIDC client 留下個 PR。

> ⚠️ **Day-0 demand 驗證 2 件**（Cloudflare Access deny log + 第三方 dev interview，memory \`project_day0_demand_verify\`）尚未完成。使用者選擇 skip prerequisite 直接啟動 V2-P1 — 接受 14 週 work risk 沒真需求。

## Migrations

### 0031 — \`oauth_models\`
Single-table generic store for Panva oidc-provider 所有 model types。設計取捨在 migration 註解。3 indexes：expires_at (sweep) / json_extract($.grantId) (revoke) / json_extract($.uid) (findByUid)。

### 0032 — \`users\` + \`auth_identities\`
Provider-agnostic schema 預留 Apple/LINE/local/Google。\`auth_identities\` UNIQUE (provider, provider_user_id) 確保同 provider sub 只 link 一個 user。既有 \`saved_pois.email\` / \`trip_permissions.email\` backfill script 留 V2-P1 後跑（不破壞既有 row）。

## D1Adapter

\`src/server/oauth-d1-adapter.ts\` 實作 Panva [Adapter interface](https://github.com/panva/node-oidc-provider/blob/main/lib/models/adapter.js) 全 6 method：

| Method | 行為 |
|--------|------|
| \`upsert\` | INSERT OR REPLACE，expires_at = now + ms |
| \`find\` | SELECT，過期 row 視為不存在（lazy delete on read）|
| \`findByUid\` | json_extract($.uid) filter（Session lookup）|
| \`consume\` | UPDATE json_set($.consumed) — authorization_code one-shot |
| \`destroy\` | DELETE by name + id |
| \`revokeByGrantId\` | DELETE 跨 name by json_extract($.grantId) |
| \`findByUserCode\` | throws not-implemented（V2-P5 device flow） |
| \`sweepExpired\` (static) | DELETE expired rows + return count（V2-P6 cron）|

## Test

\`tests/unit/oauth-d1-adapter.test.ts\` **13 cases pass**（mock D1Database 接口，純 contract test）：
- SQL string assertions
- bind params 順序
- lazy expire on find / findByUid
- consume / destroy / revoke 行為
- sweepExpired count

## Out of scope this PR

| Next slice | Why |
|-----------|-----|
| \`functions/api/oauth/\` HTTP handlers | 需要 Koa↔Fetch bridge (~100 行 adapter) |
| Google OIDC client integration | tripline 當 OAuth Client to Google，要 setup Google project + redirect_uri whitelist |
| Session cookie + CSRF middleware | 跟 OAuth flow 整合複雜 |
| \`spike.ts\` cleanup | 移除或 rewrite 成正式 well-known/openid-configuration endpoint |
| \`saved_pois.email\` / \`trip_permissions.email\` → \`user_id\` backfill | migration script + cutover plan |

## Test plan

- [x] \`npx vitest run tests/unit/oauth-d1-adapter.test.ts\` 13 pass
- [x] full vitest suite pass + tsc clean (frontend + functions both)
- [ ] Post-merge：\`npm run dev:reset\` 跑 local migration 確認 0031 + 0032 schema apply 成功
- [ ] Post-merge：\`wrangler d1 migrations apply trip-planner-db --local\` verify 沒 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)