### PR TITLE
feat(v2-p1): DesktopSidebar 加「登出」link (logged-in user)

### DIFF
--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -134,6 +134,20 @@ const SCOPED_STYLES = `
   color: var(--color-accent);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+.tp-account-logout {
+  display: block;
+  margin-top: 6px;
+  padding: 8px;
+  font: inherit;
+  font-size: var(--font-size-caption2);
+  color: var(--color-muted);
+  text-align: center;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  min-height: var(--spacing-tap-min);
+}
+.tp-account-logout:hover { color: var(--color-foreground); }
+.tp-account-logout:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 `;
 
 export interface SidebarUser {
@@ -191,13 +205,22 @@ export default function DesktopSidebar({ user, onNewTrip, brand }: DesktopSideba
           </button>
 
           {user ? (
-            <div className="tp-account-card" data-testid="sidebar-account-card">
-              <div className="tp-avatar-md" aria-hidden="true">{initial}</div>
-              <div className="tp-account-body">
-                <div className="tp-account-name">{user.name}</div>
-                <div className="tp-account-email">{user.email}</div>
+            <>
+              <div className="tp-account-card" data-testid="sidebar-account-card">
+                <div className="tp-avatar-md" aria-hidden="true">{initial}</div>
+                <div className="tp-account-body">
+                  <div className="tp-account-name">{user.name}</div>
+                  <div className="tp-account-email">{user.email}</div>
+                </div>
               </div>
-            </div>
+              <a
+                className="tp-account-logout"
+                href="/api/oauth/logout"
+                data-testid="sidebar-logout"
+              >
+                登出
+              </a>
+            </>
           ) : (
             <div className="tp-user-chip" data-testid="sidebar-user-chip">
               <div className="tp-avatar" aria-hidden="true">?</div>

--- a/tests/unit/desktop-sidebar.test.tsx
+++ b/tests/unit/desktop-sidebar.test.tsx
@@ -121,6 +121,21 @@ describe('DesktopSidebar — user chip', () => {
     });
     expect(container.querySelector('[data-testid="sidebar-user-chip"]')).toBeNull();
   });
+
+  it('已登入：顯示「登出」link href=/api/oauth/logout', () => {
+    const { container } = renderSidebar({
+      user: { name: 'Ray', email: 'ray@trip.io' },
+    });
+    const logout = container.querySelector('[data-testid="sidebar-logout"]') as HTMLAnchorElement | null;
+    expect(logout).toBeTruthy();
+    expect(logout?.getAttribute('href')).toBe('/api/oauth/logout');
+    expect(logout?.textContent).toContain('登出');
+  });
+
+  it('未登入時不顯示「登出」link', () => {
+    const { container } = renderSidebar({ user: null });
+    expect(container.querySelector('[data-testid="sidebar-logout"]')).toBeNull();
+  });
 });
 
 describe('DesktopSidebar — New Trip CTA', () => {


### PR DESCRIPTION
## Summary

V2-P1 16th slice — Sidebar bottom logged-in user 加「登出」 link → \`/api/oauth/logout\`（V2-P1 #265 endpoint）。

## UI

| State | Sidebar bottom |
|-------|----------------|
| Logged in | avatar + name + email + 「登出」 link |
| Unauth | 「未登入」 chip (no logout) |

## Diff

- \`SCOPED_STYLES\` 加 \`.tp-account-logout\` (centered, underline, ≥44px tap target, focus-visible outline)
- account-card render 後加 \`<a data-testid="sidebar-logout" href="/api/oauth/logout">登出</a>\`

## Test

- \`desktop-sidebar.test.tsx\` 加 2 cases (logged-in 顯示 + unauth 不顯示)
- 既有 14 tests still pass → **16 total**
- a11y axe-core: 7 cases still pass (0 violation 維持)
- Full suite **824 → 826** (+2)

## V2-P1 cumulative (17 PR — sprint 1 + UX wiring complete)

完整 login → manage → logout flow 都有 UI。設 secrets 後 prod work end-to-end。

🤖 Generated with [Claude Code](https://claude.com/claude-code)