### PR TITLE
feat(v2-p2): /api/oauth/login — local password login

### DIFF
--- a/functions/api/oauth/login.ts
+++ b/functions/api/oauth/login.ts
@@ -1,0 +1,91 @@
+/**
+ * POST /api/oauth/login
+ * Body: { email: string, password: string }
+ *
+ * V2-P2 — Local password login。verify password → issueSession。
+ *
+ * Security:
+ *   - Generic 401 LOGIN_INVALID 不分 email-not-found vs wrong-password
+ *     (避免 email enumeration attack)
+ *   - 失敗仍跑 verifyPassword 的 hash compute 避免 timing oracle leak
+ *     (constant time guarantee — fake hash for unknown email)
+ *   - Rate limit deferred V2-P6
+ *   - Update auth_identities.last_used_at on success
+ *
+ * Error codes:
+ *   400 LOGIN_INVALID_INPUT
+ *   401 LOGIN_INVALID  (generic — 防 email enumeration)
+ *   500 SYS_INTERNAL
+ */
+import { issueSession } from '../_session';
+import { parseJsonBody } from '../_utils';
+import { verifyPassword } from '../../../src/server/password';
+import type { Env } from '../_types';
+
+interface LoginBody {
+  email?: string;
+  password?: string;
+}
+
+interface AuthIdentityRow {
+  user_id: string;
+  password_hash: string | null;
+}
+
+// Fake hash to compute against when email not found — defeats timing oracle
+// (PBKDF2 takes constant time regardless of input)。Static value, doesn't matter
+// since constant-time compare against unrelated hash will always fail。
+const TIMING_PROBE_HASH = 'pbkdf2$600000$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+function errorResponse(code: string, message: string, status: number): Response {
+  return new Response(
+    JSON.stringify({ error: { code, message } }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const body = (await parseJsonBody<LoginBody>(context.request)) ?? {};
+  const email = (body.email ?? '').trim().toLowerCase();
+  const password = body.password ?? '';
+
+  if (!email || !password) {
+    return errorResponse('LOGIN_INVALID_INPUT', 'email + password 必填', 400);
+  }
+
+  // Lookup local provider identity
+  const identity = await context.env.DB
+    .prepare(
+      `SELECT user_id, password_hash FROM auth_identities
+       WHERE provider = ? AND provider_user_id = ?`,
+    )
+    .bind('local', email)
+    .first<AuthIdentityRow>();
+
+  // Always run verifyPassword (real hash if found, fake if not) — constant-time guarantee
+  const hashToCheck = identity?.password_hash ?? TIMING_PROBE_HASH;
+  const passwordOk = await verifyPassword(password, hashToCheck);
+
+  if (!identity || !passwordOk) {
+    return errorResponse('LOGIN_INVALID', 'email 或密碼錯誤', 401);
+  }
+
+  // Update last_used_at (best effort, don't fail login if update errors)
+  try {
+    await context.env.DB
+      .prepare(
+        `UPDATE auth_identities SET last_used_at = ? WHERE provider = ? AND provider_user_id = ?`,
+      )
+      .bind(new Date().toISOString(), 'local', email)
+      .run();
+  } catch {
+    // ignore — login still succeeds
+  }
+
+  const response = new Response(
+    JSON.stringify({ ok: true, userId: identity.user_id, email }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+  await issueSession(context.request, response, identity.user_id, context.env);
+  return response;
+};

--- a/tests/api/oauth-login.test.ts
+++ b/tests/api/oauth-login.test.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/oauth/login unit test — V2-P2
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestPost } from '../../functions/api/oauth/login';
+import { hashPassword } from '../../src/server/password';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  return stmt;
+}
+
+function makeContext(body: unknown, env: MockEnv): Parameters<typeof onRequestPost>[0] {
+  return {
+    request: new Request('https://x.com/api/oauth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestPost>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('POST /api/oauth/login', () => {
+  it('400 LOGIN_INVALID_INPUT when email or password missing', async () => {
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: vi.fn() } };
+    const r1 = await onRequestPost(makeContext({ email: 'a@b.com' }, env));
+    expect(r1.status).toBe(400);
+    expect((await r1.json() as { error: { code: string } }).error.code).toBe('LOGIN_INVALID_INPUT');
+    const r2 = await onRequestPost(makeContext({ password: 'pwd123' }, env));
+    expect(r2.status).toBe(400);
+  });
+
+  it('401 LOGIN_INVALID when email not found (generic — no enum leak)', async () => {
+    const stmt = makeStmt(null); // no identity
+    const env: MockEnv = {
+      SESSION_SECRET: 's',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const res = await onRequestPost(makeContext({ email: 'unknown@x.com', password: 'whatever' }, env));
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('LOGIN_INVALID');
+  }, 30_000);
+
+  it('401 LOGIN_INVALID when password wrong', async () => {
+    const real = await hashPassword('correct-pass');
+    const stmt = makeStmt({ user_id: 'u1', password_hash: real });
+    const env: MockEnv = {
+      SESSION_SECRET: 's',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const res = await onRequestPost(makeContext({ email: 'a@b.com', password: 'wrong-pass' }, env));
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('LOGIN_INVALID');
+  }, 60_000);
+
+  it('happy path: 200 + Set-Cookie + last_used_at update', async () => {
+    const real = await hashPassword('correct-pass');
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT user_id, password_hash')) {
+        return makeStmt({ user_id: 'logged-in-uid', password_hash: real });
+      }
+      if (sql.includes('UPDATE auth_identities')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'session-secret-test',
+      DB: { prepare: dbPrepare },
+    };
+    const res = await onRequestPost(makeContext({ email: 'a@b.com', password: 'correct-pass' }, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; userId: string; email: string };
+    expect(json.ok).toBe(true);
+    expect(json.userId).toBe('logged-in-uid');
+    expect(json.email).toBe('a@b.com');
+    expect(res.headers.get('Set-Cookie')).toMatch(/tripline_session=/);
+
+    // last_used_at UPDATE was called
+    const calls = dbPrepare.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((s) => s.includes('UPDATE auth_identities'))).toBe(true);
+  }, 60_000);
+
+  it('email lowercase + trim before lookup', async () => {
+    const stmt = makeStmt(null);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: dbPrepare } };
+    await onRequestPost(makeContext({ email: '  Mixed.Case@EXAMPLE.com  ', password: 'whatever' }, env));
+    expect(stmt.bind).toHaveBeenCalledWith('local', 'mixed.case@example.com');
+  }, 30_000);
+
+  it('still 401 even if DB returns identity with NULL password_hash (e.g. only Google identity)', async () => {
+    const stmt = makeStmt({ user_id: 'u1', password_hash: null }); // Google-only user attempting password login
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestPost(makeContext({ email: 'a@b.com', password: 'whatever' }, env));
+    expect(res.status).toBe(401);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

V2-P2 3rd slice — Local password login endpoint。POST email + password → verifyPassword → issueSession。

## API

```
POST /api/oauth/login
Body: { email: string, password: string }

→ 200 { ok: true, userId, email } + Set-Cookie
→ 400 LOGIN_INVALID_INPUT  (email or password missing)
→ 401 LOGIN_INVALID  (generic — email not found OR wrong password)
```

## Security highlights

| Issue | Mitigation |
|-------|------------|
| Email enumeration | Generic 401 不分 email-not-found vs wrong-password |
| Timing oracle leak | Email not found 仍跑 \`verifyPassword\` against \`TIMING_PROBE_HASH\` (constant time guarantee) |
| Google-only user 試 password login | \`password_hash IS NULL\` → \`verifyPassword(any, null)\` → false → 401 |
| Email case sensitivity | Lowercase + trim before SELECT |
| Rate limit | Deferred V2-P6 (middleware level) |

## Side effect

Update \`auth_identities.last_used_at\` on success — best-effort，UPDATE fail 不 block login。

## Test

\`tests/api/oauth-login.test.ts\` **6 cases TDD pass**:
- Missing input → 400
- Email not found → 401 (generic)
- Wrong password → 401 (generic)
- Happy 200 + Set-Cookie + last_used_at UPDATE
- Email lowercase + trim
- NULL password_hash (Google-only) → 401

## V2-P2 progress (3/N)

| # | Slice | Status |
|---|-------|--------|
| #273 | Password hash module | ✓ |
| #274 | Sign-up endpoint | ✓ |
| **本 PR** | **Login endpoint** | ✓ |

## Next

- Email verification flow (verify token + endpoint)
- Sign-up + login UI form
- V2-P3: 忘記密碼 flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)