### PR TITLE
feat(v2-p1): backfill prep — migration 0033 + script

### DIFF
--- a/migrations/0033_add_user_id_columns.sql
+++ b/migrations/0033_add_user_id_columns.sql
@@ -1,0 +1,32 @@
+-- Migration 0033: 加 user_id columns to email-keyed tables (V2-P1 backfill prep)
+--
+-- V2-P1 Google login 後 users + auth_identities 有 row。既有 trips ownership
+-- 用 email column 當 anchor（saved_pois.email / trip_permissions.email /
+-- trip_ideas.added_by），這個 migration 加 user_id FK column 預備 backfill。
+--
+-- 策略：
+--   1. 此 migration: ADD COLUMN user_id ... NULL (FK 但 nullable)
+--   2. 下個 migration / 一次性 script: 對每個 row，查 email → users.id，
+--      populate user_id (跑在 prod 才有 user 後)
+--   3. V2-P2 / V2-P3：UPDATE 完成後改 NOT NULL（cutover 點，需 zero-downtime
+--      pattern：deploy code that writes both columns，等 backfill 完，再 drop email）
+--
+-- 為何不直接 NOT NULL：既有 row 沒對應 user_id，加 NOT NULL 會 fail。
+-- 必須先 nullable + backfill + NOT NULL three-step migration pattern。
+--
+-- ON DELETE 行為：
+--   saved_pois / trip_permissions: CASCADE（user 被刪，pool / permission 一起清）
+--   trip_ideas: SET NULL（user 被刪，idea 文字保留 audit 用）
+
+ALTER TABLE saved_pois
+  ADD COLUMN user_id TEXT REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE trip_permissions
+  ADD COLUMN user_id TEXT REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE trip_ideas
+  ADD COLUMN added_by_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_saved_pois_user_id ON saved_pois(user_id);
+CREATE INDEX idx_trip_permissions_user_id ON trip_permissions(user_id);
+CREATE INDEX idx_trip_ideas_added_by_user_id ON trip_ideas(added_by_user_id);

