### PR TITLE
feat(v2-p1): /api/oauth/callback — completes minimum viable Google login

### DIFF
--- a/functions/api/_session.ts
+++ b/functions/api/_session.ts
@@ -21,9 +21,13 @@ import {
   type SessionPayload,
 } from '../../src/server/session';
 
+/**
+ * 任何 env 物件含 SESSION_SECRET 都接受。Caller 通常傳 functions/api/_types.ts 的
+ * `Env`（含 SESSION_SECRET? optional）。不用 [key: string]: unknown index sig
+ * 否則 Env strict-typed 物件無法直接傳入。
+ */
 interface EnvWithSession {
   SESSION_SECRET?: string;
-  [key: string]: unknown;
 }
 
 function requireSecret(env: EnvWithSession): string {

--- a/functions/api/oauth/callback.ts
+++ b/functions/api/oauth/callback.ts
@@ -1,0 +1,156 @@
+/**
+ * GET /api/oauth/callback?code=...&state=...
+ *
+ * V2-P1 OAuth flow completion — Google OIDC client callback。
+ *
+ * Flow:
+ *   1. Validate state (D1 oauth_models name='OAuthState' lookup + destroy on use)
+ *   2. POST https://oauth2.googleapis.com/token { code, client_id, client_secret, redirect_uri, grant_type: 'authorization_code' }
+ *      → { access_token, id_token, refresh_token? }
+ *   3. Decode id_token (parse JWT payload — no signature verify, trust HTTPS to Google)
+ *   4. Look up auth_identities by (provider='google', provider_user_id=sub)
+ *      a. If found: update last_used_at
+ *      b. If not: create user + auth_identities row
+ *   5. issueSession(uid)
+ *   6. 302 redirect to state.redirectAfterLogin
+ */
+import { D1Adapter, type AdapterPayload } from '../../../src/server/oauth-d1-adapter';
+import { issueSession } from '../_session';
+import type { Env } from '../_types';
+
+interface GoogleTokenResponse {
+  access_token: string;
+  id_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface GoogleIdTokenPayload {
+  sub: string;
+  email: string;
+  email_verified?: boolean;
+  name?: string;
+  picture?: string;
+  [key: string]: unknown;
+}
+
+interface OAuthStatePayload extends AdapterPayload {
+  provider: string;
+  redirectAfterLogin: string;
+  createdAt: number;
+}
+
+function errorResponse(code: string, message: string, status = 400): Response {
+  return new Response(
+    JSON.stringify({ error: { code, message } }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+/** Decode JWT payload (base64url middle part). 不驗 signature — trust Google HTTPS endpoint。 */
+function decodeJwtPayload(idToken: string): GoogleIdTokenPayload | null {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) return null;
+  const payloadB64 = parts[1];
+  if (!payloadB64) return null;
+  try {
+    const padded = payloadB64.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - (payloadB64.length % 4)) % 4);
+    const json = atob(padded);
+    return JSON.parse(json) as GoogleIdTokenPayload;
+  } catch {
+    return null;
+  }
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  if (!code || !state) {
+    return errorResponse('OAUTH_MISSING_PARAMS', '缺少 code 或 state');
+  }
+
+  // 1. Validate state (CSRF + replay guard)
+  const stateAdapter = new D1Adapter(context.env.DB, 'OAuthState');
+  const stateRow = (await stateAdapter.find(state)) as OAuthStatePayload | undefined;
+  if (!stateRow) {
+    return errorResponse('OAUTH_INVALID_STATE', 'state 過期或已使用 — 請重新登入');
+  }
+  await stateAdapter.destroy(state); // one-time use
+
+  // 2. Validate env
+  const clientId = context.env.GOOGLE_CLIENT_ID;
+  const clientSecret = context.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return errorResponse('OAUTH_NOT_CONFIGURED', 'Google OAuth secrets 未設定', 503);
+  }
+
+  // 3. Token exchange with Google
+  const callbackUri = `${url.origin}/api/oauth/callback`;
+  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: callbackUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    const errText = await tokenRes.text();
+    return errorResponse('OAUTH_TOKEN_EXCHANGE_FAILED', `Google token exchange ${tokenRes.status}: ${errText.slice(0, 200)}`, 502);
+  }
+
+  const tokenJson = (await tokenRes.json()) as GoogleTokenResponse;
+
+  // 4. Parse id_token
+  const idPayload = decodeJwtPayload(tokenJson.id_token);
+  if (!idPayload || !idPayload.sub || !idPayload.email) {
+    return errorResponse('OAUTH_INVALID_ID_TOKEN', 'id_token 解析失敗或缺 sub/email');
+  }
+
+  const { sub, email, email_verified, name, picture } = idPayload;
+  const now = new Date().toISOString();
+
+  // 5. Lookup or create auth_identities + users
+  const existing = await context.env.DB
+    .prepare('SELECT user_id FROM auth_identities WHERE provider = ? AND provider_user_id = ?')
+    .bind('google', sub)
+    .first<{ user_id: string }>();
+
+  let userId: string;
+  if (existing) {
+    userId = existing.user_id;
+    await context.env.DB
+      .prepare('UPDATE auth_identities SET last_used_at = ? WHERE provider = ? AND provider_user_id = ?')
+      .bind(now, 'google', sub)
+      .run();
+  } else {
+    userId = crypto.randomUUID();
+    await context.env.DB
+      .prepare(
+        'INSERT INTO users (id, email, email_verified_at, display_name, avatar_url) VALUES (?, ?, ?, ?, ?)',
+      )
+      .bind(userId, email, email_verified ? now : null, name ?? null, picture ?? null)
+      .run();
+    await context.env.DB
+      .prepare(
+        'INSERT INTO auth_identities (user_id, provider, provider_user_id, last_used_at) VALUES (?, ?, ?, ?)',
+      )
+      .bind(userId, 'google', sub, now)
+      .run();
+  }
+
+  // 6. Issue session + redirect
+  const response = new Response(null, {
+    status: 302,
+    headers: { Location: stateRow.redirectAfterLogin || '/manage' },
+  });
+  await issueSession(context.request, response, userId, context.env);
+  return response;
+};

