### PR TITLE
feat(v2-p1): /api/oauth/userinfo — return current session user

### DIFF
--- a/functions/api/oauth/userinfo.ts
+++ b/functions/api/oauth/userinfo.ts
@@ -1,0 +1,61 @@
+/**
+ * GET /api/oauth/userinfo — return current session user
+ *
+ * V2-P1 — SPA 用此 endpoint 在 page load 取得 logged-in user info（取代
+ * sidebar hardcode email）。OIDC userinfo endpoint 通常 return token claims；
+ * 這裡 V2-P1 階段 return D1 users row 的 subset。
+ *
+ * Auth: required (session cookie)。沒 session → 401。
+ *
+ * Response shape (200):
+ *   { id, email, displayName?, avatarUrl?, emailVerified: boolean, createdAt }
+ *
+ * 不含：refresh token / Google profile direct passthrough（V2-P5 OIDC server
+ * mode 才回 standard OIDC userinfo claims）
+ */
+import { requireSessionUser } from '../_session';
+import { AppError } from '../_errors';
+import type { Env } from '../_types';
+
+interface UserRow {
+  id: string;
+  email: string;
+  email_verified_at: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+
+  const row = await context.env.DB
+    .prepare(
+      'SELECT id, email, email_verified_at, display_name, avatar_url, created_at FROM users WHERE id = ?',
+    )
+    .bind(session.uid)
+    .first<UserRow>();
+
+  if (!row) {
+    // Session 指向已不存在的 user — 可能 user 被 admin 刪了 / DB 出錯
+    throw new AppError('AUTH_INVALID', 'Session user 不存在');
+  }
+
+  return new Response(
+    JSON.stringify({
+      id: row.id,
+      email: row.email,
+      emailVerified: row.email_verified_at !== null,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      createdAt: row.created_at,
+    }),
+    {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        // Don't cache — user 資料可能變動
+        'cache-control': 'private, no-store',
+      },
+    },
+  );
+};

