### PR TITLE
feat(v2-p1): _middleware.ts /api/oauth/* auth bypass

### DIFF
--- a/functions/api/_middleware.ts
+++ b/functions/api/_middleware.ts
@@ -242,6 +242,16 @@ async function handleAuth(
     }
   }
 
+  // V2-P1：/api/oauth/* 全部 public — OAuth endpoints 自管 auth
+  // (PKCE / client_secret / JWT)，由 oidc-provider 處理。User-session middleware
+  // 不該攔截，否則 external client + browser OAuth flow 都被 401。
+  // 包含：spike (V2 Day 0) / .well-known/openid-configuration / authorize / token /
+  // revoke / par 等所有 OAuth endpoints。
+  if (url.pathname.startsWith('/api/oauth/')) {
+    (context.data as Record<string, unknown>).auth = null;
+    return context.next();
+  }
+
   // 公開端點：POST /api/reports（使用者錯誤回報，不需認證）
   if (request.method === 'POST' && url.pathname === '/api/reports') {
     (context.data as Record<string, unknown>).auth = null;

--- a/tests/api/middleware-oauth-bypass.test.ts
+++ b/tests/api/middleware-oauth-bypass.test.ts
@@ -1,0 +1,48 @@
+/**
+ * _middleware.ts /api/oauth/* bypass 結構測試（V2-P1）
+ *
+ * 驗 source 含 OAuth bypass logic — OAuth endpoints 自管 auth (PKCE / JWT)，
+ * 不該被 user-session middleware 攔截 401。
+ *
+ * 用 source-level test 而非 integration（避 miniflare setup 成本）；
+ * end-to-end 行為靠 prod curl /api/oauth/spike 200 確認（next session post-deploy）。
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIDDLEWARE_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../../functions/api/_middleware.ts'),
+  'utf8',
+);
+
+describe('_middleware.ts — OAuth bypass (V2-P1)', () => {
+  it('含 /api/oauth/ pathname startsWith bypass block', () => {
+    expect(MIDDLEWARE_SRC).toMatch(/url\.pathname\.startsWith\(['"]\/api\/oauth\/['"]/);
+  });
+
+  it('bypass 設 auth = null 並 context.next()', () => {
+    // 抓 OAuth pattern 後 5 行 window 找 auth = null + context.next()
+    const lines = MIDDLEWARE_SRC.split('\n');
+    const oauthLineIdx = lines.findIndex((l) => l.includes("'/api/oauth/'") || l.includes('"/api/oauth/"'));
+    expect(oauthLineIdx).toBeGreaterThan(0);
+    const window = lines.slice(oauthLineIdx, oauthLineIdx + 5).join('\n');
+    expect(window).toMatch(/auth\s*=\s*null/);
+    expect(window).toMatch(/context\.next\(\)/);
+  });
+
+  it('bypass 在「公開端點：POST /api/reports」block 之前（先 short-circuit）', () => {
+    const oauthIdx = MIDDLEWARE_SRC.indexOf('/api/oauth/');
+    const reportsIdx = MIDDLEWARE_SRC.indexOf("/api/reports'");
+    expect(oauthIdx).toBeGreaterThan(0);
+    expect(reportsIdx).toBeGreaterThan(0);
+    expect(oauthIdx, 'oauth bypass 該在 /api/reports 之前').toBeLessThan(reportsIdx);
+  });
+
+  it('bypass 在 method+UTF-8 check 之後（仍套用 body encoding 驗證）', () => {
+    const utf8CheckIdx = MIDDLEWARE_SRC.indexOf('detectGarbledText');
+    const oauthIdx = MIDDLEWARE_SRC.indexOf('/api/oauth/');
+    expect(utf8CheckIdx, 'UTF-8 check 該在 source 中').toBeGreaterThan(0);
+    expect(oauthIdx, 'oauth bypass 該在 UTF-8 check 之後').toBeGreaterThan(utf8CheckIdx);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 next slice — 解決 V2 Day 0 spike Step 6 觀察的 prod \`/api/oauth/spike\` 401 問題。

OAuth endpoints 是 **public** by design：external client + browser 都會 hit 不帶 user-session cookie。OAuth flow 自管 auth（PKCE / client_secret / JWT signature）由 Panva oidc-provider 處理。User-session middleware 不該攔截，否則 standard OAuth flow 全 401。

## Diff

\`functions/api/_middleware.ts\` 加 OAuth bypass block：

```ts
// V2-P1：/api/oauth/* 全部 public — OAuth endpoints 自管 auth
if (url.pathname.startsWith('/api/oauth/')) {
  (context.data as Record<string, unknown>).auth = null;
  return context.next();
}
```

位置：UTF-8 body check 之後（仍套用 encoding 驗證），\`/api/reports\` public block 之前（先 short-circuit）。

## Effect

```bash
# Before
curl https://trip-planner-dby.pages.dev/api/oauth/spike
# → 401 {"error":{"code":"AUTH_REQUIRED"}}

# After (post-merge)
curl https://trip-planner-dby.pages.dev/api/oauth/spike
# → 200 {"ok":true,"issuer":"...","message":"oidc-provider imported + instantiated..."}
```

最後驗證 V2 Day 0 spike 在 **prod runtime** 真的 work（之前只本機 dev 跑過）。

## Test

\`tests/api/middleware-oauth-bypass.test.ts\` 4 cases source-level 驗：
- 含 \`startsWith('/api/oauth/')\` pattern
- bypass 設 \`auth = null\` + \`context.next()\`
- bypass 在 \`/api/reports\` 之前（先 short-circuit）
- bypass 在 UTF-8 \`detectGarbledText\` check 之後（仍套用）

## Out of scope this PR (next slice)

- \`functions/api/oauth/.well-known/openid-configuration.ts\` real endpoint（取代 spike.ts）
- Koa↔Fetch bridge for oidc-provider Node HTTP handler (~100 行)
- Google OIDC client flow

## OAuth endpoint inventory（all bypass active）

| Endpoint | Status |
|----------|--------|
| GET /api/oauth/spike | exists (V2 Day 0 spike) |
| GET /api/oauth/.well-known/openid-configuration | next PR |
| GET /api/oauth/authorize | next PR |
| POST /api/oauth/token | next PR |
| POST /api/oauth/revoke | next PR |
| POST /api/oauth/par | future (V2-P5) |

## Test plan

- [x] 4 cases TDD pass (api config)
- [x] full vitest pass + tsc clean
- [ ] Post-merge：\`curl prod /api/oauth/spike\` 看 200 (not 401)
- [ ] Post-merge：confirm spike result Step 6 prod verification 完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)