--- a/tests/api/oauth-callback.test.ts
+++ b/tests/api/oauth-callback.test.ts
@@ -1,0 +1,215 @@
+/**
+ * GET /api/oauth/callback unit test — V2-P1
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/callback';
+
+interface MockEnv {
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  SESSION_SECRET?: string;
+  DB?: unknown;
+}
+
+/** Minimal id_token JWT — header.payload.signature where payload is base64url(JSON) */
+function makeIdToken(payload: object): string {
+  const enc = (s: string) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return [enc('{"alg":"RS256"}'), enc(JSON.stringify(payload)), 'fake-signature'].join('.');
+}
+
+function makeStmt(firstResult: unknown = null): { bind: ReturnType<typeof vi.fn>; first: ReturnType<typeof vi.fn>; run: ReturnType<typeof vi.fn> } {
+  const stmt = {
+    bind: vi.fn(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  stmt.bind.mockReturnValue(stmt);
+  return stmt;
+}
+
+function makeContext(url: string, env: MockEnv): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+  vi.restoreAllMocks();
+});
+
+describe('GET /api/oauth/callback', () => {
+  it('400 OAUTH_MISSING_PARAMS when no code/state', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback', env));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('OAUTH_MISSING_PARAMS');
+  });
+
+  it('400 OAUTH_INVALID_STATE when state not in D1', async () => {
+    const stmt = makeStmt(null); // adapter.find returns null
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=c1&state=missing', env));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('OAUTH_INVALID_STATE');
+  });
+
+  it('503 when GOOGLE_CLIENT_SECRET missing (after state validate)', async () => {
+    const stmt = makeStmt({
+      payload: '{"provider":"google","redirectAfterLogin":"/manage"}',
+      expires_at: Date.now() + 60000,
+    });
+    const env: MockEnv = {
+      GOOGLE_CLIENT_ID: 'gid',
+      // CLIENT_SECRET missing
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=c&state=s', env));
+    expect(res.status).toBe(503);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('OAUTH_NOT_CONFIGURED');
+  });
+
+  it('happy path: existing identity → update last_used_at + 302 redirect with session cookie', async () => {
+    const states: Record<string, ReturnType<typeof makeStmt>> = {};
+    let prepareCalls = 0;
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      prepareCalls++;
+      // Sequence:
+      // 1. SELECT find OAuthState → stateRow with redirectAfterLogin
+      // 2. DELETE OAuthState (consume)
+      // 3. SELECT auth_identities → existing user
+      // 4. UPDATE auth_identities last_used_at
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: '{"provider":"google","redirectAfterLogin":"/manage"}',
+          expires_at: Date.now() + 60000,
+        });
+      }
+      if (sql.includes('DELETE FROM oauth_models')) {
+        return makeStmt();
+      }
+      if (sql.includes('SELECT user_id FROM auth_identities')) {
+        return makeStmt({ user_id: 'existing-user-uuid' });
+      }
+      if (sql.includes('UPDATE auth_identities')) {
+        return makeStmt();
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      GOOGLE_CLIENT_ID: 'gid',
+      GOOGLE_CLIENT_SECRET: 'secret',
+      SESSION_SECRET: 'session-secret-test',
+      DB: { prepare: dbPrepare },
+    };
+    // Mock global fetch for Google token exchange
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        access_token: 'at',
+        id_token: makeIdToken({ sub: 'google-sub-123', email: 'user@example.com', name: 'User Name' }),
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }), { status: 200 }),
+    );
+
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=auth-code&state=valid-state', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/manage');
+    expect(res.headers.get('Set-Cookie')).toMatch(/tripline_session=/);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it('happy path: new user → create user + identity row + redirect', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload')) return makeStmt({
+        payload: '{"redirectAfterLogin":"/explore"}',
+        expires_at: Date.now() + 60000,
+      });
+      if (sql.includes('DELETE FROM oauth_models')) return makeStmt();
+      if (sql.includes('SELECT user_id')) return makeStmt(null); // no existing identity
+      if (sql.includes('INSERT INTO users')) return makeStmt();
+      if (sql.includes('INSERT INTO auth_identities')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      GOOGLE_CLIENT_ID: 'gid',
+      GOOGLE_CLIENT_SECRET: 'secret',
+      SESSION_SECRET: 'session-secret-test',
+      DB: { prepare: dbPrepare },
+    };
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        access_token: 'at',
+        id_token: makeIdToken({ sub: 'new-sub', email: 'new@example.com', email_verified: true, name: 'New' }),
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }), { status: 200 }),
+    );
+
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=c&state=s', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/explore');
+    // 確認有 INSERT INTO users + INSERT INTO auth_identities calls
+    const calls = dbPrepare.mock.calls.map((c: unknown[]) => c[0]);
+    expect(calls.some((s) => typeof s === 'string' && s.includes('INSERT INTO users'))).toBe(true);
+    expect(calls.some((s) => typeof s === 'string' && s.includes('INSERT INTO auth_identities'))).toBe(true);
+    fetchSpy.mockRestore();
+  });
+
+  it('502 OAUTH_TOKEN_EXCHANGE_FAILED when Google rejects code', async () => {
+    const stmt = makeStmt({
+      payload: '{"redirectAfterLogin":"/manage"}',
+      expires_at: Date.now() + 60000,
+    });
+    const env: MockEnv = {
+      GOOGLE_CLIENT_ID: 'gid',
+      GOOGLE_CLIENT_SECRET: 'secret',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('invalid_grant', { status: 400 }),
+    );
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=c&state=s', env));
+    expect(res.status).toBe(502);
+    fetchSpy.mockRestore();
+  });
+
+  it('400 OAUTH_INVALID_ID_TOKEN when id_token missing sub/email', async () => {
+    const stmt = makeStmt({
+      payload: '{"redirectAfterLogin":"/manage"}',
+      expires_at: Date.now() + 60000,
+    });
+    const env: MockEnv = {
+      GOOGLE_CLIENT_ID: 'gid',
+      GOOGLE_CLIENT_SECRET: 'secret',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        access_token: 'at',
+        id_token: makeIdToken({ aud: 'no-sub-no-email' }), // missing sub/email
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }), { status: 200 }),
+    );
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/callback?code=c&state=s', env));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('OAUTH_INVALID_ID_TOKEN');
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 10th slice — **completes minimum viable Google login**。從 LoginPage 「使用 Google 登入」 button 到 session cookie + redirect 全 flow 跑通。

