### PR TITLE
feat(v2-p1): DesktopSidebarConnected wrapper — auto-fetch user via useCurrentUser

### DIFF
--- a/src/components/shell/DesktopSidebarConnected.tsx
+++ b/src/components/shell/DesktopSidebarConnected.tsx
@@ -1,0 +1,33 @@
+/**
+ * DesktopSidebarConnected — V2-P1 wrapper that auto-fetches current user
+ *
+ * Connected variant of <DesktopSidebar/> that uses useCurrentUser hook to
+ * populate the `user` prop。Use this in pages where you want sidebar to
+ * automatically show logged-in user (TripPage / ManagePage / etc.) without
+ * manually wiring fetch in each caller。
+ *
+ * Pure DesktopSidebar (prop-driven) 仍保留 for testing / explicit override
+ * use cases。
+ *
+ * Loading state：user 還沒 fetch 完時 sidebar 渲染「未登入」chip — 跟
+ * unauthenticated state 一致，避免 flicker。
+ */
+import { useMemo } from 'react';
+import DesktopSidebar, { type DesktopSidebarProps, type SidebarUser } from './DesktopSidebar';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+
+export type DesktopSidebarConnectedProps = Omit<DesktopSidebarProps, 'user'>;
+
+export default function DesktopSidebarConnected(props: DesktopSidebarConnectedProps) {
+  const { user } = useCurrentUser();
+
+  const sidebarUser = useMemo<SidebarUser | null>(() => {
+    if (!user) return null; // undefined (loading) or null (unauthed) → 未登入 state
+    return {
+      name: user.displayName ?? user.email,
+      email: user.email,
+    };
+  }, [user]);
+
+  return <DesktopSidebar {...props} user={sidebarUser} />;
+}

--- a/tests/unit/desktop-sidebar-connected.test.tsx
+++ b/tests/unit/desktop-sidebar-connected.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * DesktopSidebarConnected unit test — V2-P1
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DesktopSidebarConnected from '../../src/components/shell/DesktopSidebarConnected';
+
+const SAMPLE_USER = {
+  id: 'uid-1',
+  email: 'me@example.com',
+  emailVerified: true,
+  displayName: 'My Name',
+  avatarUrl: null,
+  createdAt: '2026-04-25',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderConnected() {
+  return render(
+    <MemoryRouter>
+      <DesktopSidebarConnected />
+    </MemoryRouter>,
+  );
+}
+
+describe('DesktopSidebarConnected', () => {
+  it('initial render (loading) shows "未登入" placeholder (avoid flicker)', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}));
+    const { container } = renderConnected();
+    // sidebar 渲染未登入 chip — "?" initial
+    expect(container.querySelector('[data-testid="desktop-sidebar"]')).toBeTruthy();
+  });
+
+  it('after fetch success renders user displayName + email', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(SAMPLE_USER), { status: 200 }),
+    );
+    const { container } = renderConnected();
+    await waitFor(() => {
+      expect(container.textContent).toContain('My Name');
+    });
+    expect(container.textContent).toContain('me@example.com');
+  });
+
+  it('falls back to email as name when displayName is null', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ...SAMPLE_USER, displayName: null }), { status: 200 }),
+    );
+    const { container } = renderConnected();
+    await waitFor(() => expect(container.textContent).toContain('me@example.com'));
+  });
+
+  it('401 response → renders unauthed sidebar (no user chip)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 401 }),
+    );
+    const { container } = renderConnected();
+    await waitFor(() => {
+      // user 為 null → 「?」 initial 仍渲染
+      expect(container.querySelector('[data-testid="desktop-sidebar"]')).toBeTruthy();
+    });
+    expect(container.textContent).not.toContain('me@example.com');
+  });
+
+  it('passes through onNewTrip prop to inner DesktopSidebar', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(SAMPLE_USER), { status: 200 }),
+    );
+    const onNewTrip = vi.fn();
+    const { container } = render(
+      <MemoryRouter>
+        <DesktopSidebarConnected onNewTrip={onNewTrip} />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(container.textContent).toContain('me@example.com'));
+    // CTA 仍 in DOM (新增行程 button)
+    expect(container.querySelector('[data-testid="desktop-sidebar"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 14th slice — Connected variant of \`DesktopSidebar\` 自動 fetch user from \`/api/oauth/userinfo\` via \`useCurrentUser\` hook。

Pure \`DesktopSidebar\` (prop-driven) 仍保留 for testing / explicit override。Caller migrate path：

```tsx
// Before
<DesktopSidebar user={null} ... />

// After
<DesktopSidebarConnected ... />
```

## Mapping CurrentUser → SidebarUser

```ts
{
  name: user.displayName ?? user.email,  // fallback email if no display name
  email: user.email,
}
```

## Loading state

\`user\` undefined (loading) → render 未登入 chip — 跟 unauthed state 一致**避免 flicker**。

## Test

\`tests/unit/desktop-sidebar-connected.test.tsx\` **5 cases TDD pass**:
- Loading renders sidebar (no flicker)
- Success → displayName + email visible
- displayName null → fallback email as name
- 401 → unauthed sidebar
- onNewTrip prop pass-through

## Out of scope (next PR)

- \`TripPage\` / \`ManagePage\` call sites migrate from \`<DesktopSidebar>\` to \`<DesktopSidebarConnected>\` (cross-page change risk medium，獨立 PR review)

## V2-P1 cumulative (15 PR — sprint 1 essentially complete + UX wiring)

| Layer | PRs |
|-------|-----|
| Schema + adapter | #254 |
| Middleware + endpoints | #255-260, #262-263, #265-266 |
| UI | #261, #267, **本 PR** |
| Docs | #264 |
| spike retire | #257 |

剩：
- TripPage / ManagePage migrate to Connected（小，避 regression 留下 PR）
- saved_pois / trip_permissions email → user_id backfill（V2-P2 排程）
- V2-P2 ~ V2-P7（12 週）

🤖 Generated with [Claude Code](https://claude.com/claude-code)