### PR TITLE
feat(v2-p1): session token module — HMAC-SHA256 opaque sessions

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,0 +1,149 @@
+/**
+ * Session token module — V2-P1 (per docs/v2-oauth-server-plan.md V2-P6 spec)
+ *
+ * Opaque session cookie + SHA-256 HMAC（非 JWT — 避免 JWT 慣性 sec issues：
+ * alg=none, key confusion, expiry-bypass-via-payload-edit 等）。Token 結構：
+ *
+ *   <base64url payload>.<base64url hmac>
+ *
+ * Payload JSON 含：
+ *   - uid: user.id
+ *   - iat: issued at (unix sec)
+ *   - exp: expires at (unix sec)
+ *   - csrf: CSRF token (32 bytes random，POST/PUT/DELETE 都驗)
+ *
+ * 驗證：HMAC(secret, payload) === provided_hmac → 接受；過期 reject。
+ *
+ * 為何用 Web Crypto 而非 JWT lib：
+ *   - CF Workers Web Crypto 是 native，不需 nodejs_compat
+ *   - 控制權：自定 payload schema 不必 jose / jsonwebtoken 依賴
+ *   - Spec align：V2-P6 explicit「opaque session cookie + SHA-256 hash（非 JWT）」
+ *
+ * 不負責（其他 module）：
+ *   - User authentication（OAuth flow / password verify → 才 issue session）
+ *   - Cookie storage（這個 module 只管 sign/verify token string；
+ *     setSessionCookie / getSessionCookie helper 在 functions/api/_cookies.ts）
+ */
+
+const SESSION_VERSION = 1;
+const ALG = 'SHA-256';
+
+export interface SessionPayload {
+  uid: string;
+  iat: number;
+  exp: number;
+  csrf: string;
+  /** Schema version 預留 — V2-P1 = 1 */
+  v: number;
+  [key: string]: unknown;
+}
+
+/** base64url (no padding, URL-safe) — sign 用，跟 JWT 同 encoding */
+function base64urlEncode(bytes: Uint8Array | string): string {
+  const buf = typeof bytes === 'string' ? new TextEncoder().encode(bytes) : bytes;
+  let str = '';
+  // noUncheckedIndexedAccess: buf[i] 是 number | undefined；range 安全用 ! assertion
+  for (let i = 0; i < buf.length; i++) str += String.fromCharCode(buf[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - (s.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: ALG },
+    false,
+    ['sign', 'verify'],
+  );
+}
+
+async function hmacSign(secret: string, data: string): Promise<string> {
+  const key = await importHmacKey(secret);
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return base64urlEncode(new Uint8Array(sig));
+}
+
+/** Constant-time compare — 避免 timing attack 推 HMAC byte-by-byte */
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** Generate cryptographically random CSRF token (32 bytes → 43 char base64url) */
+export function generateCsrfToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64urlEncode(bytes);
+}
+
+/**
+ * Sign session token — return `<payload>.<hmac>` string。
+ *
+ * @param uid user.id
+ * @param secret session signing secret (env)
+ * @param ttlSeconds default 30 days (long-lived web session)
+ */
+export async function signSessionToken(
+  uid: string,
+  secret: string,
+  ttlSeconds = 30 * 24 * 60 * 60,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: SessionPayload = {
+    v: SESSION_VERSION,
+    uid,
+    iat: now,
+    exp: now + ttlSeconds,
+    csrf: generateCsrfToken(),
+  };
+  const payloadStr = base64urlEncode(JSON.stringify(payload));
+  const sig = await hmacSign(secret, payloadStr);
+  return `${payloadStr}.${sig}`;
+}
+
+/**
+ * Verify session token — return parsed payload if valid, null otherwise。
+ *
+ * Reject conditions:
+ *   - format invalid (not exactly 1 dot)
+ *   - HMAC mismatch (tampered or wrong secret)
+ *   - exp < now (expired)
+ *   - v not supported (future schema migration)
+ */
+export async function verifySessionToken(
+  token: string,
+  secret: string,
+): Promise<SessionPayload | null> {
+  const parts = token.split('.');
+  if (parts.length !== 2) return null;
+  const [payloadStr, providedSig] = parts;
+  // noUncheckedIndexedAccess 推為 string | undefined — runtime 已 length===2 但 TS 不知
+  if (!payloadStr || !providedSig) return null;
+
+  const expectedSig = await hmacSign(secret, payloadStr);
+  if (!constantTimeEquals(expectedSig, providedSig)) return null;
+
+  let payload: SessionPayload;
+  try {
+    const json = new TextDecoder().decode(base64urlDecode(payloadStr));
+    payload = JSON.parse(json) as SessionPayload;
+  } catch {
+    return null;
+  }
+
+  if (payload.v !== SESSION_VERSION) return null;
+  if (typeof payload.exp !== 'number' || payload.exp < Math.floor(Date.now() / 1000)) return null;
+  if (typeof payload.uid !== 'string' || !payload.uid) return null;
+
+  return payload;
+}