## Full flow（完整跑通）

```
1. User clicks「使用 Google 登入」
2. Browser → GET /api/oauth/authorize?provider=google
3. Server: gen state → store D1 → 302 to Google
4. Google: user 同意 → 302 callback?code=...&state=...
5. Server callback:
   a. Validate state (D1 lookup + destroy)
   b. POST oauth2.googleapis.com/token → access_token + id_token
   c. Decode id_token → { sub, email, name }
   d. Lookup auth_identities or create user + identity
   e. Sign session token + Set-Cookie
   f. 302 redirect → /manage
6. User logged in，session cookie 有 30 天 TTL
```

## Endpoint behavior

| Condition | Response |
|-----------|----------|
| Missing code/state | 400 OAUTH_MISSING_PARAMS |
| State expired/invalid | 400 OAUTH_INVALID_STATE |
| GOOGLE_CLIENT_SECRET missing | 503 OAUTH_NOT_CONFIGURED |
| Google token exchange fail | 502 OAUTH_TOKEN_EXCHANGE_FAILED |
| id_token missing sub/email | 400 OAUTH_INVALID_ID_TOKEN |
| **Happy: existing user** | 302 redirect + update last_used_at |
| **Happy: new user** | 302 redirect + INSERT users + INSERT auth_identities + Set-Cookie |

