### PR TITLE
feat(v2-p4): OAuth Server authorize request validator (RFC 6749 §4.1.1 + PKCE)

### DIFF
--- a/src/server/oauth-server/validate-authorize-request.ts
+++ b/src/server/oauth-server/validate-authorize-request.ts
@@ -1,0 +1,174 @@
+/**
+ * OAuth Server `/authorize` request validator — V2-P4
+ *
+ * Pure module — caller (functions/api/oauth/server-authorize.ts，next slice)
+ * 用此驗 incoming authorize request from external OAuth client。
+ *
+ * Per RFC 6749 §4.1.1（authorization_code grant）：
+ *   - response_type=code (only — no implicit/hybrid)
+ *   - client_id required，必須在 client_apps + active
+ *   - redirect_uri must EXACT match client_apps.redirect_uris (no prefix / wildcard)
+ *   - scope subset of client_apps.allowed_scopes
+ *   - state recommended (anti-CSRF — 不強制但 warn)
+ *   - PKCE required for public clients (code_challenge + code_challenge_method=S256)
+ *   - PKCE optional for confidential clients (V2-P6 enforce always)
+ */
+
+export interface ClientAppRow {
+  client_id: string;
+  client_type: 'public' | 'confidential';
+  app_name: string;
+  redirect_uris: string;     // JSON array
+  allowed_scopes: string;    // JSON array
+  status: 'active' | 'suspended' | 'pending_review';
+}
+
+export interface AuthorizeRequest {
+  response_type?: string;
+  client_id?: string;
+  redirect_uri?: string;
+  scope?: string;
+  state?: string;
+  code_challenge?: string;
+  code_challenge_method?: string;
+  prompt?: string;
+}
+
+export interface ValidationError {
+  code: string;
+  message: string;
+  /** RFC 6749 spec：error 應 redirect 回 client redirect_uri (除非 redirect_uri 本身 invalid) */
+  redirectableToClient: boolean;
+}
+
+export interface ValidatedRequest {
+  client: ClientAppRow;
+  redirectUri: string;
+  scopes: string[];
+  state: string | null;
+  codeChallenge: string | null;
+  codeChallengeMethod: 'S256' | null;
+  prompt: string | null;
+}
+
+function safeParseArray(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Validate authorize request against client_apps row。
+ *
+ * @returns ValidatedRequest on success, ValidationError on fail
+ */
+export function validateAuthorizeRequest(
+  req: AuthorizeRequest,
+  client: ClientAppRow | null,
+): ValidatedRequest | ValidationError {
+  // 1. client_id check (must be in DB)
+  if (!req.client_id) {
+    return { code: 'invalid_request', message: 'Missing client_id', redirectableToClient: false };
+  }
+  if (!client) {
+    return { code: 'unauthorized_client', message: 'Unknown client_id', redirectableToClient: false };
+  }
+  if (client.status !== 'active') {
+    return {
+      code: 'unauthorized_client',
+      message: `Client status: ${client.status}（須 active）`,
+      redirectableToClient: false,
+    };
+  }
+
+  // 2. redirect_uri exact match
+  if (!req.redirect_uri) {
+    return { code: 'invalid_request', message: 'Missing redirect_uri', redirectableToClient: false };
+  }
+  const allowedRedirects = safeParseArray(client.redirect_uris);
+  if (!allowedRedirects.includes(req.redirect_uri)) {
+    return {
+      code: 'invalid_request',
+      message: 'redirect_uri 不在 client whitelist（exact match required）',
+      redirectableToClient: false,
+    };
+  }
+
+  // 3. response_type
+  if (req.response_type !== 'code') {
+    return {
+      code: 'unsupported_response_type',
+      message: 'Only response_type=code supported (V2-P4)',
+      redirectableToClient: true,
+    };
+  }
+
+  // 4. scope subset of allowed_scopes
+  const allowedScopes = safeParseArray(client.allowed_scopes);
+  const requestedScopes = (req.scope ?? '').split(/\s+/).filter(Boolean);
+  if (requestedScopes.length === 0) {
+    return {
+      code: 'invalid_scope',
+      message: 'scope must contain at least one value',
+      redirectableToClient: true,
+    };
+  }
+  const invalidScopes = requestedScopes.filter((s) => !allowedScopes.includes(s));
+  if (invalidScopes.length > 0) {
+    return {
+      code: 'invalid_scope',
+      message: `Scopes not allowed for this client: ${invalidScopes.join(', ')}`,
+      redirectableToClient: true,
+    };
+  }
+
+  // 5. PKCE for public clients
+  if (client.client_type === 'public') {
+    if (!req.code_challenge) {
+      return {
+        code: 'invalid_request',
+        message: 'PKCE code_challenge required for public clients',
+        redirectableToClient: true,
+      };
+    }
+    if (req.code_challenge_method !== 'S256') {
+      return {
+        code: 'invalid_request',
+        message: 'PKCE code_challenge_method must be S256 (plain not supported)',
+        redirectableToClient: true,
+      };
+    }
+  } else {
+    // confidential client：PKCE optional V2-P4，V2-P6 may enforce always
+    if (req.code_challenge && req.code_challenge_method !== 'S256') {
+      return {
+        code: 'invalid_request',
+        message: 'PKCE code_challenge_method must be S256 if provided',
+        redirectableToClient: true,
+      };
+    }
+  }
+
+  // 6. prompt validation (optional)
+  const validPrompts = ['none', 'login', 'consent', 'select_account'];
+  if (req.prompt && !validPrompts.includes(req.prompt)) {
+    return {
+      code: 'invalid_request',
+      message: `prompt must be one of: ${validPrompts.join(', ')}`,
+      redirectableToClient: true,
+    };
+  }
+
+  return {
+    client,
+    redirectUri: req.redirect_uri,
+    scopes: requestedScopes,
+    state: req.state ?? null,
+    codeChallenge: req.code_challenge ?? null,
+    codeChallengeMethod: req.code_challenge ? 'S256' : null,
+    prompt: req.prompt ?? null,
+  };
+}

--- a/tests/unit/oauth-server-validate-authorize.test.ts
+++ b/tests/unit/oauth-server-validate-authorize.test.ts
@@ -1,0 +1,212 @@
+/**
+ * validateAuthorizeRequest unit test — V2-P4
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateAuthorizeRequest,
+  type ClientAppRow,
+  type AuthorizeRequest,
+  type ValidationError,
+  type ValidatedRequest,
+} from '../../src/server/oauth-server/validate-authorize-request';
+
+const ACTIVE_CONFIDENTIAL: ClientAppRow = {
+  client_id: 'partner-x',
+  client_type: 'confidential',
+  app_name: 'Partner X',
+  redirect_uris: JSON.stringify(['https://partner-x.com/cb', 'https://partner-x.com/cb2']),
+  allowed_scopes: JSON.stringify(['openid', 'profile', 'email', 'trips:read']),
+  status: 'active',
+};
+
+const ACTIVE_PUBLIC: ClientAppRow = {
+  ...ACTIVE_CONFIDENTIAL,
+  client_id: 'mobile-app',
+  client_type: 'public',
+};
+
+const SUSPENDED: ClientAppRow = { ...ACTIVE_CONFIDENTIAL, status: 'suspended' };
+const PENDING: ClientAppRow = { ...ACTIVE_CONFIDENTIAL, status: 'pending_review' };
+
+const VALID_REQUEST: AuthorizeRequest = {
+  response_type: 'code',
+  client_id: 'partner-x',
+  redirect_uri: 'https://partner-x.com/cb',
+  scope: 'openid profile email',
+  state: 'csrf-token-123',
+};
+
+function isErr(v: ValidatedRequest | ValidationError): v is ValidationError {
+  return 'code' in v && 'message' in v;
+}
+
+describe('validateAuthorizeRequest — client_id checks', () => {
+  it('Missing client_id → invalid_request (not redirectable)', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, client_id: undefined }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) {
+      expect(r.code).toBe('invalid_request');
+      expect(r.redirectableToClient).toBe(false);
+    }
+  });
+
+  it('Client not in DB (null) → unauthorized_client (not redirectable)', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, null);
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) {
+      expect(r.code).toBe('unauthorized_client');
+      expect(r.redirectableToClient).toBe(false);
+    }
+  });
+
+  it('Client suspended → unauthorized_client', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, SUSPENDED);
+    expect(isErr(r) && r.code).toBe('unauthorized_client');
+  });
+
+  it('Client pending_review → unauthorized_client', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, PENDING);
+    expect(isErr(r) && r.code).toBe('unauthorized_client');
+  });
+});
+
+describe('validateAuthorizeRequest — redirect_uri checks', () => {
+  it('Missing redirect_uri → invalid_request (not redirectable)', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, redirect_uri: undefined }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_request');
+    expect(isErr(r) && r.redirectableToClient).toBe(false);
+  });
+
+  it('redirect_uri not in whitelist → invalid_request (not redirectable — security critical)', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, redirect_uri: 'https://evil.com/cb' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_request');
+    expect(isErr(r) && r.redirectableToClient).toBe(false);
+  });
+
+  it('redirect_uri exact match (multiple whitelist entries supported)', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, redirect_uri: 'https://partner-x.com/cb2' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('redirect_uri trailing slash mismatch → reject (no tolerance)', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, redirect_uri: 'https://partner-x.com/cb/' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_request');
+  });
+});
+
+describe('validateAuthorizeRequest — response_type', () => {
+  it('response_type=code → ok (only supported)', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('response_type=token (implicit) → unsupported_response_type', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, response_type: 'token' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('unsupported_response_type');
+    expect(isErr(r) && r.redirectableToClient).toBe(true);
+  });
+
+  it('Missing response_type → unsupported_response_type', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, response_type: undefined }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('unsupported_response_type');
+  });
+});
+
+describe('validateAuthorizeRequest — scope', () => {
+  it('Empty scope → invalid_scope', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, scope: '' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_scope');
+  });
+
+  it('Subset of allowed_scopes → ok', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, scope: 'openid' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('Exact match all allowed_scopes → ok', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, scope: 'openid profile email trips:read' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('Scope not in allowed → invalid_scope', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, scope: 'openid admin' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_scope');
+  });
+});
+
+describe('validateAuthorizeRequest — PKCE', () => {
+  it('Public client without code_challenge → invalid_request (PKCE required)', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, ACTIVE_PUBLIC);
+    expect(isErr(r) && r.code).toBe('invalid_request');
+    if (isErr(r)) expect(r.message).toContain('PKCE');
+  });
+
+  it('Public client with code_challenge + S256 → ok', () => {
+    const r = validateAuthorizeRequest(
+      { ...VALID_REQUEST, code_challenge: 'abc123', code_challenge_method: 'S256' },
+      ACTIVE_PUBLIC,
+    );
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('Public client with code_challenge_method=plain → invalid_request', () => {
+    const r = validateAuthorizeRequest(
+      { ...VALID_REQUEST, code_challenge: 'abc', code_challenge_method: 'plain' },
+      ACTIVE_PUBLIC,
+    );
+    expect(isErr(r) && r.code).toBe('invalid_request');
+  });
+
+  it('Confidential client without PKCE → ok (V2-P4 optional)', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+  });
+
+  it('Confidential client with PKCE plain → invalid_request (S256 only when provided)', () => {
+    const r = validateAuthorizeRequest(
+      { ...VALID_REQUEST, code_challenge: 'abc', code_challenge_method: 'plain' },
+      ACTIVE_CONFIDENTIAL,
+    );
+    expect(isErr(r) && r.code).toBe('invalid_request');
+  });
+});
+
+describe('validateAuthorizeRequest — prompt', () => {
+  it('Valid prompts: none / login / consent / select_account', () => {
+    for (const prompt of ['none', 'login', 'consent', 'select_account']) {
+      const r = validateAuthorizeRequest({ ...VALID_REQUEST, prompt }, ACTIVE_CONFIDENTIAL);
+      expect(isErr(r), `prompt=${prompt} should be ok`).toBe(false);
+    }
+  });
+
+  it('Invalid prompt → invalid_request', () => {
+    const r = validateAuthorizeRequest({ ...VALID_REQUEST, prompt: 'unknown' }, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r) && r.code).toBe('invalid_request');
+  });
+});
+
+describe('validateAuthorizeRequest — successful return shape', () => {
+  it('Returns parsed scopes + state + redirectUri', () => {
+    const r = validateAuthorizeRequest(VALID_REQUEST, ACTIVE_CONFIDENTIAL);
+    expect(isErr(r)).toBe(false);
+    if (!isErr(r)) {
+      expect(r.client).toBe(ACTIVE_CONFIDENTIAL);
+      expect(r.redirectUri).toBe('https://partner-x.com/cb');
+      expect(r.scopes).toEqual(['openid', 'profile', 'email']);
+      expect(r.state).toBe('csrf-token-123');
+      expect(r.codeChallenge).toBeNull();
+      expect(r.codeChallengeMethod).toBeNull();
+    }
+  });
+
+  it('codeChallenge populated when provided', () => {
+    const r = validateAuthorizeRequest(
+      { ...VALID_REQUEST, code_challenge: 'pkce-challenge', code_challenge_method: 'S256' },
+      ACTIVE_PUBLIC,
+    );
+    if (!isErr(r)) {
+      expect(r.codeChallenge).toBe('pkce-challenge');
+      expect(r.codeChallengeMethod).toBe('S256');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 2nd slice — pure validator module for incoming OAuth Server \`/authorize\` requests。Caller (\`functions/api/oauth/server-authorize.ts\`, next slice) 用此驗 client_id / redirect_uri / response_type / scope / PKCE。

## Validation rules (per RFC 6749 §4.1.1 + RFC 7636 PKCE)

| Check | Result on fail |
|-------|---------------|
| client_id present + active in client_apps | unauthorized_client (not redirectable) |
| redirect_uri EXACT match whitelist | invalid_request (not redirectable — security critical) |
| response_type=code only | unsupported_response_type (redirectable) |
| scope subset of allowed_scopes | invalid_scope (redirectable) |
| PKCE required for public clients (S256 only) | invalid_request (redirectable) |
| PKCE optional for confidential V2-P4 | (V2-P6 may enforce) |
| prompt ∈ { none, login, consent, select_account } | invalid_request (redirectable) |

## redirectableToClient flag (security)

Per [RFC 6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)：invalid client_id / redirect_uri 不該 redirect 回 client（防 attacker 用 invalid client trick server send error to attacker URL）。其他 errors 可 redirect with \`error=...&state=...\` 給 client 處理。

## Test

\`tests/unit/oauth-server-validate-authorize.test.ts\` **24 cases TDD pass**:
- client_id (4 cases): missing / unknown / suspended / pending_review
- redirect_uri (4 cases): missing / not in whitelist / trailing slash / multi-entry
- response_type (3): code ok / token unsupported / missing
- scope (4): empty / subset / exact match / not allowed
- PKCE (5): public requires / S256 / confidential optional / plain rejected
- prompt (2): valid options / unknown
- successful shape (2): scopes / codeChallenge populated

## V2-P4 progress (2/N)

| # | Slice |
|---|-------|
| #278 | client_apps schema |
| **本 PR** | **authorize request validator** |

Next: \`functions/api/oauth/server-authorize.ts\` endpoint integration + authorization_code generation + D1 store + redirect to client。

🤖 Generated with [Claude Code](https://claude.com/claude-code)