### PR TITLE
feat(v2-p2): password hashing module — PBKDF2-SHA256 (Web Crypto)

### DIFF
--- a/src/server/password.ts
+++ b/src/server/password.ts
@@ -1,0 +1,123 @@
+/**
+ * Password hashing module — V2-P2 (per docs/v2-oauth-server-plan.md)
+ *
+ * 設計取捨：
+ *   - 用 Web Crypto PBKDF2-SHA256（CF Workers native，無 wasm dep）
+ *   - 不用 argon2id（雖然 spec 較 prefer）— argon2 在 CF Workers 需 wasm
+ *     （hash-wasm package），增加 cold-start 跟 deps 風險。PBKDF2 with
+ *     600,000 iterations 是 OWASP 2023 password 儲存 recommendation 之一
+ *     [https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html]
+ *   - V2-P6 security hardening 階段 evaluate argon2id wasm migration（可
+ *     共存：根據 hash format prefix 決定 verify 方式）
+ *
+ * Hash format（self-describing，便於將來 algorithm migration）:
+ *
+ *   pbkdf2$<iterations>$<base64url salt>$<base64url hash>
+ *
+ * 例：pbkdf2$600000$rA5j...$x8K2...
+ *
+ * Verify 時 parse format → 用同 iteration + salt 重算 → constant-time compare。
+ */
+
+const ALGORITHM_NAME = 'pbkdf2';
+const HASH_FN = 'SHA-256';
+const ITERATIONS = 600_000; // OWASP 2023 PBKDF2-SHA256 recommendation
+const SALT_BYTES = 16;
+const HASH_BYTES = 32;
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - (s.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function pbkdf2(password: string, salt: Uint8Array, iterations: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits'],
+  );
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: HASH_FN,
+      // TS 5.x strict：Uint8Array<ArrayBufferLike> 不能直接當 BufferSource
+      // (因可能含 SharedArrayBuffer)。cast 到 ArrayBuffer subset 因 new Uint8Array() 永遠不會 share。
+      salt: salt as unknown as ArrayBuffer,
+      iterations,
+    },
+    key,
+    HASH_BYTES * 8,
+  );
+  return new Uint8Array(derivedBits);
+}
+
+function constantTimeEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i]! ^ b[i]!;
+  return diff === 0;
+}
+
+/**
+ * Hash a plaintext password。
+ * Returns format: `pbkdf2$<iter>$<salt-b64u>$<hash-b64u>`
+ */
+export async function hashPassword(plain: string): Promise<string> {
+  if (!plain || plain.length < 8) {
+    throw new Error('Password must be at least 8 chars');
+  }
+  const salt = new Uint8Array(SALT_BYTES);
+  crypto.getRandomValues(salt);
+  const hash = await pbkdf2(plain, salt, ITERATIONS);
+  return `${ALGORITHM_NAME}$${ITERATIONS}$${base64urlEncode(salt)}$${base64urlEncode(hash)}`;
+}
+
+/**
+ * Verify plaintext against stored hash。
+ * Returns true if match, false otherwise (no throw on bad format — fail closed)。
+ */
+export async function verifyPassword(plain: string, stored: string): Promise<boolean> {
+  if (!plain || !stored) return false;
+  const parts = stored.split('$');
+  if (parts.length !== 4) return false;
+  const [algo, iterStr, saltB64, hashB64] = parts;
+  if (algo !== ALGORITHM_NAME) return false;
+  if (!iterStr || !saltB64 || !hashB64) return false;
+  const iterations = Number(iterStr);
+  if (!Number.isFinite(iterations) || iterations < 1) return false;
+  let salt: Uint8Array;
+  let storedHash: Uint8Array;
+  try {
+    salt = base64urlDecode(saltB64);
+    storedHash = base64urlDecode(hashB64);
+  } catch {
+    return false;
+  }
+  const computed = await pbkdf2(plain, salt, iterations);
+  return constantTimeEquals(computed, storedHash);
+}
+
+/**
+ * Re-hash if iteration count is below current。Useful for incremental upgrade
+ * when OWASP recommendation bumps（V2-P6 might raise to 1M）。Caller storing
+ * password should call this on successful login + persist if returned non-null。
+ */
+export function needsRehash(stored: string): boolean {
+  const parts = stored.split('$');
+  if (parts.length !== 4) return true;
+  const [algo, iterStr] = parts;
+  if (algo !== ALGORITHM_NAME) return true;
+  const iterations = Number(iterStr);
+  return !Number.isFinite(iterations) || iterations < ITERATIONS;
+}

