### PR TITLE
feat(v2-p1): /api/oauth/authorize Google OAuth redirect

### DIFF
--- a/functions/api/_types.ts
+++ b/functions/api/_types.ts
@@ -16,4 +16,8 @@ export interface Env {
   TRIPLINE_API_URL?: string;
   TRIPLINE_API_SECRET?: string;
   ASSETS: { fetch: (request: Request) => Promise<Response> };
+  // V2-P1 OAuth (optional during staged rollout)
+  SESSION_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
 }

--- a/functions/api/oauth/authorize.ts
+++ b/functions/api/oauth/authorize.ts
@@ -1,0 +1,88 @@
+/**
+ * GET /api/oauth/authorize?provider=google&redirect_after_login=/manage
+ *
+ * V2-P1 OAuth flow start — Google OIDC client redirect。
+ *
+ * Flow:
+ *   1. Validate provider=google (其他暫不支援)
+ *   2. Validate GOOGLE_CLIENT_ID env (503 if missing)
+ *   3. Generate cryptographically random `state` (32 bytes base64url)
+ *   4. Store state in D1 oauth_models name='OAuthState' with redirect_after_login
+ *      + 5min TTL (CSRF protection — callback 收到 code 時 validate state matches)
+ *   5. Build Google authorize URL (response_type=code + PKCE later)
+ *   6. 302 redirect
+ *
+ * Callback handler (functions/api/oauth/callback.ts) — V2-P1 next slice。
+ *
+ * 安全性備註：
+ *   - state 是 CSRF token + 1-time replay guard（D1 destroy on consume in callback）
+ *   - 沒 PKCE 因 client_secret 在 server side（Google OIDC for confidential client OK）
+ *     V2-P5 加 PKCE for public clients（mobile / SPA flow）
+ *   - redirect_after_login 限制 same-origin 路徑（不允許 absolute URL，防 open redirect）
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import type { Env } from '../_types';
+
+const STATE_TTL_SEC = 5 * 60; // 5 minutes — user 通常 OAuth flow < 30s
+const SAFE_REDIRECT_DEFAULT = '/manage';
+
+function generateState(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let str = '';
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** 限制 redirect_after_login 為 same-origin 路徑（防 open redirect attack） */
+function sanitizeRedirect(value: string | null): string {
+  if (!value) return SAFE_REDIRECT_DEFAULT;
+  // 必須以 / 開頭且不以 // 開頭（後者是 protocol-relative，會跳出去）
+  if (!value.startsWith('/') || value.startsWith('//')) return SAFE_REDIRECT_DEFAULT;
+  return value;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const provider = url.searchParams.get('provider');
+  if (provider !== 'google') {
+    return new Response(
+      JSON.stringify({ error: { code: 'PROVIDER_UNSUPPORTED', message: '只支援 provider=google（V2-P1）' } }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  const clientId = context.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    return new Response(
+      JSON.stringify({ error: { code: 'OAUTH_NOT_CONFIGURED', message: 'GOOGLE_CLIENT_ID 未設定 — 需 ops 在 Cloudflare secrets 加入' } }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  const state = generateState();
+  const redirectAfterLogin = sanitizeRedirect(url.searchParams.get('redirect_after_login'));
+
+  // Store state in D1 (CSRF protection + replay guard via consume on callback)
+  const adapter = new D1Adapter(context.env.DB, 'OAuthState');
+  await adapter.upsert(
+    state,
+    { provider: 'google', redirectAfterLogin, createdAt: Date.now() },
+    STATE_TTL_SEC,
+  );
+
+  // Build Google OIDC authorize URL
+  const callbackUri = `${url.origin}/api/oauth/callback`;
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: callbackUri,
+    scope: 'openid profile email',
+    state,
+    access_type: 'offline', // 取 refresh_token (V2-P5 用)
+    prompt: 'consent',      // 強制 consent screen 確保拿 refresh_token
+  });
+  const authorizeUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+
+  return Response.redirect(authorizeUrl, 302);
+};

--- a/tests/api/oauth-authorize.test.ts
+++ b/tests/api/oauth-authorize.test.ts
@@ -1,0 +1,132 @@
+/**
+ * GET /api/oauth/authorize unit test — V2-P1
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/authorize';
+
+interface MockEnv {
+  GOOGLE_CLIENT_ID?: string;
+  DB?: {
+    prepare: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeEnv(opts: { clientId?: string } = {}): MockEnv {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  return {
+    GOOGLE_CLIENT_ID: opts.clientId,
+    DB: { prepare: vi.fn().mockReturnValue(stmt) },
+  };
+}
+
+function makeContext(url: string, env: MockEnv): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/oauth/authorize', () => {
+  it('rejects provider != google with 400 PROVIDER_UNSUPPORTED', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=apple', env));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('PROVIDER_UNSUPPORTED');
+  });
+
+  it('rejects no provider param with 400', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/authorize', env));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 OAUTH_NOT_CONFIGURED when GOOGLE_CLIENT_ID missing', async () => {
+    const env = makeEnv({}); // no clientId
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google', env));
+    expect(res.status).toBe(503);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('OAUTH_NOT_CONFIGURED');
+  });
+
+  it('redirects 302 to Google authorize URL when configured', async () => {
+    const env = makeEnv({ clientId: 'test-client-id' });
+    const res = await onRequestGet(makeContext('https://trip-planner-dby.pages.dev/api/oauth/authorize?provider=google', env));
+    expect(res.status).toBe(302);
+    const location = res.headers.get('Location');
+    expect(location).toMatch(/^https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?/);
+    expect(location).toContain('client_id=test-client-id');
+    expect(location).toContain('response_type=code');
+    expect(location).toContain('scope=openid+profile+email');
+    expect(location).toContain('redirect_uri=https%3A%2F%2Ftrip-planner-dby.pages.dev%2Fapi%2Foauth%2Fcallback');
+    expect(location).toContain('access_type=offline');
+    expect(location).toContain('prompt=consent');
+    expect(location).toMatch(/state=[A-Za-z0-9_-]+/);
+  });
+
+  it('stores state in D1 oauth_models with 5min TTL', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google', env));
+
+    expect(env.DB!.prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT OR REPLACE INTO oauth_models'));
+    const stmt = env.DB!.prepare.mock.results[0].value;
+    expect(stmt.bind).toHaveBeenCalledWith(
+      'OAuthState',
+      expect.any(String), // state
+      expect.stringContaining('"provider":"google"'),
+      Date.now() + 300 * 1000, // 5min TTL
+    );
+  });
+
+  it('open redirect protection: redirect_after_login must start with single /', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    // open redirect attempt: //evil.com → 應 fallback default
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google&redirect_after_login=//evil.com/steal', env));
+    expect(res.status).toBe(302);
+    // state stored 但 redirectAfterLogin 應 = /manage default
+    const stmt = env.DB!.prepare.mock.results[0].value;
+    const payload = JSON.parse(stmt.bind.mock.calls[0][2]);
+    expect(payload.redirectAfterLogin).toBe('/manage');
+  });
+
+  it('open redirect protection: absolute URL → fallback default', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google&redirect_after_login=https://evil.com', env));
+    expect(res.status).toBe(302);
+    const stmt = env.DB!.prepare.mock.results[0].value;
+    const payload = JSON.parse(stmt.bind.mock.calls[0][2]);
+    expect(payload.redirectAfterLogin).toBe('/manage');
+  });
+
+  it('valid same-origin redirect_after_login preserved', async () => {
+    const env = makeEnv({ clientId: 'gid' });
+    await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google&redirect_after_login=/trip/test-trip', env));
+    const stmt = env.DB!.prepare.mock.results[0].value;
+    const payload = JSON.parse(stmt.bind.mock.calls[0][2]);
+    expect(payload.redirectAfterLogin).toBe('/trip/test-trip');
+  });
+
+  it('state is unique across calls (32 bytes random)', async () => {
+    const env1 = makeEnv({ clientId: 'gid' });
+    const env2 = makeEnv({ clientId: 'gid' });
+    const res1 = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google', env1));
+    const res2 = await onRequestGet(makeContext('https://x.com/api/oauth/authorize?provider=google', env2));
+    const state1 = new URL(res1.headers.get('Location')!).searchParams.get('state');
+    const state2 = new URL(res2.headers.get('Location')!).searchParams.get('state');
+    expect(state1).not.toBe(state2);
+    expect(state1!.length).toBeGreaterThan(40);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 9th slice — \`GET /api/oauth/authorize\` real Google OAuth flow start。LoginPage 「使用 Google 登入」 button 點擊 → 本 endpoint → 302 to Google → Google 完登入後 callback 回 \`/api/oauth/callback\`（next slice）。

## Flow

```
User → /api/oauth/authorize?provider=google&redirect_after_login=/manage
       ├─ Validate provider=google
       ├─ Validate GOOGLE_CLIENT_ID env (else 503)
       ├─ Generate state (32 bytes random base64url)
       ├─ Store state in D1 oauth_models name='OAuthState' (5min TTL)
       └─ 302 → https://accounts.google.com/o/oauth2/v2/auth?...
              client_id, redirect_uri (callback), scope, state, access_type=offline, prompt=consent
```

## Security

- **State token**：CSRF protection + 1-time replay guard（callback consume on use）
- **5min TTL**：user 通常 OAuth flow < 30s
- **Open redirect protection**：\`redirect_after_login\` 限制 same-origin 路徑（\`//evil.com\` / \`https://evil\` → fallback \`/manage\`）
- **No PKCE**：confidential client (server-side client_secret)，V2-P5 加 PKCE for SPA/mobile flow
- **\`access_type=offline\` + \`prompt=consent\`**：強制取 refresh_token

## env requirements

```toml
# Cloudflare secrets
wrangler secret put GOOGLE_CLIENT_ID
wrangler secret put GOOGLE_CLIENT_SECRET   # callback 才會用
wrangler secret put SESSION_SECRET          # session module 用
```

設 secrets 前 endpoint 回 503 OAUTH_NOT_CONFIGURED — LoginPage button 點擊不 crash。

## Test

\`tests/api/oauth-authorize.test.ts\` **9 cases TDD pass**:
- provider != google → 400 PROVIDER_UNSUPPORTED
- 無 provider → 400
- CLIENT_ID missing → 503 OAUTH_NOT_CONFIGURED
- 完整 redirect URL with all 7 params
- State stored in D1 with 5min TTL
- Open redirect protection (3 cases: //, absolute URL, same-origin preserved)
- State uniqueness across calls

## V2-P1 cumulative (10 PR shipped)

| # | Slice |
|---|-------|
| #254 | Migration + adapter |
| #255 | /api/oauth/* middleware bypass |
| #256 | Discovery + JWKS |
| #257 | spike deprecation |
| #258 | session token module |
| #259 | session cookie helpers |
| #260 | \_session.ts helper |
| #261 | LoginPage Google button |
| **本 PR** | **/api/oauth/authorize Google redirect** |

## Next slice

- \`functions/api/oauth/callback.ts\`: code exchange + create user + issueSession
- \`docs/v2-oauth-google-setup.md\`: ops setup guide (Google Cloud Console + redirect_uri whitelist + secrets)
- Backfill \`saved_pois.email\` / \`trip_permissions.email\` → \`user_id\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)