### PR TITLE
feat(v2-p1): DesktopSidebar logged-in 時 hide「登入」 nav item

### DIFF
--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -168,6 +168,11 @@ export default function DesktopSidebar({ user, onNewTrip, brand }: DesktopSideba
   const { pathname } = useLocation();
   const initial = user?.name?.charAt(0)?.toUpperCase() ?? '?';
 
+  // Logged in 時 hide「登入」 nav item — user chip + 登出 link 已在 sidebar bottom
+  const visibleNavItems = user
+    ? NAV_ITEMS.filter((item) => item.key !== 'login')
+    : NAV_ITEMS;
+
   return (
     <>
       <style>{SCOPED_STYLES}</style>
@@ -177,7 +182,7 @@ export default function DesktopSidebar({ user, onNewTrip, brand }: DesktopSideba
         </div>
 
         <nav className="tp-sidebar-nav" aria-label="主要功能">
-          {NAV_ITEMS.map((item) => {
+          {visibleNavItems.map((item) => {
             const active = isItemActive(pathname, item);
             return (
               <Link

--- a/tests/unit/desktop-sidebar.test.tsx
+++ b/tests/unit/desktop-sidebar.test.tsx
@@ -136,6 +136,25 @@ describe('DesktopSidebar — user chip', () => {
     const { container } = renderSidebar({ user: null });
     expect(container.querySelector('[data-testid="sidebar-logout"]')).toBeNull();
   });
+
+  it('已登入時 nav 隱藏「登入」item（已有 user chip + 登出，避免重複）', () => {
+    const { container } = renderSidebar({
+      user: { name: 'Ray', email: 'ray@trip.io' },
+    });
+    const nav = container.querySelector('[aria-label="主要功能"]');
+    expect(nav?.textContent).not.toContain('登入');
+    // 其他 4 nav item 仍在
+    expect(nav?.textContent).toContain('聊天');
+    expect(nav?.textContent).toContain('行程');
+    expect(nav?.textContent).toContain('地圖');
+    expect(nav?.textContent).toContain('探索');
+  });
+
+  it('未登入時 nav 顯示「登入」item', () => {
+    const { container } = renderSidebar({ user: null });
+    const nav = container.querySelector('[aria-label="主要功能"]');
+    expect(nav?.textContent).toContain('登入');
+  });
 });
 
 describe('DesktopSidebar — New Trip CTA', () => {


### PR DESCRIPTION
## Summary

V2-P1 17th slice — small UX wiring。Logged-in 時 sidebar 5 nav items 中「登入」item 不該顯示（已有 sidebar bottom 的 user chip + 登出 link，避免重複）。

## Behavior

| State | Nav items |
|-------|-----------|
| Logged in | 聊天 / 行程 / 地圖 / 探索 (4 items, no 「登入」) |
| Unauth | 聊天 / 行程 / 地圖 / 探索 / 登入 (5 items) |

## Diff

```diff
+ const visibleNavItems = user
+   ? NAV_ITEMS.filter((item) => item.key !== 'login')
+   : NAV_ITEMS;
...
- {NAV_ITEMS.map(...)}
+ {visibleNavItems.map(...)}
```

## Test

- desktop-sidebar.test.tsx 加 2 cases (logged in 不含「登入」 + unauth 含)
- 既有 16 → **18 cases pass**
- a11y axe-core 7/7 still pass (0 violation 維持)

## V2-P1 sprint 1 + UX wiring — **真的完整 wrap**

完整 user flow code-complete + 視覺 polished:

```
LoginPage button → Google OAuth → callback → user create + session
  ↓
DesktopSidebar (logged in)
  - 4 nav items (聊天/行程/地圖/探索)
  - user chip (avatar + displayName + email)
  - 登出 link → /api/oauth/logout
  ↓
clearSession + redirect /login
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)