--- a/tests/unit/password-module.test.ts
+++ b/tests/unit/password-module.test.ts
@@ -1,0 +1,83 @@
+/**
+ * src/server/password.ts unit test — V2-P2
+ *
+ * PBKDF2-SHA256 password hashing — sign+verify roundtrip + edge cases。
+ */
+import { describe, it, expect } from 'vitest';
+import { hashPassword, verifyPassword, needsRehash } from '../../src/server/password';
+
+describe('hashPassword', () => {
+  it('returns format pbkdf2$iter$salt$hash', async () => {
+    const stored = await hashPassword('correct-horse-battery-staple');
+    expect(stored).toMatch(/^pbkdf2\$\d+\$[A-Za-z0-9_-]+\$[A-Za-z0-9_-]+$/);
+  });
+
+  it('iterations field ≥ 600000 (OWASP 2023)', async () => {
+    const stored = await hashPassword('password123');
+    const iter = Number(stored.split('$')[1]);
+    expect(iter).toBeGreaterThanOrEqual(600_000);
+  });
+
+  it('different calls produce different output (random salt)', async () => {
+    const h1 = await hashPassword('same-password');
+    const h2 = await hashPassword('same-password');
+    expect(h1).not.toBe(h2);
+    // 但 verify 兩個都通
+    expect(await verifyPassword('same-password', h1)).toBe(true);
+    expect(await verifyPassword('same-password', h2)).toBe(true);
+  });
+
+  it('rejects password < 8 chars (sanity)', async () => {
+    await expect(hashPassword('short')).rejects.toThrow(/8 chars/);
+    await expect(hashPassword('')).rejects.toThrow();
+  });
+}, 30_000); // 600k iterations 慢，給 30s timeout
+
+describe('verifyPassword', () => {
+  it('correct password → true', async () => {
+    const stored = await hashPassword('p@ssw0rd-test');
+    expect(await verifyPassword('p@ssw0rd-test', stored)).toBe(true);
+  });
+
+  it('wrong password → false', async () => {
+    const stored = await hashPassword('correct1');
+    expect(await verifyPassword('wrong-password', stored)).toBe(false);
+  });
+
+  it('empty plaintext → false', async () => {
+    const stored = await hashPassword('p@ssw0rd');
+    expect(await verifyPassword('', stored)).toBe(false);
+  });
+
+  it('malformed stored hash → false (no throw)', async () => {
+    expect(await verifyPassword('any', 'not-pbkdf2-format')).toBe(false);
+    expect(await verifyPassword('any', 'pbkdf2$$$')).toBe(false);
+    expect(await verifyPassword('any', 'pbkdf2$abc$salt$hash')).toBe(false); // iter not number
+  });
+
+  it('different algorithm prefix → false (future-proof)', async () => {
+    expect(await verifyPassword('any', 'argon2id$1$salt$hash')).toBe(false);
+  });
+
+  it('case-sensitive password compare', async () => {
+    const stored = await hashPassword('CaseSensitive');
+    expect(await verifyPassword('CaseSensitive', stored)).toBe(true);
+    expect(await verifyPassword('casesensitive', stored)).toBe(false);
+  });
+}, 60_000);
+
+describe('needsRehash', () => {
+  it('returns false for current-iteration hash', async () => {
+    const stored = await hashPassword('test1234');
+    expect(needsRehash(stored)).toBe(false);
+  });
+
+  it('returns true for hash with lower iter count (legacy)', () => {
+    expect(needsRehash('pbkdf2$100000$salt$hash')).toBe(true);
+  });
+
+  it('returns true for non-pbkdf2 algorithm (legacy md5/sha1)', () => {
+    expect(needsRehash('md5$salt$hash')).toBe(true);
+    expect(needsRehash('plaintext-not-formatted')).toBe(true);
+  });
+}, 30_000);


### PR DESCRIPTION
## Summary

**V2-P2 first slice** — Local password provider 鋪路。Password hash + verify module 為 V2-P2 sign-up / local login 預備。

## API

```ts
import { hashPassword, verifyPassword, needsRehash } from './password';

const stored = await hashPassword('correct-horse-battery-staple');
// 'pbkdf2$600000$rA5j...$x8K2...'

await verifyPassword('correct-horse-battery-staple', stored);  // true
await verifyPassword('wrong', stored);                          // false

needsRehash(stored);  // false (current iter count)
needsRehash('md5$...');  // true (legacy algorithm)
```

## Algorithm choice rationale

- **Web Crypto PBKDF2-SHA256** — CF Workers native，無 wasm dep
- 不用 argon2id：CF Workers 需 wasm package (\`hash-wasm\`)，增 cold-start 風險
- **600,000 iterations** — [OWASP 2023 PBKDF2-SHA256 password storage recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
- V2-P6 評估 argon2id wasm 升級（self-describing format 支援 algorithm migration）

## Format (self-describing)

```
pbkdf2$<iterations>$<base64url-salt>$<base64url-hash>
```

Future algo migration via prefix: \`argon2id$...\` / \`scrypt$...\` 共存。

## Security

- Random 16-byte salt (crypto.getRandomValues)
- 32-byte hash output
- Constant-time compare 避免 timing attack
- ≥ 8 char min (sanity，sign-up 上層 stricter validation)

## Test

\`tests/unit/password-module.test.ts\` **13 cases TDD pass**:
- Format / iter count
- Random salt → different output, both verify
- Rejects < 8 chars
- Verify happy / wrong / empty / malformed / wrong algorithm / case-sensitive
- needsRehash legacy / current

## V2-P2 progress (1/N)

| Slice | Status |
|-------|--------|
| Password hash/verify module | ✓ (本 PR) |
| Sign-up endpoint | next |
| Local login endpoint | next |
| Email verification flow | future |
| Sign-up form UI | future |

## Phase tracker

V2-P1 ✓ done (sprint 1: 17 PR + backfill prep)
V2-P2 → in progress (本 PR 起)
V2-P3 ~ V2-P7 → future sprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)