### PR TITLE
feat(v2-p1): _session.ts helper — getSessionUser / requireSessionUser / issueSession / clearSession

### DIFF
--- a/functions/api/_session.ts
+++ b/functions/api/_session.ts
@@ -1,0 +1,88 @@
+/**
+ * Session helper — V2-P1 整合 cookies + session token module
+ *
+ * Caller convenience：把 _cookies.ts + src/server/session.ts 包成
+ * Pages Function 友善的 API（getSessionUser / requireSessionUser / issueSession /
+ * clearSession）。
+ *
+ * 用 SESSION_SECRET env 簽 token；env 缺少時 throw（fail loud avoid silent
+ * security degrade）。
+ */
+import { AppError } from './_errors';
+import {
+  getSessionCookie,
+  buildSessionSetCookie,
+  buildClearSessionSetCookie,
+  shouldSetSecure,
+} from './_cookies';
+import {
+  signSessionToken,
+  verifySessionToken,
+  type SessionPayload,
+} from '../../src/server/session';
+
+interface EnvWithSession {
+  SESSION_SECRET?: string;
+  [key: string]: unknown;
+}
+
+function requireSecret(env: EnvWithSession): string {
+  const secret = env.SESSION_SECRET;
+  if (!secret) {
+    // SESSION_SECRET 缺少是 deployment config 缺失，500 SYS_INTERNAL
+    throw new AppError('SYS_INTERNAL', 'SESSION_SECRET env 未設定');
+  }
+  return secret;
+}
+
+/**
+ * Read session cookie + verify token → return payload or null。
+ * 用於不強制 auth 的 endpoint（如 GET /api/trips）。
+ */
+export async function getSessionUser(
+  request: Request,
+  env: EnvWithSession,
+): Promise<SessionPayload | null> {
+  const token = getSessionCookie(request);
+  if (!token) return null;
+  const secret = requireSecret(env);
+  return verifySessionToken(token, secret);
+}
+
+/**
+ * Read session cookie + verify token → throw AUTH_REQUIRED if missing/invalid。
+ * 用於強制 auth 的 endpoint。
+ */
+export async function requireSessionUser(
+  request: Request,
+  env: EnvWithSession,
+): Promise<SessionPayload> {
+  const payload = await getSessionUser(request, env);
+  if (!payload) throw new AppError('AUTH_REQUIRED');
+  return payload;
+}
+
+/**
+ * Sign new session token + append Set-Cookie header to response。
+ * 用於 OAuth callback / login success path。
+ */
+export async function issueSession(
+  request: Request,
+  response: Response,
+  uid: string,
+  env: EnvWithSession,
+  ttlSeconds?: number,
+): Promise<void> {
+  const secret = requireSecret(env);
+  const token = await signSessionToken(uid, secret, ttlSeconds);
+  const cookie = buildSessionSetCookie(token, { secure: shouldSetSecure(request), maxAge: ttlSeconds });
+  response.headers.append('Set-Cookie', cookie);
+}
+
+/**
+ * Append clear-session Set-Cookie header → logout。
+ */
+export function clearSession(request: Request, response: Response): void {
+  const cookie = buildClearSessionSetCookie(shouldSetSecure(request));
+  response.headers.append('Set-Cookie', cookie);
+}