--- a/tests/api/oauth-userinfo.test.ts
+++ b/tests/api/oauth-userinfo.test.ts
@@ -1,0 +1,119 @@
+/**
+ * GET /api/oauth/userinfo unit test — V2-P1
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/userinfo';
+import { signSessionToken } from '../../src/server/session';
+
+const SECRET = 'test-userinfo-secret';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+  };
+  return stmt;
+}
+
+function makeContext(url: string, env: MockEnv, cookie?: string): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url, { headers: cookie ? { Cookie: cookie } : undefined }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/oauth/userinfo', () => {
+  it('throws AUTH_REQUIRED when no session cookie', async () => {
+    const env: MockEnv = { SESSION_SECRET: SECRET, DB: { prepare: vi.fn() } };
+    await expect(onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env))).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('throws AUTH_REQUIRED when session token invalid', async () => {
+    const env: MockEnv = { SESSION_SECRET: SECRET, DB: { prepare: vi.fn() } };
+    await expect(
+      onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env, 'tripline_session=tampered.signature')),
+    ).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('returns 200 + user payload when session valid + user exists', async () => {
+    const token = await signSessionToken('user-uuid-1', SECRET);
+    const stmt = makeStmt({
+      id: 'user-uuid-1',
+      email: 'me@example.com',
+      email_verified_at: '2026-04-25T00:00:00.000Z',
+      display_name: 'Me',
+      avatar_url: 'https://avatar.example.com/me.png',
+      created_at: '2026-04-20T00:00:00.000Z',
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env, `tripline_session=${token}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('no-store');
+    const json = await res.json() as Record<string, unknown>;
+    expect(json).toEqual({
+      id: 'user-uuid-1',
+      email: 'me@example.com',
+      emailVerified: true,
+      displayName: 'Me',
+      avatarUrl: 'https://avatar.example.com/me.png',
+      createdAt: '2026-04-20T00:00:00.000Z',
+    });
+  });
+
+  it('emailVerified = false when email_verified_at is null', async () => {
+    const token = await signSessionToken('u', SECRET);
+    const stmt = makeStmt({
+      id: 'u', email: 'u@x.com',
+      email_verified_at: null,
+      display_name: null, avatar_url: null,
+      created_at: '2026-04-25',
+    });
+    const env: MockEnv = { SESSION_SECRET: SECRET, DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env, `tripline_session=${token}`));
+    const json = await res.json() as { emailVerified: boolean; displayName: null; avatarUrl: null };
+    expect(json.emailVerified).toBe(false);
+    expect(json.displayName).toBeNull();
+    expect(json.avatarUrl).toBeNull();
+  });
+
+  it('throws AUTH_INVALID when session valid but user row missing (deleted user)', async () => {
+    const token = await signSessionToken('ghost-user', SECRET);
+    const stmt = makeStmt(null); // user not found
+    const env: MockEnv = { SESSION_SECRET: SECRET, DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    await expect(
+      onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env, `tripline_session=${token}`)),
+    ).rejects.toMatchObject({ code: 'AUTH_INVALID' });
+  });
+
+  it('SQL filters by uid from session', async () => {
+    const token = await signSessionToken('specific-uid', SECRET);
+    const stmt = makeStmt({
+      id: 'specific-uid', email: 'x@x.com',
+      email_verified_at: null, display_name: null, avatar_url: null,
+      created_at: '2026-04-25',
+    });
+    const prepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { SESSION_SECRET: SECRET, DB: { prepare } };
+    await onRequestGet(makeContext('https://x.com/api/oauth/userinfo', env, `tripline_session=${token}`));
+    expect(prepare).toHaveBeenCalledWith(expect.stringContaining('WHERE id = ?'));
+    expect(stmt.bind).toHaveBeenCalledWith('specific-uid');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 12th slice — SPA 用此 endpoint 在 page load 取得 logged-in user info（取代 sidebar hardcode email）。

## API

```
GET /api/oauth/userinfo
Cookie: tripline_session=...

→ 200 JSON
  {
    "id": "uuid-...",
    "email": "user@example.com",
    "emailVerified": true,
    "displayName": "User Name",
    "avatarUrl": "https://...",
    "createdAt": "2026-04-25T..."
  }

→ 401 AUTH_REQUIRED  (no/invalid session)
→ 401 AUTH_INVALID   (session 指 deleted user)
```

\`cache-control: private, no-store\` — user 資料可能變動。

## Why not standard OIDC userinfo claims (yet)

OIDC userinfo endpoint spec return token claims (sub/email/etc.)。V2-P1 階段 tripline 是 **OAuth Client (consume Google)** 不是 OAuth Server，return D1 users row subset 適合 SPA 用。V2-P5 OIDC server mode 才 spec-compliant。

## Test

\`tests/api/oauth-userinfo.test.ts\` **6 cases TDD pass**:
- No cookie → AUTH_REQUIRED
- Tampered token → AUTH_REQUIRED
- Happy 200 + payload shape
- emailVerified=false when NULL
- User row missing → AUTH_INVALID (ghost session protection)
- SQL filters by uid

## V2-P1 cumulative (13 PR — sprint 1 essentially complete)

| # | Slice |
|---|-------|
| #254 | Migration + adapter |
| #255 | middleware bypass |
| #256 | Discovery + JWKS |
| #257 | spike deprecation |
| #258 | session token |
| #259 | session cookies |
| #260 | _session helper |
| #261 | LoginPage Google button |
| #262 | /api/oauth/authorize |
| #263 | /api/oauth/callback |
| #264 | ops setup guide |
| #265 | /api/oauth/logout |
| **本 PR** | **/api/oauth/userinfo** |

## Next slice

- DesktopSidebar 接 \`/api/oauth/userinfo\`: 取代 hardcode email
- \`saved_pois.email\` / \`trip_permissions.email\` / \`trip_ideas.added_by\` → \`user_id\` backfill migration + script
- V2-P2: local password provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)