### PR TITLE
feat(v2-p1): useCurrentUser hook — fetch /api/oauth/userinfo

### DIFF
--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,61 @@
+/**
+ * useCurrentUser — V2-P1 fetch logged-in user from /api/oauth/userinfo
+ *
+ * Component 用此 hook 拿 current user 給 DesktopSidebar / TopBar 顯示 user chip。
+ * 沒 session 時 user = null（401 → null），方便 caller render「登入」CTA。
+ *
+ * 不快取 across navigation — useEffect fetch on mount。Future V2-P5 加 SWR-style
+ * cache + revalidate（避免每頁 mount 都打 API）。
+ *
+ * 不依賴 React Query / SWR — keep dependency surface small。Vanilla useState/useEffect。
+ */
+import { useEffect, useState } from 'react';
+
+export interface CurrentUser {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt: string;
+}
+
+export interface UseCurrentUserResult {
+  /** undefined = loading, null = unauthenticated, CurrentUser = logged in */
+  user: CurrentUser | null | undefined;
+  /** Re-fetch（after login / logout 用） */
+  reload: () => void;
+}
+
+const USERINFO_ENDPOINT = '/api/oauth/userinfo';
+
+export function useCurrentUser(): UseCurrentUserResult {
+  const [user, setUser] = useState<CurrentUser | null | undefined>(undefined);
+  const [reloadCount, setReloadCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(USERINFO_ENDPOINT, { credentials: 'include' })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (!res.ok) {
+          // 401 / 503 / etc. → 視為未登入
+          setUser(null);
+          return;
+        }
+        const data = (await res.json()) as CurrentUser;
+        setUser(data);
+      })
+      .catch(() => {
+        if (!cancelled) setUser(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadCount]);
+
+  return {
+    user,
+    reload: () => setReloadCount((n) => n + 1),
+  };
+}

--- a/tests/unit/use-current-user.test.tsx
+++ b/tests/unit/use-current-user.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * useCurrentUser hook unit test — V2-P1
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCurrentUser } from '../../src/hooks/useCurrentUser';
+
+const SAMPLE_USER = {
+  id: 'uid-1',
+  email: 'user@example.com',
+  emailVerified: true,
+  displayName: 'User',
+  avatarUrl: 'https://x.com/a.png',
+  createdAt: '2026-04-25',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useCurrentUser', () => {
+  it('initial state user = undefined (loading)', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useCurrentUser());
+    expect(result.current.user).toBeUndefined();
+  });
+
+  it('successful fetch → user = payload', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(SAMPLE_USER), { status: 200 }),
+    );
+    const { result } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.user).not.toBeUndefined());
+    expect(result.current.user).toEqual(SAMPLE_USER);
+  });
+
+  it('401 → user = null (unauthenticated)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'AUTH_REQUIRED' } }), { status: 401 }),
+    );
+    const { result } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.user).not.toBeUndefined());
+    expect(result.current.user).toBeNull();
+  });
+
+  it('network error → user = null', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+    const { result } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.user).not.toBeUndefined());
+    expect(result.current.user).toBeNull();
+  });
+
+  it('reload() triggers re-fetch', async () => {
+    let callCount = 0;
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async () => {
+      callCount++;
+      return new Response(JSON.stringify({ ...SAMPLE_USER, displayName: `Call ${callCount}` }), { status: 200 });
+    });
+
+    const { result, rerender } = renderHook(() => useCurrentUser());
+    await waitFor(() => expect(result.current.user?.displayName).toBe('Call 1'));
+
+    result.current.reload();
+    rerender();
+    await waitFor(() => expect(result.current.user?.displayName).toBe('Call 2'));
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetch uses credentials: include for cookie-based auth', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(SAMPLE_USER), { status: 200 }),
+    );
+    renderHook(() => useCurrentUser());
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/oauth/userinfo',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('cancelled fetch (unmount) does not setState (no warning)', async () => {
+    let resolveFetch: (res: Response) => void = () => undefined;
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    }));
+    const { unmount } = renderHook(() => useCurrentUser());
+    unmount();
+    // Resolve after unmount — should not set state on unmounted component
+    resolveFetch(new Response(JSON.stringify(SAMPLE_USER), { status: 200 }));
+    // No assertion needed — vitest will warn if setState called on unmounted
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 13th slice — React hook for components 拿 current logged-in user。為 DesktopSidebar 等 user-aware UI 鋪路。

## API

```tsx
const { user, reload } = useCurrentUser();

// user = undefined  → loading
// user = null       → unauthenticated (401 / network error)
// user = CurrentUser → logged in
// reload()          → re-fetch (post-login / post-logout)
```

## Implementation notes

- \`credentials: 'include'\` for cookie-based auth
- \`cancelled\` flag 防 unmount 後 setState（避 React warn）
- 不快取 across navigation — V2-P5 加 SWR-style cache + revalidate
- Vanilla useState/useEffect — no React Query / SWR dep

## Test

\`tests/unit/use-current-user.test.tsx\` **7 cases TDD pass**:
- Initial loading
- 200 → user payload
- 401 → null
- Network error → null
- reload() triggers re-fetch
- credentials: include verified
- Unmount during pending (no setState warning)

## V2-P1 cumulative (14 PR — sprint 1 wrap)

| # | Slice |
|---|-------|
| #254-264 | (12 PR) Schema / adapter / middleware / discovery / spike / session / LoginPage / authorize / callback / logout / userinfo / ops guide |
| **本 PR** | **useCurrentUser hook** |

## Next slice

- DesktopSidebar wire \`useCurrentUser\` → 顯示 real user，no hardcode
- \`saved_pois\` / \`trip_permissions\` email → user_id backfill (V2-P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)