--- a/tests/api/session-helper.test.ts
+++ b/tests/api/session-helper.test.ts
@@ -1,0 +1,110 @@
+/**
+ * functions/api/_session.ts unit test — V2-P1
+ *
+ * Integration of _cookies + src/server/session — wraps Pages Function-style helpers。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getSessionUser,
+  requireSessionUser,
+  issueSession,
+  clearSession,
+} from '../../functions/api/_session';
+import { signSessionToken } from '../../src/server/session';
+
+const SECRET = 'test-session-secret';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('getSessionUser', () => {
+  it('returns null when no cookie', async () => {
+    const req = new Request('https://x.com/api/foo');
+    const result = await getSessionUser(req, { SESSION_SECRET: SECRET });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cookie present but token invalid', async () => {
+    const req = new Request('https://x.com/api/foo', {
+      headers: { Cookie: 'tripline_session=invalid.token' },
+    });
+    const result = await getSessionUser(req, { SESSION_SECRET: SECRET });
+    expect(result).toBeNull();
+  });
+
+  it('returns payload when cookie present and token valid', async () => {
+    const token = await signSessionToken('user-1', SECRET);
+    const req = new Request('https://x.com/api/foo', {
+      headers: { Cookie: `tripline_session=${token}` },
+    });
+    const result = await getSessionUser(req, { SESSION_SECRET: SECRET });
+    expect(result?.uid).toBe('user-1');
+  });
+
+  it('throws when SESSION_SECRET env missing AND cookie present', async () => {
+    const req = new Request('https://x.com/api/foo', {
+      headers: { Cookie: 'tripline_session=anything' },
+    });
+    await expect(getSessionUser(req, {})).rejects.toMatchObject({ code: 'SYS_INTERNAL' });
+  });
+
+  it('returns null without throwing when no cookie even if SESSION_SECRET missing', async () => {
+    const req = new Request('https://x.com/api/foo');
+    expect(await getSessionUser(req, {})).toBeNull();
+  });
+});
+
+describe('requireSessionUser', () => {
+  it('throws AUTH_REQUIRED when no session', async () => {
+    const req = new Request('https://x.com/api/foo');
+    await expect(requireSessionUser(req, { SESSION_SECRET: SECRET })).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('returns payload when session valid', async () => {
+    const token = await signSessionToken('user-1', SECRET);
+    const req = new Request('https://x.com/api/foo', {
+      headers: { Cookie: `tripline_session=${token}` },
+    });
+    const result = await requireSessionUser(req, { SESSION_SECRET: SECRET });
+    expect(result.uid).toBe('user-1');
+  });
+});
+
+describe('issueSession', () => {
+  it('appends Set-Cookie header with token + Secure (https)', async () => {
+    const req = new Request('https://x.com/api/login');
+    const res = new Response('ok');
+    await issueSession(req, res, 'user-2', { SESSION_SECRET: SECRET });
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toMatch(/tripline_session=/);
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Secure');
+    expect(setCookie).toContain('SameSite=Lax');
+  });
+
+  it('http://localhost → no Secure attr', async () => {
+    const req = new Request('http://localhost:8788/api/login');
+    const res = new Response('ok');
+    await issueSession(req, res, 'user-2', { SESSION_SECRET: SECRET });
+    expect(res.headers.get('Set-Cookie')).not.toContain('Secure');
+  });
+
+  it('throws when SESSION_SECRET missing', async () => {
+    const req = new Request('https://x.com/api/login');
+    const res = new Response('ok');
+    await expect(issueSession(req, res, 'u', {})).rejects.toMatchObject({ code: 'SYS_INTERNAL' });
+  });
+});
+
+describe('clearSession', () => {
+  it('appends Set-Cookie with Max-Age=0', () => {
+    const req = new Request('https://x.com/api/logout');
+    const res = new Response('ok');
+    clearSession(req, res);
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toContain('Max-Age=0');
+    expect(setCookie).toContain('Expires=Thu, 01 Jan 1970');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 7th slice — \`functions/api/_session.ts\` 整合 \`_cookies.ts\` + \`src/server/session.ts\` 成 Pages Function-friendly API。

## API

```ts
import { getSessionUser, requireSessionUser, issueSession, clearSession } from './_session';

// Optional auth (e.g. GET /api/trips/:id)
const user = await getSessionUser(context.request, context.env);  // null | SessionPayload

// Required auth (e.g. POST /api/trips)
const user = await requireSessionUser(context.request, context.env);  // throw AUTH_REQUIRED

// Login success
await issueSession(context.request, response, user.id, context.env);

// Logout
clearSession(context.request, response);
```

## env contract

- \`SESSION_SECRET\` 缺少 → throw \`SYS_INTERNAL\` (fail loud)
- 沒 cookie 時 \`getSessionUser\` 不查 secret 直接 return null（避免無 cookie 也 throw config error）
- \`Secure\` cookie attribute 自動從 request URL https/http derive

## Test

\`tests/api/session-helper.test.ts\` **11 cases TDD pass**:
- getSessionUser: no cookie / invalid token / valid / SECRET 缺
- requireSessionUser: AUTH_REQUIRED throw / valid pass-through
- issueSession: Set-Cookie attrs / http localhost no Secure / SECRET 缺
- clearSession: Max-Age=0 + Expires past

## V2-P1 cumulative progress (8 PR shipped + 1 pending)

| # | Slice |
|---|-------|
| #254 | Migration 0031/0032 + D1Adapter |
| #255 | /api/oauth/* middleware bypass |
| #256 | Discovery + JWKS endpoints |
| #257 | spike RFC 8594 deprecation |
| #258 | session token module |
| #259 | session cookie helpers |
| **本 PR** | **\_session.ts integration helper** |

## Next slice

- LoginPage UI: sign-in button → \`/api/oauth/authorize\` redirect
- \`functions/api/oauth/authorize.ts\` + \`callback.ts\`（Google OIDC client flow）
- Backfill \`saved_pois.email\` / \`trip_permissions.email\` → \`user_id\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)