## Why id_token signature not verified

Trust HTTPS endpoint to \`oauth2.googleapis.com\` — Google's TLS guarantees response authenticity. Alternative：fetch JWKS + verify RS256 signature 增複雜度但 marginal security gain since we control HTTP fetch direction. V2-P5 加 JWKS verify when 上 production scale。

## Side fix: \_session.ts EnvWithSession 接口

移除 \`[key: string]: unknown\` index signature — strict-typed \`Env\` interface (functions/api/_types.ts) 沒 index sig，跨 PR 整合時 TS 拒絕。改成 \`{ SESSION_SECRET?: string }\` 純 prop interface（subset，duck typing OK）。

## Test

\`tests/api/oauth-callback.test.ts\` **7 cases TDD pass**:
- missing params / invalid state / SECRET missing / Token fail / id_token invalid
- Happy path 2 cases: existing user (UPDATE last_used_at) + new user (INSERT users + identities)
- Mock global fetch (Google token exchange) + D1 prepare/bind

## V2-P1 cumulative — sprint 1 essentially complete

| # | Slice | Status |
|---|-------|--------|
| #254 | Migration + adapter | ✓ |
| #255 | middleware bypass | ✓ |
| #256 | Discovery + JWKS | ✓ |
| #257 | spike deprecation | ✓ |
| #258 | session token | ✓ |
| #259 | session cookies | ✓ |
| #260 | _session helper | ✓ |
| #261 | LoginPage Google button | ✓ |
| #262 | /api/oauth/authorize | ✓ |
| **本 PR** | **/api/oauth/callback** | ✓ |

## Ops setup required for prod login

```bash
# 1. Google Cloud Console: create OAuth 2.0 Client (Web application)
# 2. Authorized redirect URI: https://trip-planner-dby.pages.dev/api/oauth/callback
# 3. Copy CLIENT_ID + CLIENT_SECRET to Cloudflare secrets:
wrangler secret put GOOGLE_CLIENT_ID --env production
wrangler secret put GOOGLE_CLIENT_SECRET --env production
wrangler secret put SESSION_SECRET --env production  # 32+ char random
```

設 secrets 後 LoginPage Google button 即可 work end-to-end。

## Next slice

- \`docs/v2-oauth-google-setup.md\`: ops setup guide
- \`functions/api/oauth/logout.ts\`: clearSession + 302
- \`functions/api/oauth/userinfo.ts\`: return current session user
- Backfill \`saved_pois.email\` / \`trip_permissions.email\` → \`user_id\` script

🤖 Generated with [Claude Code](https://claude.com/claude-code)