### PR TITLE
feat(v2-p1): /api/oauth/logout — clearSession + redirect

### DIFF
--- a/functions/api/oauth/logout.ts
+++ b/functions/api/oauth/logout.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/oauth/logout
+ * GET  /api/oauth/logout?redirect_after=/login
+ *
+ * V2-P1 logout — clearSession + redirect。
+ *
+ * 兩種 invocation:
+ *   - POST: form/JS submit (XHR-friendly，CSRF 防護靠 SameSite=Lax cookie attr)
+ *   - GET:  link click（如 Sidebar「登出」連結）— 走 GET 不需 form
+ *     NOTE: GET logout 通常不被 spec rec 因 CSRF risk，但 SameSite=Lax 已防外站
+ *     <a> 觸發；此 endpoint 只 clear cookie + redirect 沒副作用，可接受
+ *
+ * Behavior:
+ *   1. clearSession (Set-Cookie Max-Age=0)
+ *   2. 302 redirect to redirect_after (sanitized) or /login default
+ *
+ * 不做（V2 後續）：
+ *   - Server-side session table revoke (V2-P5 oauth_models 整合後加)
+ *   - Google session revoke (Google revocation endpoint，需 access_token)
+ *   - Telemetry log on logout
+ */
+import { clearSession } from '../_session';
+import type { Env } from '../_types';
+
+const SAFE_REDIRECT_DEFAULT = '/login';
+
+function sanitizeRedirect(value: string | null): string {
+  if (!value) return SAFE_REDIRECT_DEFAULT;
+  if (!value.startsWith('/') || value.startsWith('//')) return SAFE_REDIRECT_DEFAULT;
+  return value;
+}
+
+function buildLogoutResponse(request: Request): Response {
+  const url = new URL(request.url);
+  const redirectAfter = sanitizeRedirect(url.searchParams.get('redirect_after'));
+  const response = new Response(null, {
+    status: 302,
+    headers: { Location: redirectAfter },
+  });
+  clearSession(request, response);
+  return response;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  return buildLogoutResponse(context.request);
+};
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  return buildLogoutResponse(context.request);
+};

--- a/tests/api/oauth-logout.test.ts
+++ b/tests/api/oauth-logout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * POST/GET /api/oauth/logout unit test — V2-P1
+ */
+import { describe, it, expect } from 'vitest';
+import { onRequestGet, onRequestPost } from '../../functions/api/oauth/logout';
+
+function makeContext(url: string, method: 'GET' | 'POST' = 'GET'): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url, { method }),
+    env: {} as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+describe('GET/POST /api/oauth/logout', () => {
+  it('GET → 302 redirect to /login default + Set-Cookie Max-Age=0', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout'));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login');
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toContain('tripline_session=');
+    expect(setCookie).toContain('Max-Age=0');
+    expect(setCookie).toContain('Expires=Thu, 01 Jan 1970');
+  });
+
+  it('POST behaves identically to GET (clearSession + redirect)', async () => {
+    const res = await onRequestPost(makeContext('https://x.com/api/oauth/logout', 'POST'));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login');
+    expect(res.headers.get('Set-Cookie')).toMatch(/tripline_session=.*Max-Age=0/);
+  });
+
+  it('redirect_after preserves same-origin path', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout?redirect_after=/explore'));
+    expect(res.headers.get('Location')).toBe('/explore');
+  });
+
+  it('open redirect protection: //evil.com → fallback /login', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout?redirect_after=//evil.com'));
+    expect(res.headers.get('Location')).toBe('/login');
+  });
+
+  it('open redirect protection: absolute URL → fallback /login', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout?redirect_after=https://evil.com'));
+    expect(res.headers.get('Location')).toBe('/login');
+  });
+
+  it('http://localhost → no Secure cookie attr (local dev compat)', async () => {
+    const res = await onRequestGet(makeContext('http://localhost:8788/api/oauth/logout'));
+    expect(res.headers.get('Set-Cookie')).not.toContain('Secure');
+  });
+
+  it('https → Set-Cookie includes Secure', async () => {
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout'));
+    expect(res.headers.get('Set-Cookie')).toContain('Secure');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 11th slice — logout endpoint。GET + POST 都接受，clearSession + 302 redirect（default \`/login\`）。

## API

```
GET  /api/oauth/logout?redirect_after=/explore   → 302 /explore + Max-Age=0 cookie
POST /api/oauth/logout                           → same behavior
```

## Why GET acceptable for logout

通常 spec rec POST logout 防 CSRF（外站 \`<img src=...>\` 觸發），但 \`SameSite=Lax\` cookie attribute 已防外站觸發 cookie-bearing GET。\`clearSession\` 純 cookie 操作無 server-side state mutation，GET 可接受 + 給 sidebar 「登出」連結方便接。

## Open redirect protection

```
?redirect_after=/explore       → /explore  ✓
?redirect_after=//evil.com     → /login    (fallback)
?redirect_after=https://evil   → /login    (fallback)
```

## Test

\`tests/api/oauth-logout.test.ts\` **7 cases TDD pass**:
- GET 302 + Max-Age=0
- POST identical
- redirect_after same-origin / open-redirect 2 cases
- http localhost no Secure
- https with Secure

## Out of scope (V2 後續)

- Server-side session table revoke (V2-P5 oauth_models 整合)
- Google session revoke (revocation endpoint with access_token)
- Telemetry log on logout

## V2-P1 cumulative (12 PR)

| # | Slice |
|---|-------|
| #254 | Migration + adapter |
| #255 | middleware bypass |
| #256 | Discovery + JWKS |
| #257 | spike deprecation |
| #258 | session token |
| #259 | session cookies |
| #260 | _session helper |
| #261 | LoginPage Google button |
| #262 | /api/oauth/authorize |
| #263 | /api/oauth/callback |
| #264 | ops setup guide |
| **本 PR** | **/api/oauth/logout** |

## Next slice

- \`/api/oauth/userinfo\`: GET current session user payload (small)
- saved_pois.email / trip_permissions.email → user_id backfill (V2-P2 排程)

🤖 Generated with [Claude Code](https://claude.com/claude-code)