--- a/tests/unit/session-module.test.ts
+++ b/tests/unit/session-module.test.ts
@@ -1,0 +1,113 @@
+/**
+ * src/server/session.ts unit test — V2-P1
+ *
+ * Sign/verify roundtrip + tamper detection + expiry + format validation。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  signSessionToken,
+  verifySessionToken,
+  generateCsrfToken,
+} from '../../src/server/session';
+
+const SECRET = 'test-session-secret-not-real-prod';
+
+describe('session module', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+  });
+
+  describe('generateCsrfToken', () => {
+    it('returns base64url string ~43 chars (32 bytes)', () => {
+      const token = generateCsrfToken();
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/); // base64url (no +/=)
+      expect(token.length).toBeGreaterThanOrEqual(40);
+      expect(token.length).toBeLessThanOrEqual(44);
+    });
+
+    it('generates unique tokens (random)', () => {
+      const tokens = new Set();
+      for (let i = 0; i < 50; i++) tokens.add(generateCsrfToken());
+      expect(tokens.size).toBe(50);
+    });
+  });
+
+  describe('signSessionToken / verifySessionToken roundtrip', () => {
+    it('sign + verify same secret → returns parsed payload with uid + iat + exp + csrf + v', async () => {
+      const token = await signSessionToken('user-uuid-123', SECRET);
+      const payload = await verifySessionToken(token, SECRET);
+      expect(payload).not.toBeNull();
+      expect(payload?.uid).toBe('user-uuid-123');
+      expect(payload?.v).toBe(1);
+      expect(typeof payload?.iat).toBe('number');
+      expect(typeof payload?.exp).toBe('number');
+      expect(typeof payload?.csrf).toBe('string');
+      expect(payload!.exp - payload!.iat).toBe(30 * 24 * 60 * 60); // default 30d
+    });
+
+    it('custom TTL respected', async () => {
+      const token = await signSessionToken('uid-1', SECRET, 600); // 10 min
+      const payload = await verifySessionToken(token, SECRET);
+      expect(payload?.exp).toBe(payload!.iat + 600);
+    });
+
+    it('verify with different secret → null (HMAC mismatch)', async () => {
+      const token = await signSessionToken('uid-1', SECRET);
+      expect(await verifySessionToken(token, 'wrong-secret')).toBeNull();
+    });
+
+    it('verify expired token → null', async () => {
+      const token = await signSessionToken('uid-1', SECRET, 60); // 1min TTL
+      vi.advanceTimersByTime(61 * 1000); // jump 61s
+      expect(await verifySessionToken(token, SECRET)).toBeNull();
+    });
+
+    it('format invalid (no dot) → null', async () => {
+      expect(await verifySessionToken('not-a-valid-token', SECRET)).toBeNull();
+    });
+
+    it('format invalid (3 dots like JWT) → null', async () => {
+      expect(await verifySessionToken('a.b.c', SECRET)).toBeNull();
+    });
+
+    it('payload tamper (modify base64url payload but keep HMAC) → null', async () => {
+      const token = await signSessionToken('uid-1', SECRET);
+      const [, sig] = token.split('.');
+      // Replace payload with alternative valid base64url but different content
+      const tampered = `eyJ2IjoxLCJ1aWQiOiJoYWNrZXIifQ.${sig}`;
+      expect(await verifySessionToken(tampered, SECRET)).toBeNull();
+    });
+
+    it('payload version mismatch (v=999) → null (schema migration safety)', async () => {
+      // Manually craft a payload with v=999 + valid HMAC for that payload
+      const fakePayload = {
+        v: 999, uid: 'u1', iat: 1, exp: 9999999999, csrf: 'x',
+      };
+      const json = JSON.stringify(fakePayload);
+      const b64 = btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      // We need to compute HMAC with same algorithm as production code
+      const key = await crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(SECRET),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign'],
+      );
+      const sigBytes = new Uint8Array(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(b64)));
+      let sigStr = '';
+      for (let i = 0; i < sigBytes.length; i++) sigStr += String.fromCharCode(sigBytes[i]);
+      const sig = btoa(sigStr).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      const token = `${b64}.${sig}`;
+      expect(await verifySessionToken(token, SECRET)).toBeNull();
+    });
+
+    it('csrf token is unique per session (each sign creates new)', async () => {
+      const t1 = await signSessionToken('uid-1', SECRET);
+      const t2 = await signSessionToken('uid-1', SECRET);
+      const p1 = await verifySessionToken(t1, SECRET);
+      const p2 = await verifySessionToken(t2, SECRET);
+      expect(p1?.csrf).not.toBe(p2?.csrf);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 5th slice — \`src/server/session.ts\` HMAC-SHA256 opaque session token module。為後續 OAuth flow + login 鋪路。

## Why opaque + HMAC (not JWT)

- 避免 JWT 慣性 sec issues：\`alg=none\` / key confusion / 用 base64 編解碼 bypass expiry 等
- Spec align V2-P6：「opaque session cookie + SHA-256 hash（非 JWT）」
- Web Crypto native，不需 nodejs_compat
- Payload schema 受我們完全控制

## Token format

```
<base64url(JSON)>.<base64url(HMAC-SHA256)>
```

Payload schema:
```ts
{
  v: 1,           // schema version
  uid: string,    // user.id
  iat: number,    // issued at (unix sec)
  exp: number,    // expires at (unix sec)
  csrf: string    // 32-byte random base64url
}
```

## API

```ts
import { signSessionToken, verifySessionToken, generateCsrfToken } from './session';

const token = await signSessionToken(user.id, env.SESSION_SECRET); // 30d default
const payload = await verifySessionToken(token, env.SESSION_SECRET);
if (!payload) { /* invalid / expired / tampered */ }
```

## Reject conditions

- Format invalid (not exactly 1 dot / 3 dots like JWT)
- HMAC mismatch (tampered or wrong secret)
- \`exp < now\` (expired)
- \`v\` not 1 (future schema migration)
- payload non-JSON / \`uid\` missing
- Constant-time HMAC compare (避 timing attack)

## Test

\`tests/unit/session-module.test.ts\` **11 cases TDD pass**:
- csrf token uniqueness + base64url format
- sign+verify roundtrip + custom TTL
- wrong secret / expired / format invalid (no dot, 3 dots)
- payload tamper detection (replace payload but keep HMAC → reject)
- schema version mismatch (v=999 → null)
- csrf unique per sign call

Full suite **799 pass** + tsc clean。

## V2-P1 cumulative progress (7 PR)

- ✓ Migration + adapter (#254)
- ✓ /api/oauth/* middleware bypass (#255)
- ✓ Discovery + JWKS endpoints (#256)
- ✓ spike RFC 8594 deprecation (#257)
- ✓ **session token module (本 PR)**

## Next slice

- \`functions/api/_cookies.ts\`: setSessionCookie / getSessionCookie helpers (httpOnly + Secure + SameSite=Lax)
- LoginPage UI: sign-in button + click → redirect /api/oauth/authorize
- Google OIDC client integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)