### PR TITLE
feat(v2-p4): client_apps migration — OAuth Server client registry (starter)

### DIFF
--- a/migrations/0034_client_apps.sql
+++ b/migrations/0034_client_apps.sql
@@ -1,0 +1,49 @@
+-- Migration 0034: client_apps — V2-P4 OAuth Server client registry
+--
+-- V2-P4 階段 tripline 開始當 Authorization Server（不只 OAuth Client to Google）。
+-- 外部 client app 要走 tripline 的 /oauth/authorize + /oauth/token flow，需要先
+-- register 在 client_apps 表，配上 client_id + client_secret + redirect_uris
+-- whitelist。
+--
+-- 對應 docs/v2-oauth-server-plan.md V2-P4 spec：
+--   - /oauth/authorize（PKCE + consent screen）
+--   - /oauth/token（authorization_code / refresh_token grants）
+--   - /.well-known/jwks.json + key rotation
+--
+-- ## 設計取捨
+--
+-- - **client_id format**：app-style stable identifier, free-form text，不是 UUID
+--   方便 ops human-readable（例：'tripline-mobile-ios' / 'partner-airbnb-poi'）
+-- - **client_secret_hash**：argon2id / pbkdf2 hash 不存明文（reuse password module）
+-- - **redirect_uris**：JSON array of strings（SQLite 沒 array type，用 TEXT JSON）
+-- - **client_type**：'public' (no secret, PKCE required) / 'confidential' (server-side, secret + client_credentials)
+-- - **allowed_scopes**：JSON array (e.g. ["openid","profile","email","trips:read"])
+-- - **owner_user_id**：誰建這個 client（developer dashboard 顯示用）
+-- - **status**：'active' / 'suspended' / 'pending_review' (新 client 要 ops 審核)
+--
+-- ## Pending V2-P4 next slices
+--
+-- - /oauth/authorize 接 client_id lookup
+-- - /oauth/token client_secret verify (constant-time)
+-- - Developer dashboard: register client + view client_id
+-- - Audit log on client_app create / suspend
+
+CREATE TABLE client_apps (
+  client_id            TEXT PRIMARY KEY,             -- e.g. 'partner-xyz'
+  client_secret_hash   TEXT,                          -- pbkdf2$...，public client 為 NULL
+  client_type          TEXT NOT NULL CHECK (client_type IN ('public', 'confidential')),
+  app_name             TEXT NOT NULL,                 -- consent screen 顯示
+  app_description      TEXT,
+  app_logo_url         TEXT,
+  homepage_url         TEXT,
+  redirect_uris        TEXT NOT NULL,                 -- JSON array of strings
+  allowed_scopes       TEXT NOT NULL,                 -- JSON array, default '["openid","profile","email"]'
+  owner_user_id        TEXT REFERENCES users(id) ON DELETE SET NULL,
+  status               TEXT NOT NULL DEFAULT 'pending_review'
+                         CHECK (status IN ('active', 'suspended', 'pending_review')),
+  created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_client_apps_owner_user_id ON client_apps(owner_user_id);
+CREATE INDEX idx_client_apps_status ON client_apps(status);

--- a/tests/unit/migration-0034-client-apps.test.ts
+++ b/tests/unit/migration-0034-client-apps.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Migration 0034 — client_apps schema 結構測試（V2-P4 starter）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = fs.readFileSync(
+  path.resolve(__dirname, '../../migrations/0034_client_apps.sql'),
+  'utf8',
+);
+
+describe('Migration 0034 — client_apps (V2-P4 OAuth Server)', () => {
+  it('client_id is TEXT PRIMARY KEY (human-readable identifier)', () => {
+    expect(MIGRATION).toMatch(/client_id\s+TEXT PRIMARY KEY/);
+  });
+
+  it('client_secret_hash 用 hash 不存明文 (nullable for public clients)', () => {
+    expect(MIGRATION).toMatch(/client_secret_hash\s+TEXT[\s,]/);
+    // 不該 NOT NULL — public client (PKCE) 沒 secret
+    expect(MIGRATION).not.toMatch(/client_secret_hash[^,\n]+NOT NULL/);
+  });
+
+  it('client_type CHECK constraint: public | confidential', () => {
+    expect(MIGRATION).toMatch(/client_type[\s\S]*?CHECK[\s\S]*?'public'[\s\S]*?'confidential'/);
+  });
+
+  it('app_name NOT NULL (consent screen 必顯示)', () => {
+    expect(MIGRATION).toMatch(/app_name\s+TEXT NOT NULL/);
+  });
+
+  it('redirect_uris + allowed_scopes 都 NOT NULL JSON array (TEXT)', () => {
+    expect(MIGRATION).toMatch(/redirect_uris\s+TEXT NOT NULL/);
+    expect(MIGRATION).toMatch(/allowed_scopes\s+TEXT NOT NULL/);
+  });
+
+  it('owner_user_id FK to users.id ON DELETE SET NULL (保留 client app history)', () => {
+    expect(MIGRATION).toMatch(/owner_user_id\s+TEXT REFERENCES users\(id\) ON DELETE SET NULL/);
+  });
+
+  it('status CHECK constraint includes pending_review (ops 審核 flow)', () => {
+    expect(MIGRATION).toMatch(/status[\s\S]*?CHECK[\s\S]*?pending_review/);
+  });
+
+  it('default status = pending_review (new client 等審核)', () => {
+    expect(MIGRATION).toMatch(/status\s+TEXT NOT NULL DEFAULT 'pending_review'/);
+  });
+
+  it('indexes on owner_user_id + status', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_client_apps_owner_user_id/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_client_apps_status/);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 first slice — OAuth Server client registry schema。Tripline 進入「當 Authorization Server」階段，external client app 要 register 才能走 \`/oauth/authorize\` + \`/oauth/token\` flow。

## Schema

| Column | Type | Notes |
|--------|------|-------|
| client_id | TEXT PK | Human-readable (e.g. 'partner-xyz') |
| client_secret_hash | TEXT | pbkdf2$..., NULL for public clients |
| client_type | TEXT CHECK | 'public' (PKCE required) / 'confidential' (server-side secret) |
| app_name | TEXT NOT NULL | Consent screen 顯示 |
| app_description / app_logo_url / homepage_url | TEXT | Consent screen UI |
| redirect_uris | TEXT (JSON array) | Whitelist enforce |
| allowed_scopes | TEXT (JSON array) | default openid+profile+email |
| owner_user_id | TEXT FK users.id | ON DELETE SET NULL |
| status | TEXT CHECK | 'active' / 'suspended' / 'pending_review' (default) |

## Why pending_review default

新 client 預設 \`pending_review\` — ops 必須手動 review + 改 \`active\`。防止 spam registration / phishing 應用 abuse tripline OAuth。

## Pending V2-P4 next slices

- \`/oauth/authorize\`: client_id lookup + redirect_uris whitelist enforce
- \`/oauth/token\`: client_secret verify (constant-time, reuse password module)
- Developer dashboard (register client + view client_id) UI page
- PKCE enforcement for public clients
- Audit log on client_app create / suspend

## Test

\`tests/unit/migration-0034-client-apps.test.ts\` **9 cases TDD pass**:
- PK + column types
- secret nullable (public client)
- CHECK constraints (client_type / status)
- FK ON DELETE SET NULL (preserve client_app history)
- Default status pending_review
- Indexes

## Phase tracker

| Phase | Status |
|-------|--------|
| V2-P1 OAuth Identity Core | ✓ done (sprint 1: 17 PR + backfill prep) |
| V2-P2 Local password | ✓ 3/N (hash / signup / login) |
| V2-P3 忘記密碼 | ✓ 2/N (forgot / reset) |
| **V2-P4 OAuth Server** | 🔄 **本 PR (1/N starter)** |
| V2-P5 Token + Consent | ⏳ |
| V2-P6 Security hardening | ⏳ |
| V2-P7 Docs + Audit + Launch | ⏳ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)