### PR TITLE
feat(v2-p3): /api/oauth/reset-password — verify token + update password

### DIFF
--- a/functions/api/oauth/reset-password.ts
+++ b/functions/api/oauth/reset-password.ts
@@ -1,0 +1,95 @@
+/**
+ * POST /api/oauth/reset-password
+ * Body: { token: string, password: string }
+ *
+ * V2-P3 — verify reset token + update password_hash + destroy token (one-time use)。
+ *
+ * Flow:
+ *   1. Validate token + password format
+ *   2. D1Adapter find token (oauth_models name='PasswordReset')
+ *   3. If not found / expired / used → 400 RESET_TOKEN_INVALID
+ *   4. hashPassword(new password) → UPDATE auth_identities WHERE user_id = ?
+ *   5. destroy token (one-time use, atomic via D1Adapter.destroy)
+ *   6. Return 200 (caller redirect to /login)
+ *
+ * 不 issue session 自動：force user 用新密碼 explicit login，verify 他記得新密碼。
+ *
+ * Future (V2-P3 next slice): 加 session revoke — invalidate all existing sessions
+ * for this user (V2-P5 oauth_models Session table)。
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import { hashPassword } from '../../../src/server/password';
+import { parseJsonBody } from '../_utils';
+import type { Env } from '../_types';
+
+interface ResetBody {
+  token?: string;
+  password?: string;
+}
+
+interface ResetTokenPayload {
+  userId: string;
+  email: string;
+  createdAt: number;
+  used?: boolean;
+  [key: string]: unknown;
+}
+
+const MIN_PASSWORD_LEN = 8;
+
+function errorResponse(code: string, message: string, status: number): Response {
+  return new Response(
+    JSON.stringify({ error: { code, message } }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const body = (await parseJsonBody<ResetBody>(context.request)) ?? {};
+  const token = (body.token ?? '').trim();
+  const password = body.password ?? '';
+
+  if (!token) {
+    return errorResponse('RESET_TOKEN_MISSING', '缺少 token', 400);
+  }
+  if (!password || password.length < MIN_PASSWORD_LEN) {
+    return errorResponse('RESET_INVALID_PASSWORD', `密碼至少 ${MIN_PASSWORD_LEN} 字元`, 400);
+  }
+
+  const adapter = new D1Adapter(context.env.DB, 'PasswordReset');
+  const tokenRow = (await adapter.find(token)) as ResetTokenPayload | undefined;
+
+  if (!tokenRow) {
+    return errorResponse('RESET_TOKEN_INVALID', '重設連結已過期或無效', 400);
+  }
+
+  // One-time use safeguard
+  if (tokenRow.used) {
+    return errorResponse('RESET_TOKEN_INVALID', '重設連結已使用，請重新申請', 400);
+  }
+
+  // Hash + UPDATE
+  let passwordHash: string;
+  try {
+    passwordHash = await hashPassword(password);
+  } catch {
+    return errorResponse('RESET_INVALID_PASSWORD', '密碼格式不符', 400);
+  }
+
+  await context.env.DB
+    .prepare(
+      `UPDATE auth_identities
+       SET password_hash = ?, password_algo = ?, last_used_at = ?
+       WHERE user_id = ? AND provider = 'local'`,
+    )
+    .bind(passwordHash, 'pbkdf2', new Date().toISOString(), tokenRow.userId)
+    .run();
+
+  // Destroy token (one-time use guard)
+  await adapter.destroy(token);
+
+  return new Response(
+    JSON.stringify({ ok: true, message: '密碼已更新，請用新密碼登入' }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+};

--- a/tests/api/oauth-reset-password.test.ts
+++ b/tests/api/oauth-reset-password.test.ts
@@ -1,0 +1,128 @@
+/**
+ * POST /api/oauth/reset-password unit test — V2-P3
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestPost } from '../../functions/api/oauth/reset-password';
+
+interface MockEnv {
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  return stmt;
+}
+
+function makeContext(body: unknown, env: MockEnv): Parameters<typeof onRequestPost>[0] {
+  return {
+    request: new Request('https://x.com/api/oauth/reset-password', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestPost>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('POST /api/oauth/reset-password', () => {
+  it('400 RESET_TOKEN_MISSING when token empty', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestPost(makeContext({ password: 'newpass123' }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('RESET_TOKEN_MISSING');
+  });
+
+  it('400 RESET_INVALID_PASSWORD when password < 8 chars', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestPost(makeContext({ token: 'tok', password: 'short' }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('RESET_INVALID_PASSWORD');
+  });
+
+  it('400 RESET_TOKEN_INVALID when token not in D1 (expired or never existed)', async () => {
+    const stmt = makeStmt(null);
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestPost(makeContext({ token: 'expired', password: 'newpass1234' }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('RESET_TOKEN_INVALID');
+  });
+
+  it('happy path: 200 + UPDATE password_hash + destroy token', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        // D1Adapter.find — return reset token payload
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u1', email: 'u@x.com', createdAt: Date.now(), used: false }),
+          expires_at: Date.now() + 1000 * 60 * 30, // 30 min remaining
+        });
+      }
+      if (sql.includes('UPDATE auth_identities')) return makeStmt();
+      if (sql.includes('DELETE FROM oauth_models')) return makeStmt(); // adapter.destroy
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      token: 'valid-token',
+      password: 'new-secure-password-123',
+    }, env));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; message: string };
+    expect(json.ok).toBe(true);
+    expect(json.message).toContain('密碼已更新');
+
+    // Verify UPDATE auth_identities + DELETE oauth_models calls
+    const sqls = dbPrepare.mock.calls.map((c) => c[0] as string);
+    expect(sqls.some((s) => s.includes('UPDATE auth_identities'))).toBe(true);
+    expect(sqls.some((s) => s.includes('DELETE FROM oauth_models'))).toBe(true);
+  }, 30_000);
+
+  it('400 when token already used (one-time use guard)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u1', email: 'u@x.com', used: true }),
+          expires_at: Date.now() + 1000 * 60,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ token: 'used-tok', password: 'newpass1234' }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('RESET_TOKEN_INVALID');
+  });
+
+  it('UPDATE filters provider=local (不影響 Google identity)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u1', email: 'u@x.com' }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onRequestPost(makeContext({ token: 't', password: 'newpass1234' }, env));
+
+    const updateSql = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE auth_identities'),
+    )?.[0] as string;
+    expect(updateSql).toContain("provider = 'local'");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

V2-P3 2nd slice — 收 token + 新密碼 → verify D1 PasswordReset row → UPDATE \`auth_identities.password_hash\` → destroy token (one-time use)。

## API

```
POST /api/oauth/reset-password
Body: { token: string, password: string }

→ 200 { ok: true, message: '密碼已更新，請用新密碼登入' }
→ 400 RESET_TOKEN_MISSING / RESET_INVALID_PASSWORD / RESET_TOKEN_INVALID
```

## Flow

1. Validate token + password ≥ 8 chars
2. \`D1Adapter.find\` PasswordReset (lazy expire on read built-in)
3. \`used\` flag check (防 race condition)
4. \`hashPassword\` → UPDATE auth_identities WHERE provider='local'
5. \`adapter.destroy\` (one-time guard)
6. 200 — 不 issue session (force explicit re-login)

## Why no auto-session

Force user 用新密碼 explicit login → verify 他記得新密碼 + 防 token theft 場景下 attacker 不能拿 session。

## Future (V2-P3 next slice)

- **Session revoke**：所有現有 session for this user invalidate（V2-P5 oauth_models Session table 的 prefix scan + delete）
- 配合 forgot-password 加 email service integration

## Test

\`tests/api/oauth-reset-password.test.ts\` **6 cases TDD pass**:
- Empty token → 400
- Password < 8 → 400
- Token not in D1 → 400 RESET_TOKEN_INVALID
- Happy 200 + UPDATE + DELETE
- used flag → 400 (one-time guard)
- UPDATE WHERE provider='local' (Google untouched)

## V2-P3 progress (2/N)

| # | Slice | Status |
|---|-------|--------|
| #276 | forgot-password (token gen) | pending |
| **本 PR** | **reset-password (token verify + update)** | ✓ |

Forgot + reset endpoint pair complete。剩 email service integration + UI form 留 next slice。

🤖 Generated with [Claude Code](https://claude.com/claude-code)