### PR TITLE
chore(v2-p1): mark spike.ts deprecated — RFC 8594 Sunset + Link successor

### DIFF
--- a/functions/api/oauth/spike.ts
+++ b/functions/api/oauth/spike.ts
@@ -1,4 +1,8 @@
 /**
+ * @deprecated V2-P1 完成 OIDC Discovery + JWKS endpoints 後 spike 已過任務目標。
+ *   未來 V2-P2 整合 oidc-provider Koa↔Fetch bridge 後此檔應移除。
+ *   保留至 V2-P2 ship — V2 Day 0 spike result 的 prod runtime verify 仍會用到。
+ *
  * V2 Day 0 spike endpoint — 驗 oidc-provider 在 CF Pages Functions 能否 import + instantiate
  *
  * 跑法：
@@ -13,18 +17,32 @@
  *   - import 本身失敗（wrangler 啟動就 crash）→ fallback 到 @openauthjs/openauth + KV
  *
  * 結果寫到 docs/v2-oauth-spike-result.md
+ *
+ * Response 加 RFC 8594 Deprecation + Sunset headers + Link to successor discovery endpoint。
  */
 
 // @ts-expect-error — oidc-provider 在 Day 0 spike 期 types 未完整接 Workers runtime，先忽略
 import Provider from 'oidc-provider';
 
-export const onRequestGet: PagesFunction = async () => {
+/** Sunset date — V2-P2 Koa↔Fetch bridge ship 後 retire。預估 2026-06-30 留 2 個月 buffer。 */
+const SUNSET_DATE = 'Tue, 30 Jun 2026 00:00:00 GMT';
+
+function deprecationHeaders(request: Request): Record<string, string> {
+  const origin = new URL(request.url).origin;
+  return {
+    'Deprecation': 'true',
+    'Sunset': SUNSET_DATE,
+    'Link': `<${origin}/api/oauth/.well-known/openid-configuration>; rel="successor-version"`,
+  };
+}
+
+export const onRequestGet: PagesFunction = async (context) => {
   try {
     const provider = new Provider('https://trip-planner-dby.pages.dev', {
       clients: [
         {
-          client_id: 'test-client',
-          client_secret: 'test-secret-change-me',
+          client_id: 'spike-test-client',
+          client_secret: 'spike-test-secret-not-for-production',
           redirect_uris: ['https://example.com/cb'],
         },
       ],
@@ -36,11 +54,18 @@ export const onRequestGet: PagesFunction = async () => {
           ok: true,
           message: 'oidc-provider imported + instantiated inside CF Pages Functions (nodejs_compat)',
           issuer: provider.issuer,
+          deprecated: true,
+          successor: '/api/oauth/.well-known/openid-configuration',
         },
         null,
         2,
       ),
-      { headers: { 'content-type': 'application/json; charset=utf-8' } },
+      {
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          ...deprecationHeaders(context.request),
+        },
+      },
     );
   } catch (err: unknown) {
     const e = err as Error;
@@ -57,7 +82,10 @@ export const onRequestGet: PagesFunction = async () => {
       ),
       {
         status: 500,
-        headers: { 'content-type': 'application/json; charset=utf-8' },
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          ...deprecationHeaders(context.request),
+        },
       },
     );
   }

--- a/tests/api/oauth-spike-deprecation.test.ts
+++ b/tests/api/oauth-spike-deprecation.test.ts
@@ -1,0 +1,53 @@
+/**
+ * /api/oauth/spike deprecation headers 測試（V2-P1）
+ *
+ * RFC 8594 Sunset + Deprecation + Link rel=successor-version。
+ * 確保 client 收 spike 回應時看到 deprecation 訊號，可遷到 discovery endpoint。
+ */
+import { describe, it, expect } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/spike';
+
+function makeContext(url: string): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url),
+    env: {} as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+describe('GET /api/oauth/spike — deprecation headers', () => {
+  it('Deprecation: true header', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/spike'));
+    expect(res.headers.get('Deprecation')).toBe('true');
+  });
+
+  it('Sunset header (RFC 8594) — V2-P2 ship 後 retire date', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/spike'));
+    const sunset = res.headers.get('Sunset');
+    expect(sunset).toBeTruthy();
+    expect(sunset).toMatch(/2026/); // sunset year
+  });
+
+  it('Link header rel=successor-version 指向 discovery endpoint', async () => {
+    const res = await onRequestGet(makeContext('https://trip-planner-dby.pages.dev/api/oauth/spike'));
+    const link = res.headers.get('Link');
+    expect(link).toMatch(/successor-version/);
+    expect(link).toMatch(/\/api\/oauth\/\.well-known\/openid-configuration/);
+  });
+
+  it('Link header origin from request URL (not hardcoded)', async () => {
+    const res = await onRequestGet(makeContext('http://localhost:8788/api/oauth/spike'));
+    expect(res.headers.get('Link')).toMatch(/http:\/\/localhost:8788\/api\/oauth\/\.well-known\/openid-configuration/);
+  });
+
+  it('response body 含 deprecated: true + successor path', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/spike'));
+    const json = await res.json() as { deprecated?: boolean; successor?: string };
+    expect(json.deprecated).toBe(true);
+    expect(json.successor).toBe('/api/oauth/.well-known/openid-configuration');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 4 個 PR ship 後（migration / adapter / middleware bypass / discovery + JWKS），spike 已過任務目標。本 PR 加 RFC 8594 standard deprecation 訊號，但**保留 endpoint 至 V2-P2 ship** — V2 Day 0 spike result 的 prod runtime verify 仍會 reference。

## Headers (RFC 8594)

```
Deprecation: true
Sunset: Tue, 30 Jun 2026 00:00:00 GMT
Link: <origin>/api/oauth/.well-known/openid-configuration; rel="successor-version"
```

Response body 加：
```json
{ "ok": true, ..., "deprecated": true, "successor": "/api/oauth/.well-known/openid-configuration" }
```

## Why keep until V2-P2

Spike 的 value：driver test \`oidc-provider\` 在 prod CF Workers runtime 是否真 instantiate 成功（非 cold-start fail）。V2-P2 整合 oidc-provider 跟 Koa↔Fetch bridge 後，其他 endpoints (authorize/token) 自然 verify runtime — spike 才 retire。

Sunset \`2026-06-30\` 是 V2-P2 預估 ship + 2 個月 client migration buffer。

## Cleanup

- Rename \`test-client\` → \`spike-test-client\` / \`test-secret-change-me\` → \`spike-test-secret-not-for-production\` 避免 prod code 看到 generic test fixtures 誤會

## Test

\`tests/api/oauth-spike-deprecation.test.ts\` 5 cases 驗 RFC 8594 headers + body fields。

## V2-P1 cumulative progress（5 PR）

- ✓ Migration 0031 oauth_models (PR #254)
- ✓ Migration 0032 users + auth_identities (PR #254)
- ✓ D1Adapter for oidc-provider (PR #254)
- ✓ /api/oauth/* middleware bypass (PR #255)
- ✓ Discovery + JWKS endpoints (PR #256)
- ✓ **Spike deprecation (本 PR)**

## Test plan

- [x] 5 cases TDD pass
- [x] full suite + tsc clean
- [ ] Post-merge: \`curl -I https://trip-planner-dby.pages.dev/api/oauth/spike\` 看 \`Deprecation\` / \`Sunset\` / \`Link\` headers
- [ ] V2-P2 ship 後 retire spike endpoint + 移除本 deprecation block

🤖 Generated with [Claude Code](https://claude.com/claude-code)