### PR TITLE
feat(v2-p4): /api/oauth/server-authorize — OAuth Server endpoint integration

### DIFF
--- a/functions/api/oauth/server-authorize.ts
+++ b/functions/api/oauth/server-authorize.ts
@@ -1,0 +1,136 @@
+/**
+ * GET /api/oauth/server-authorize
+ *
+ * V2-P4 — OAuth Server `/authorize` endpoint。Tripline as Authorization Server
+ * 接收 external client 的 authorize request，驗 + 生成 authorization_code +
+ * redirect 回 client redirect_uri (with code + state)。
+ *
+ * 跟 OAuth Client `/api/oauth/authorize` 不同（後者是 redirect to Google）。
+ *
+ * Flow:
+ *   1. Parse query params (client_id / redirect_uri / response_type / scope /
+ *      state / code_challenge / code_challenge_method / prompt)
+ *   2. Lookup client_apps row by client_id
+ *   3. validateAuthorizeRequest（pure validator from V2-P4 #280）
+ *   4. If invalid:
+ *      - redirectableToClient=false → 400 JSON
+ *      - redirectableToClient=true → 302 redirect_uri?error=...&state=...
+ *   5. Check user logged in (session cookie):
+ *      - Not logged in → 302 /login?redirect_after=<this URL>
+ *   6. (V2-P5 will add: consent screen render)
+ *      - For V2-P4 starter: skip consent, auto-approve
+ *   7. Generate authorization_code (32 bytes random) + store D1 oauth_models
+ *      name='AuthorizationCode' { client_id, user_id, redirect_uri, scopes,
+ *      code_challenge, code_challenge_method, used: false } + 10min TTL
+ *   8. 302 redirect_uri?code=<code>&state=<state>
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import {
+  validateAuthorizeRequest,
+  type ClientAppRow,
+} from '../../../src/server/oauth-server/validate-authorize-request';
+import { getSessionUser } from '../_session';
+import type { Env } from '../_types';
+
+const CODE_TTL_SEC = 10 * 60; // RFC 6749 §4.1.2 recommends short
+
+function generateAuthCode(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let str = '';
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jsonError(code: string, message: string, status: number): Response {
+  return new Response(
+    JSON.stringify({ error: code, error_description: message }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function redirectError(
+  redirectUri: string,
+  errorCode: string,
+  errorDescription: string,
+  state: string | null,
+): Response {
+  const params = new URLSearchParams({ error: errorCode, error_description: errorDescription });
+  if (state) params.set('state', state);
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${redirectUri}?${params.toString()}` },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const params = url.searchParams;
+
+  const req = {
+    response_type: params.get('response_type') ?? undefined,
+    client_id: params.get('client_id') ?? undefined,
+    redirect_uri: params.get('redirect_uri') ?? undefined,
+    scope: params.get('scope') ?? undefined,
+    state: params.get('state') ?? undefined,
+    code_challenge: params.get('code_challenge') ?? undefined,
+    code_challenge_method: params.get('code_challenge_method') ?? undefined,
+    prompt: params.get('prompt') ?? undefined,
+  };
+
+  // Lookup client_apps row (if client_id provided)
+  let client: ClientAppRow | null = null;
+  if (req.client_id) {
+    client = await context.env.DB
+      .prepare(
+        `SELECT client_id, client_type, app_name, redirect_uris, allowed_scopes, status
+         FROM client_apps WHERE client_id = ?`,
+      )
+      .bind(req.client_id)
+      .first<ClientAppRow>();
+  }
+
+  // Validate
+  const result = validateAuthorizeRequest(req, client);
+  if ('code' in result && 'redirectableToClient' in result) {
+    if (result.redirectableToClient && req.redirect_uri) {
+      return redirectError(req.redirect_uri, result.code, result.message, req.state ?? null);
+    }
+    return jsonError(result.code, result.message, 400);
+  }
+
+  // Check user logged in
+  const session = await getSessionUser(context.request, context.env);
+  if (!session) {
+    // Preserve full request URL — login redirects back here on success
+    const loginUrl = `/login?redirect_after=${encodeURIComponent(url.pathname + url.search)}`;
+    return new Response(null, { status: 302, headers: { Location: loginUrl } });
+  }
+
+  // V2-P5 will add consent screen here. V2-P4 starter: auto-approve + redirect.
+
+  // Generate authorization_code + store D1
+  const code = generateAuthCode();
+  const adapter = new D1Adapter(context.env.DB, 'AuthorizationCode');
+  await adapter.upsert(
+    code,
+    {
+      client_id: result.client.client_id,
+      user_id: session.uid,
+      redirect_uri: result.redirectUri,
+      scopes: result.scopes,
+      code_challenge: result.codeChallenge,
+      code_challenge_method: result.codeChallengeMethod,
+      used: false,
+    },
+    CODE_TTL_SEC,
+  );
+
+  // Redirect back to client with code + state
+  const redirectParams = new URLSearchParams({ code });
+  if (result.state) redirectParams.set('state', result.state);
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${result.redirectUri}?${redirectParams.toString()}` },
+  });
+};

--- a/tests/api/oauth-server-authorize.test.ts
+++ b/tests/api/oauth-server-authorize.test.ts
@@ -1,0 +1,187 @@
+/**
+ * GET /api/oauth/server-authorize unit test — V2-P4
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/server-authorize';
+import { signSessionToken } from '../../src/server/session';
+
+const SECRET = 'session-secret-test';
+
+const ACTIVE_CLIENT = {
+  client_id: 'partner-x',
+  client_type: 'confidential',
+  app_name: 'Partner X',
+  redirect_uris: JSON.stringify(['https://partner.com/cb']),
+  allowed_scopes: JSON.stringify(['openid', 'profile', 'email']),
+  status: 'active',
+};
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  return stmt;
+}
+
+function makeContext(url: string, env: MockEnv, cookie?: string): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(url, cookie ? { headers: { Cookie: cookie } } : {}),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+const buildUrl = (params: Record<string, string>) => {
+  const sp = new URLSearchParams(params);
+  return `https://x.com/api/oauth/server-authorize?${sp.toString()}`;
+};
+
+describe('GET /api/oauth/server-authorize', () => {
+  it('400 when client_id missing (not redirectable)', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestGet(makeContext(buildUrl({ response_type: 'code' }), env));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when client_id unknown (not redirectable)', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(makeStmt(null)) } };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'unknown',
+      redirect_uri: 'https://partner.com/cb',
+      response_type: 'code',
+      scope: 'openid',
+    }), env));
+    expect(res.status).toBe(400);
+  });
+
+  it('302 to client redirect_uri with error when scope invalid', async () => {
+    const env: MockEnv = {
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt(ACTIVE_CLIENT)) },
+    };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'partner-x',
+      redirect_uri: 'https://partner.com/cb',
+      response_type: 'code',
+      scope: 'admin', // not in allowed
+      state: 'csrf-1',
+    }), env));
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toContain('https://partner.com/cb?');
+    expect(loc).toContain('error=invalid_scope');
+    expect(loc).toContain('state=csrf-1');
+  });
+
+  it('302 to /login when valid request but no session', async () => {
+    const env: MockEnv = {
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt(ACTIVE_CLIENT)) },
+    };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'partner-x',
+      redirect_uri: 'https://partner.com/cb',
+      response_type: 'code',
+      scope: 'openid',
+      state: 's',
+    }), env));
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toMatch(/^\/login\?redirect_after=/);
+    expect(decodeURIComponent(loc)).toContain('/api/oauth/server-authorize?');
+  });
+
+  it('happy path: logged in + valid → 302 redirect_uri?code=&state=', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(ACTIVE_CLIENT);
+      if (sql.includes('INSERT OR REPLACE INTO oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const token = await signSessionToken('user-1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: dbPrepare },
+    };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'partner-x',
+      redirect_uri: 'https://partner.com/cb',
+      response_type: 'code',
+      scope: 'openid profile',
+      state: 'csrf-xyz',
+    }), env, `tripline_session=${token}`));
+
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toMatch(/^https:\/\/partner\.com\/cb\?code=[A-Za-z0-9_-]+&state=csrf-xyz$/);
+
+    // Verify INSERT AuthorizationCode in D1
+    const insertCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertCall).toBeTruthy();
+  });
+
+  it('PKCE public client: code_challenge stored', async () => {
+    const PUBLIC_CLIENT = { ...ACTIVE_CLIENT, client_id: 'mobile', client_type: 'public' };
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      return makeStmt();
+    });
+    const token = await signSessionToken('user-1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: dbPrepare },
+    };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'mobile',
+      redirect_uri: 'https://partner.com/cb',
+      response_type: 'code',
+      scope: 'openid',
+      code_challenge: 'pkce-challenge-abc',
+      code_challenge_method: 'S256',
+      state: 's',
+    }), env, `tripline_session=${token}`));
+
+    expect(res.status).toBe(302);
+
+    // Inspect INSERT payload — should contain code_challenge
+    const insertStmt = dbPrepare.mock.results.find(
+      (r, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
+                (dbPrepare.mock.calls[i][0] as string).includes('INSERT OR REPLACE'),
+    )?.value;
+    if (insertStmt) {
+      const bindArgs = (insertStmt as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
+      const payload = JSON.parse(bindArgs[2] as string);
+      expect(payload.code_challenge).toBe('pkce-challenge-abc');
+      expect(payload.code_challenge_method).toBe('S256');
+    }
+  });
+
+  it('Rejects redirect_uri not in whitelist (not redirectable)', async () => {
+    const env: MockEnv = {
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt(ACTIVE_CLIENT)) },
+    };
+    const res = await onRequestGet(makeContext(buildUrl({
+      client_id: 'partner-x',
+      redirect_uri: 'https://evil.com/cb',
+      response_type: 'code',
+      scope: 'openid',
+    }), env));
+    expect(res.status).toBe(400);
+    // Not 302 — security critical, attacker shouldn't get redirect to their own URL
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 3rd slice — OAuth Server \`/authorize\` endpoint integration。Tripline accepts authorize request from external client → validate → generate authorization_code → redirect back with code + state。

## API

```
GET /api/oauth/server-authorize
  ?client_id=partner-x
  &redirect_uri=https://partner.com/cb
  &response_type=code
  &scope=openid+profile+email
  &state=csrf-token
  &code_challenge=...     # required for public clients
  &code_challenge_method=S256

→ 302 https://partner.com/cb?code=<auth-code>&state=csrf-token   (success)
→ 302 /login?redirect_after=...                                   (no session)
→ 302 https://partner.com/cb?error=invalid_scope&state=...        (recoverable)
→ 400 JSON                                                        (security-critical errors)
```

## Flow

1. Parse query params (RFC 6749 §4.1.1)
2. Lookup \`client_apps\` WHERE client_id
3. \`validateAuthorizeRequest\` (V2-P4 #280 module)
4. Invalid + \`redirectableToClient=true\` → 302 redirect with error
5. Invalid + \`redirectableToClient=false\` → 400 JSON (security: 不 redirect 給 attacker URL)
6. No session → 302 \`/login?redirect_after=<this-url>\`
7. (V2-P5 will add: consent screen render)
8. Generate authorization_code (32 bytes random base64url)
9. D1Adapter store \`oauth_models\` name='AuthorizationCode' with PKCE challenge + 10min TTL
10. 302 redirect_uri?code=&state=

## Security highlights

- **Open redirect protection**：invalid client_id/redirect_uri → 400 JSON 不 302（防 attacker fish error params with own redirect_uri）
- **Code TTL 10min**：RFC 6749 §4.1.2 recommends short
- **PKCE challenge stored**：V2-P4 next slice token endpoint 會 verify code_verifier matches

## Test

\`tests/api/oauth-server-authorize.test.ts\` **7 cases TDD pass**:
- Missing/unknown client_id → 400
- Invalid scope → 302 with error
- No session → /login redirect with preserved params
- Happy path → 302 with code + state + INSERT AuthorizationCode
- PKCE public: code_challenge stored
- Bad redirect_uri → 400 (security critical)

## V2-P4 progress (3/N)

| # | Slice |
|---|-------|
| #278 | client_apps schema |
| #280 | authorize request validator |
| **本 PR** | **server-authorize endpoint** |

## Next

- \`/api/oauth/server-token\`: code exchange + PKCE verify + issue access_token + refresh_token + id_token
- ConsentPage UI (V2-P5)
- Developer dashboard: register client app

🤖 Generated with [Claude Code](https://claude.com/claude-code)