### PR TITLE
feat(v2-p1): session cookie helpers — _cookies.ts module

### DIFF
--- a/functions/api/_cookies.ts
+++ b/functions/api/_cookies.ts
@@ -1,0 +1,70 @@
+/**
+ * Cookie helpers — V2-P1 session cookie 操作
+ *
+ * 提供 typesafe getter / setter / clearer for `tripline_session` cookie，
+ * 配合 src/server/session.ts 的 sign/verify token 使用。
+ *
+ * Cookie 屬性：
+ *   - HttpOnly：JS 不能讀（防 XSS 偷 token）
+ *   - Secure：只 HTTPS 傳（local dev 用 SameSite=Lax 仍 work over http）
+ *   - SameSite=Lax：跨站 GET 帶 cookie（OAuth redirect callback 需要），
+ *     但 form POST 等 cross-site 不帶 — 防 CSRF（搭配 token 內的 csrf 欄位）
+ *   - Path=/：全站可讀（API + SPA）
+ *   - Max-Age：跟 token 內 exp 對齊（session module 預設 30 天）
+ */
+
+const COOKIE_NAME = 'tripline_session';
+const DEFAULT_MAX_AGE = 30 * 24 * 60 * 60; // 30 days, sec
+
+/** Parse Cookie header → 取 tripline_session 的 value（沒有則 null） */
+export function getSessionCookie(request: Request): string | null {
+  const header = request.headers.get('Cookie');
+  if (!header) return null;
+  const cookies = header.split(';').map((c) => c.trim());
+  for (const c of cookies) {
+    const [key, ...rest] = c.split('=');
+    if (key?.trim() === COOKIE_NAME) return rest.join('=');
+  }
+  return null;
+}
+
+/**
+ * Build Set-Cookie header value for session cookie。
+ *
+ * 注意：CF Workers Response.headers 不支援 setCookie API，要 append 到
+ * 'Set-Cookie' header。caller 自行 `response.headers.append('Set-Cookie', value)`。
+ */
+export function buildSessionSetCookie(token: string, options: { maxAge?: number; secure?: boolean } = {}): string {
+  const maxAge = options.maxAge ?? DEFAULT_MAX_AGE;
+  // Local dev (http://localhost) 不該設 Secure，否則 cookie 不傳。生產一定要 Secure。
+  const secure = options.secure ?? true;
+  const parts = [
+    `${COOKIE_NAME}=${token}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${maxAge}`,
+  ];
+  if (secure) parts.push('Secure');
+  return parts.join('; ');
+}
+
+/** Build Set-Cookie header value to clear session（logout） */
+export function buildClearSessionSetCookie(secure = true): string {
+  const parts = [
+    `${COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    'Max-Age=0',
+    'Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+  ];
+  if (secure) parts.push('Secure');
+  return parts.join('; ');
+}
+
+/** 判斷 request URL 是否應設 Secure cookie（http://localhost 不該）。 */
+export function shouldSetSecure(request: Request): boolean {
+  const url = new URL(request.url);
+  return url.protocol === 'https:';
+}

--- a/tests/api/cookies-module.test.ts
+++ b/tests/api/cookies-module.test.ts
@@ -1,0 +1,97 @@
+/**
+ * functions/api/_cookies.ts unit test — V2-P1
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getSessionCookie,
+  buildSessionSetCookie,
+  buildClearSessionSetCookie,
+  shouldSetSecure,
+} from '../../functions/api/_cookies';
+
+describe('getSessionCookie', () => {
+  it('returns null when no Cookie header', () => {
+    const req = new Request('https://x.com');
+    expect(getSessionCookie(req)).toBeNull();
+  });
+
+  it('returns null when Cookie header empty', () => {
+    const req = new Request('https://x.com', { headers: { Cookie: '' } });
+    expect(getSessionCookie(req)).toBeNull();
+  });
+
+  it('returns null when no tripline_session in Cookie', () => {
+    const req = new Request('https://x.com', { headers: { Cookie: 'foo=bar; baz=qux' } });
+    expect(getSessionCookie(req)).toBeNull();
+  });
+
+  it('returns token value when present', () => {
+    const req = new Request('https://x.com', {
+      headers: { Cookie: 'foo=bar; tripline_session=eyJhbGc.signature; baz=qux' },
+    });
+    expect(getSessionCookie(req)).toBe('eyJhbGc.signature');
+  });
+
+  it('handles cookie value with = inside (base64url 不會但 future-proof)', () => {
+    const req = new Request('https://x.com', {
+      headers: { Cookie: 'tripline_session=a=b=c' },
+    });
+    expect(getSessionCookie(req)).toBe('a=b=c');
+  });
+
+  it('trims whitespace around key', () => {
+    const req = new Request('https://x.com', {
+      headers: { Cookie: 'foo=1; tripline_session=token' },
+    });
+    expect(getSessionCookie(req)).toBe('token');
+  });
+});
+
+describe('buildSessionSetCookie', () => {
+  it('default attributes: HttpOnly + SameSite=Lax + Path=/ + Secure + Max-Age 30d', () => {
+    const cookie = buildSessionSetCookie('mytoken');
+    expect(cookie).toContain('tripline_session=mytoken');
+    expect(cookie).toContain('Path=/');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Lax');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Max-Age=2592000'); // 30 * 24 * 60 * 60
+  });
+
+  it('secure: false 不含 Secure（local dev http）', () => {
+    const cookie = buildSessionSetCookie('t', { secure: false });
+    expect(cookie).not.toContain('Secure');
+    expect(cookie).toContain('HttpOnly'); // 其他 attr 仍在
+  });
+
+  it('custom maxAge respected', () => {
+    const cookie = buildSessionSetCookie('t', { maxAge: 600 });
+    expect(cookie).toContain('Max-Age=600');
+  });
+});
+
+describe('buildClearSessionSetCookie', () => {
+  it('Max-Age=0 + Expires past + empty value', () => {
+    const cookie = buildClearSessionSetCookie();
+    expect(cookie).toContain('tripline_session=');
+    expect(cookie).toContain('Max-Age=0');
+    expect(cookie).toContain('Expires=Thu, 01 Jan 1970');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+  });
+
+  it('secure: false 不含 Secure', () => {
+    const cookie = buildClearSessionSetCookie(false);
+    expect(cookie).not.toContain('Secure');
+  });
+});
+
+describe('shouldSetSecure', () => {
+  it('https request → true', () => {
+    expect(shouldSetSecure(new Request('https://x.com/api/foo'))).toBe(true);
+  });
+
+  it('http request → false (local dev)', () => {
+    expect(shouldSetSecure(new Request('http://localhost:8788/api/foo'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 6th slice — \`functions/api/_cookies.ts\` cookie helpers，配合 \`src/server/session.ts\` 提供完整 session 操作 stack。

## API

```ts
import { getSessionCookie, buildSessionSetCookie, buildClearSessionSetCookie, shouldSetSecure } from './_cookies';

// Read
const token = getSessionCookie(request);  // string | null

// Write
const cookie = buildSessionSetCookie(token, { secure: shouldSetSecure(request) });
response.headers.append('Set-Cookie', cookie);

// Logout
response.headers.append('Set-Cookie', buildClearSessionSetCookie(shouldSetSecure(request)));
```

## Cookie attributes

| Attribute | Why |
|-----------|-----|
| HttpOnly | 防 JS 讀（XSS 偷 token） |
| Secure | 只 HTTPS 傳（http://localhost 自動 disable）|
| SameSite=Lax | 跨站 GET 帶（OAuth redirect callback 需要），form POST 等不帶（搭 token 內 csrf 欄位防 CSRF）|
| Path=/ | 全站 API + SPA 可讀 |
| Max-Age default 30d | 跟 token exp 對齊 |

## Test

\`tests/api/cookies-module.test.ts\` **13 cases TDD pass**:
- getSessionCookie：empty / no match / present / value with = / whitespace trim
- buildSessionSetCookie：default attributes / secure: false / custom maxAge
- buildClearSessionSetCookie：Max-Age=0 + Expires past + empty value
- shouldSetSecure：https vs http

## V2-P1 cumulative progress (6 PR shipped + 2 pending)

| # | Slice |
|---|-------|
| #254 | Migration 0031/0032 + D1Adapter |
| #255 | /api/oauth/* middleware bypass |
| #256 | Discovery + JWKS endpoints |
| #257 | spike RFC 8594 deprecation |
| #258 | session token module (pending merge) |
| **本 PR** | **session cookie helpers** |

## Next slice

- LoginPage UI: sign-in button → \`/api/oauth/authorize\`
- functions/api/oauth/authorize.ts: redirect to Google OAuth (V2-P1 simplest path)
- functions/api/oauth/callback.ts: code exchange + create user + issue session
- (V2-P2) password local provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)