### PR TITLE
feat(v2-p1): TripPage + ManagePage migrate to DesktopSidebarConnected

### DIFF
--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -12,7 +12,7 @@ import { useTripSelector } from '../hooks/useTripSelector';
 import { sanitizeHtml } from '../lib/sanitize';
 import { lsGet, lsSet, LS_KEY_TRIP_PREF } from '../lib/localStorage';
 import AppShell from '../components/shell/AppShell';
-import DesktopSidebar from '../components/shell/DesktopSidebar';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 
 import { marked } from 'marked';
 
@@ -599,7 +599,7 @@ export default function ManagePage() {
   /* ===== Render ===== */
   return (
     <AppShell
-      sidebar={<DesktopSidebar user={null} />}
+      sidebar={<DesktopSidebarConnected />}
       main={
         <div className="manage-wrap">
           <style>{MANAGE_SCOPED_STYLES}</style>

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -23,7 +23,7 @@ import Footer, { type FooterData } from '../components/trip/Footer';
 import OverflowMenu from '../components/trip/OverflowMenu';
 import BottomNavBar from '../components/shell/BottomNavBar';
 import AppShell from '../components/shell/AppShell';
-import DesktopSidebar from '../components/shell/DesktopSidebar';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import InfoSheet from '../components/trip/InfoSheet';
 import ToastContainer from '../components/shared/Toast';
 import { FooterArt } from '../components/trip/ThemeArt';
@@ -643,7 +643,7 @@ export default function TripPage() {
 
   return (
     <AppShell
-      sidebar={<DesktopSidebar user={null} />}
+      sidebar={<DesktopSidebarConnected />}
       main={mainContent}
       sheet={sheetContent}
       bottomNav={bottomNavContent}


### PR DESCRIPTION
## Summary

V2-P1 15th slice — wire 兩個 main user-facing pages 用 \`DesktopSidebarConnected\`（從 #268）自動 fetch user from \`/api/oauth/userinfo\`。

## Diff

```diff
-import DesktopSidebar from '../components/shell/DesktopSidebar';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';

-      sidebar={<DesktopSidebar user={null} />}
+      sidebar={<DesktopSidebarConnected />}
```

兩處：\`src/pages/TripPage.tsx\` + \`src/pages/ManagePage.tsx\`。LoginPage 不用 sidebar。

## No regression

Connected wrapper 內部 render \`DesktopSidebar\`，\`data-testid="desktop-sidebar"\` 不變。既有 **102 test files / 824 tests all pass**，typecheck clean。

## Effect (post-deploy with secrets set)

| State | UI |
|-------|----|
| Logged in | Sidebar bottom 顯示 displayName + email + initial avatar |
| 未登入 / loading | 「未登入」chip + \`?\` avatar (no flicker) |

## V2-P1 cumulative (16 PR — sprint 1 essentially complete + main page wire-up)

| Layer | PRs |
|-------|-----|
| Schema + adapter | #254 |
| Middleware + endpoints | #255-260, #262-263, #265-266 |
| UI | #261, #267, #268, **本 PR** |
| Docs | #264 |
| spike retire | #257 |

## Pending V2-P1 (~1 PR)

- \`saved_pois.email\` / \`trip_permissions.email\` / \`trip_ideas.added_by\` → \`user_id\` backfill migration（V2-P2 scope）

## V2-P2 onwards (12 週)

Local password / 忘記密碼 / OAuth Server / Token+Consent / Security hardening / Docs+Audit+Launch — 詳見 \`docs/v2-oauth-server-plan.md\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)