--- a/scripts/backfill-user-id.js
+++ b/scripts/backfill-user-id.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * backfill-user-id.js — V2-P1 backfill prep script
+ *
+ * 對應 migration 0033（加 user_id columns nullable）。此 script 跑：
+ *   1. SELECT DISTINCT email FROM saved_pois / trip_permissions / trip_ideas.added_by
+ *   2. 對每個 distinct email，查 users.email 是否存在
+ *      - 存在: take user_id
+ *      - 不存在: skip（need user 自己 Google login first → users row 才會建）
+ *   3. UPDATE saved_pois SET user_id = ? WHERE email = ? AND user_id IS NULL
+ *      (similar for trip_permissions / trip_ideas.added_by → added_by_user_id)
+ *
+ * Idempotent — 跑多次只 update 沒 user_id 的 row（after first prod login wave 才有 effect）。
+ *
+ * Dry-run mode（default）：只印 report 不改 DB。`--apply` 才實際 UPDATE。
+ *
+ * Usage:
+ *   node scripts/backfill-user-id.js                        # dry-run prod
+ *   node scripts/backfill-user-id.js --apply                # 真跑 prod
+ *   node scripts/backfill-user-id.js --local                # 跑 local D1
+ *   node scripts/backfill-user-id.js --local --apply        # 真跑 local
+ *
+ * Env: CLOUDFLARE_API_TOKEN, CF_ACCOUNT_ID, D1_DATABASE_ID（從 openspec/config.yaml fallback）
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const APPLY = process.argv.includes('--apply');
+const LOCAL = process.argv.includes('--local');
+
+function loadEnvFromYaml() {
+  try {
+    const content = fs.readFileSync(path.join(__dirname, '..', 'openspec', 'config.yaml'), 'utf8');
+    const env = {};
+    let inEnv = false;
+    content.split('\n').forEach((line) => {
+      if (/^env:/.test(line)) { inEnv = true; return; }
+      if (inEnv && /^\S/.test(line)) { inEnv = false; return; }
+      if (inEnv) {
+        const m = line.match(/^\s+(\w+):\s*(.+)/);
+        if (m && !m[2].startsWith('#') && !m[2].startsWith('(')) {
+          env[m[1]] = m[2].replace(/^["']|["']$/g, '').replace(/#.*$/, '').trim();
+        }
+      }
+    });
+    return env;
+  } catch { return {}; }
+}
+
+const yamlEnv = loadEnvFromYaml();
+const env = (k) => process.env[k] || yamlEnv[k] || '';
+
+async function queryD1Remote(sql) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${env('CF_ACCOUNT_ID')}/d1/database/${env('D1_DATABASE_ID')}/query`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${env('CLOUDFLARE_API_TOKEN')}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sql }),
+  });
+  if (!res.ok) throw new Error(`D1 ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  if (!data.success) throw new Error(`D1 error: ${JSON.stringify(data.errors)}`);
+  return data.result[0].results;
+}
+
+function queryD1Local(sql) {
+  const escaped = sql.replace(/"/g, '\\"');
+  const out = execSync(
+    `npx wrangler d1 execute trip-planner-db --local --json --command "${escaped}"`,
+    { encoding: 'utf8', timeout: 30000 },
+  );
+  return JSON.parse(out.slice(out.indexOf('[')))[0]?.results ?? [];
+}
+
+const queryD1 = LOCAL ? queryD1Local : queryD1Remote;
+
+async function main() {
+  console.log(`backfill-user-id.js — ${APPLY ? 'APPLY' : 'DRY-RUN'} mode (${LOCAL ? 'local' : 'prod'})`);
+  console.log('---');
+
+  // 1. Distinct emails from 3 sources
+  const savedPoiEmails = await queryD1(
+    `SELECT DISTINCT email FROM saved_pois WHERE email IS NOT NULL AND user_id IS NULL`,
+  );
+  const permissionEmails = await queryD1(
+    `SELECT DISTINCT email FROM trip_permissions WHERE email IS NOT NULL AND email != '*' AND user_id IS NULL`,
+  );
+  const ideaEmails = await queryD1(
+    `SELECT DISTINCT added_by AS email FROM trip_ideas WHERE added_by IS NOT NULL AND added_by_user_id IS NULL`,
+  );
+
+  const allEmails = new Set([
+    ...savedPoiEmails.map((r) => r.email),
+    ...permissionEmails.map((r) => r.email),
+    ...ideaEmails.map((r) => r.email),
+  ]);
+
+  console.log(`Distinct emails to backfill:`);
+  console.log(`  saved_pois:        ${savedPoiEmails.length}`);
+  console.log(`  trip_permissions:  ${permissionEmails.length}`);
+  console.log(`  trip_ideas:        ${ideaEmails.length}`);
+  console.log(`  Combined unique:   ${allEmails.size}`);
+
+  // 2. Lookup users.id per email
+  const emailToUid = new Map();
+  let foundUsers = 0;
+  for (const email of allEmails) {
+    const rows = await queryD1(
+      `SELECT id FROM users WHERE email = '${email.replace(/'/g, "''")}' LIMIT 1`,
+    );
+    if (rows.length > 0) {
+      emailToUid.set(email, rows[0].id);
+      foundUsers++;
+    }
+  }
+
+  console.log(`---`);
+  console.log(`Users found:    ${foundUsers} / ${allEmails.size}`);
+  console.log(`Users missing:  ${allEmails.size - foundUsers} (這些 email 還沒 Google login)`);
+
+  // 3. UPDATE rows (or report)
+  let updates = 0;
+  for (const [email, uid] of emailToUid) {
+    const sqlSaved = `UPDATE saved_pois SET user_id = '${uid}' WHERE email = '${email.replace(/'/g, "''")}' AND user_id IS NULL`;
+    const sqlPerm = `UPDATE trip_permissions SET user_id = '${uid}' WHERE email = '${email.replace(/'/g, "''")}' AND user_id IS NULL`;
+    const sqlIdea = `UPDATE trip_ideas SET added_by_user_id = '${uid}' WHERE added_by = '${email.replace(/'/g, "''")}' AND added_by_user_id IS NULL`;
+
+    if (APPLY) {
+      await queryD1(sqlSaved);
+      await queryD1(sqlPerm);
+      await queryD1(sqlIdea);
+    }
+    updates++;
+  }
+
+  console.log(`---`);
+  if (APPLY) {
+    console.log(`✓ Applied ${updates} email→uid mappings to 3 tables`);
+  } else {
+    console.log(`Dry-run: ${updates} email→uid mappings would update 3 tables`);
+    console.log(`Re-run with --apply to actually update.`);
+  }
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/migration-0033-add-user-id-columns.test.ts
+++ b/tests/unit/migration-0033-add-user-id-columns.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Migration 0033 — add user_id columns 結構測試（V2-P1 backfill prep）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = fs.readFileSync(
+  path.resolve(__dirname, '../../migrations/0033_add_user_id_columns.sql'),
+  'utf8',
+);
+
+describe('Migration 0033 — add user_id columns', () => {
+  it('saved_pois 加 user_id TEXT FK to users.id', () => {
+    expect(MIGRATION).toMatch(/ALTER TABLE saved_pois\s+ADD COLUMN user_id TEXT REFERENCES users\(id\)/);
+  });
+
+  it('trip_permissions 加 user_id TEXT FK to users.id', () => {
+    expect(MIGRATION).toMatch(/ALTER TABLE trip_permissions\s+ADD COLUMN user_id TEXT REFERENCES users\(id\)/);
+  });
+
+  it('trip_ideas 加 added_by_user_id TEXT FK to users.id', () => {
+    expect(MIGRATION).toMatch(/ALTER TABLE trip_ideas\s+ADD COLUMN added_by_user_id TEXT REFERENCES users\(id\)/);
+  });
+
+  it('saved_pois / trip_permissions ON DELETE CASCADE (user 被刪 pool/perm 一起清)', () => {
+    expect(MIGRATION).toMatch(/saved_pois[\s\S]*?ON DELETE CASCADE/);
+    expect(MIGRATION).toMatch(/trip_permissions[\s\S]*?ON DELETE CASCADE/);
+  });
+
+  it('trip_ideas ON DELETE SET NULL (idea 文字保留 audit 用)', () => {
+    expect(MIGRATION).toMatch(/trip_ideas[\s\S]*?ON DELETE SET NULL/);
+  });
+
+  it('3 個 user_id columns 都有 index', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_saved_pois_user_id/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_trip_permissions_user_id/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_trip_ideas_added_by_user_id/);
+  });
+
+  it('column 是 nullable（沒 NOT NULL）— 預備 backfill three-step pattern', () => {
+    // user_id column 不能含 NOT NULL（既有 row 沒對應 user 會 fail）
+    expect(MIGRATION).not.toMatch(/user_id TEXT[\s\S]*?NOT NULL/);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P1 backfill 完整套件 — 加 user_id columns nullable + script 跑 email→uid mapping。

## Migration 0033

3 columns added (all nullable):
- \`saved_pois.user_id\` TEXT FK to users.id, ON DELETE CASCADE
- \`trip_permissions.user_id\` TEXT FK to users.id, ON DELETE CASCADE
- \`trip_ideas.added_by_user_id\` TEXT FK to users.id, ON DELETE SET NULL

3 indexes added (one per column).

**Three-step migration pattern**：
1. Add nullable (此 PR)
2. Backfill via script
3. NOT NULL cutover (V2-P2)

## Backfill script

\`scripts/backfill-user-id.js\`:
- Idempotent: 只 update \`user_id IS NULL\` 的 row
- Dry-run default：不指定 \`--apply\` 只印 report
- \`--local\`: 跑 local D1 via wrangler
- Prod: Cloudflare REST API D1 endpoint

```bash
node scripts/backfill-user-id.js                 # dry-run prod
node scripts/backfill-user-id.js --apply         # 真跑 prod
node scripts/backfill-user-id.js --local         # 跑 local
node scripts/backfill-user-id.js --local --apply # 真跑 local
```

## Operation order

1. ✓ Migration 0033 deploy (此 PR)
2. (Wait) user 們 Google login → users + auth_identities 有 row
3. Run \`scripts/backfill-user-id.js --apply\` (跑幾次直到 missing 數 stable)
4. (V2-P2 cutover) 加 NOT NULL constraint + drop email column

## Test

\`tests/unit/migration-0033-add-user-id-columns.test.ts\` **7 cases TDD pass**:
- 3 columns shape + FK
- ON DELETE 行為（CASCADE / SET NULL）
- 3 indexes
- Nullable verified（three-step pattern）

## V2-P1 sprint 1 — **完整真實 wrap**

V2-P1 sprint 1 含 backfill prep complete。剩 V2-P2 ~ V2-P7 是 12 週 sprint work。

🤖 Generated with [Claude Code](https://claude.com/claude-code)