### PR TITLE
feat(v2-p4): server-token grant_type=refresh_token + token rotation

### DIFF
--- a/functions/api/oauth/server-token.ts
+++ b/functions/api/oauth/server-token.ts
@@ -37,6 +37,13 @@ interface AuthorizationCodePayload extends AdapterPayload {
   used: boolean;
 }
 
+interface RefreshTokenPayload extends AdapterPayload {
+  client_id: string;
+  user_id: string;
+  scopes: string[];
+  grantId: string;
+}
+
 interface ClientAppRow {
   client_id: string;
   client_type: 'public' | 'confidential';
@@ -97,15 +104,62 @@ function parseBasicAuth(request: Request): { id: string; secret: string } | null
   }
 }
 
+/** Issue access+refresh tokens 共用 helper — shared by 2 grant types. */
+async function issueTokenPair(
+  db: Env['DB'],
+  clientId: string,
+  userId: string,
+  scopes: string[],
+): Promise<{ access_token: string; refresh_token: string; grantId: string }> {
+  const grantId = crypto.randomUUID();
+  const accessToken = generateOpaqueToken();
+  const refreshToken = generateOpaqueToken();
+
+  const accessAdapter = new D1Adapter(db, 'AccessToken');
+  await accessAdapter.upsert(
+    accessToken,
+    { client_id: clientId, user_id: userId, scopes, grantId },
+    ACCESS_TOKEN_TTL_SEC,
+  );
+
+  const refreshAdapter = new D1Adapter(db, 'RefreshToken');
+  await refreshAdapter.upsert(
+    refreshToken,
+    { client_id: clientId, user_id: userId, scopes, grantId },
+    REFRESH_TOKEN_TTL_SEC,
+  );
+
+  return { access_token: accessToken, refresh_token: refreshToken, grantId };
+}
+
+function tokenResponse(tokens: { access_token: string; refresh_token: string }, scopes: string[]): Response {
+  return new Response(
+    JSON.stringify({
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      token_type: 'Bearer',
+      expires_in: ACCESS_TOKEN_TTL_SEC,
+      scope: scopes.join(' '),
+    }),
+    {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+        'pragma': 'no-cache',
+      },
+    },
+  );
+}
+
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const body = await parseBody(context.request);
   const grant_type = body.grant_type;
 
-  if (grant_type !== 'authorization_code') {
-    return jsonError('unsupported_grant_type', 'Only authorization_code grant supported (V2-P4)');
+  if (grant_type !== 'authorization_code' && grant_type !== 'refresh_token') {
+    return jsonError('unsupported_grant_type', 'Supported: authorization_code, refresh_token');
   }
 
-  // Client auth: HTTP Basic OR body fields
+  // Client auth: HTTP Basic OR body fields (shared by both grant types)
   const basic = parseBasicAuth(context.request);
   const clientId = basic?.id ?? body.client_id;
   const clientSecret = basic?.secret ?? body.client_secret;
@@ -126,7 +180,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     return jsonError('invalid_client', 'Unknown or inactive client_id', 401);
   }
 
-  // Confidential client: verify client_secret
+  // Confidential client: verify client_secret (both grant types)
   if (client.client_type === 'confidential') {
     if (!clientSecret || !client.client_secret_hash) {
       return jsonError('invalid_client', 'client_secret required for confidential client', 401);
@@ -135,7 +189,41 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     if (!ok) return jsonError('invalid_client', 'Invalid client_secret', 401);
   }
 
-  // Lookup authorization_code
+  // Branch on grant_type
+  if (grant_type === 'refresh_token') {
+    const refreshTokenInput = body.refresh_token;
+    if (!refreshTokenInput) {
+      return jsonError('invalid_request', 'Missing refresh_token');
+    }
+
+    const refreshAdapter = new D1Adapter(context.env.DB, 'RefreshToken');
+    const refreshRow = (await refreshAdapter.find(refreshTokenInput)) as RefreshTokenPayload | undefined;
+
+    if (!refreshRow) {
+      return jsonError('invalid_grant', 'refresh_token expired or invalid');
+    }
+    if (refreshRow.client_id !== clientId) {
+      return jsonError('invalid_grant', 'refresh_token does not belong to this client');
+    }
+
+    // Optional scope downgrade: caller can request narrower scope
+    const requestedScopes = (body.scope ?? '').split(/\s+/).filter(Boolean);
+    let finalScopes = refreshRow.scopes;
+    if (requestedScopes.length > 0) {
+      const invalid = requestedScopes.filter((s) => !refreshRow.scopes.includes(s));
+      if (invalid.length > 0) {
+        return jsonError('invalid_scope', `Cannot widen scope: ${invalid.join(', ')}`);
+      }
+      finalScopes = requestedScopes;
+    }
+
+    // Rotation: destroy old refresh + issue new pair (V2-P6 spec)
+    await refreshAdapter.destroy(refreshTokenInput);
+    const tokens = await issueTokenPair(context.env.DB, clientId, refreshRow.user_id, finalScopes);
+    return tokenResponse(tokens, finalScopes);
+  }
+
+  // grant_type === 'authorization_code'
   const code = body.code;
   if (!code) return jsonError('invalid_request', 'Missing code');
 
@@ -170,39 +258,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   // Mark code as used (one-time)
   await codeAdapter.consume(code);
 
-  // Issue access_token + refresh_token
-  const grantId = crypto.randomUUID();
-  const accessToken = generateOpaqueToken();
-  const refreshToken = generateOpaqueToken();
-
-  const accessAdapter = new D1Adapter(context.env.DB, 'AccessToken');
-  await accessAdapter.upsert(
-    accessToken,
-    { client_id: clientId, user_id: codeRow.user_id, scopes: codeRow.scopes, grantId },
-    ACCESS_TOKEN_TTL_SEC,
-  );
-
-  const refreshAdapter = new D1Adapter(context.env.DB, 'RefreshToken');
-  await refreshAdapter.upsert(
-    refreshToken,
-    { client_id: clientId, user_id: codeRow.user_id, scopes: codeRow.scopes, grantId },
-    REFRESH_TOKEN_TTL_SEC,
-  );
-
-  return new Response(
-    JSON.stringify({
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      token_type: 'Bearer',
-      expires_in: ACCESS_TOKEN_TTL_SEC,
-      scope: codeRow.scopes.join(' '),
-    }),
-    {
-      headers: {
-        'content-type': 'application/json',
-        'cache-control': 'no-store',
-        'pragma': 'no-cache',
-      },
-    },
-  );
+  // Issue tokens via shared helper
+  const tokens = await issueTokenPair(context.env.DB, clientId, codeRow.user_id, codeRow.scopes);
+  return tokenResponse(tokens, codeRow.scopes);
 };

--- a/tests/api/oauth-server-token.test.ts
+++ b/tests/api/oauth-server-token.test.ts
@@ -253,3 +253,151 @@ describe('POST /api/oauth/server-token', () => {
     expect((await r1.json() as { error: string }).error).toBe('invalid_client');
   }, 60_000);
 });
+
+describe('POST /api/oauth/server-token — refresh_token grant', () => {
+  it('happy path: rotate refresh + issue new access', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            client_id: 'mobile',
+            user_id: 'u1',
+            scopes: ['openid', 'profile'],
+            grantId: 'g1',
+          }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      refresh_token: 'old-refresh-token',
+    }, env));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as Record<string, unknown>;
+    expect(typeof json.access_token).toBe('string');
+    expect(typeof json.refresh_token).toBe('string');
+    expect(json.token_type).toBe('Bearer');
+    expect(json.scope).toBe('openid profile');
+
+    // Old refresh token destroyed (rotation)
+    const sqls = dbPrepare.mock.calls.map((c) => c[0] as string);
+    expect(sqls.some((s) => s.includes('DELETE FROM oauth_models'))).toBe(true);
+  });
+
+  it('400 invalid_grant when refresh_token unknown / expired', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      if (sql.includes('SELECT payload')) return makeStmt(null);
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      refresh_token: 'expired',
+    }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toBe('invalid_grant');
+  });
+
+  it('400 invalid_grant when refresh_token belongs to other client (anti-token theft)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      if (sql.includes('SELECT payload')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            client_id: 'other-client',
+            user_id: 'u1',
+            scopes: ['openid'],
+            grantId: 'g1',
+          }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      refresh_token: 'someone-elses-token',
+    }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error_description: string }).error_description).toContain('does not belong');
+  });
+
+  it('400 invalid_request when refresh_token missing', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      // missing refresh_token
+    }, env));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toBe('invalid_request');
+  });
+
+  it('Scope downgrade allowed (subset of stored), widening rejected', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      if (sql.includes('SELECT payload')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            client_id: 'mobile',
+            user_id: 'u1',
+            scopes: ['openid', 'profile', 'email'],
+            grantId: 'g1',
+          }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    // Downgrade ok
+    const r1 = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      refresh_token: 'tok',
+      scope: 'openid',
+    }, env));
+    expect(r1.status).toBe(200);
+    expect(((await r1.json()) as { scope: string }).scope).toBe('openid');
+
+    // Widening rejected
+    const dbPrepare2 = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM client_apps')) return makeStmt(PUBLIC_CLIENT);
+      if (sql.includes('SELECT payload')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            client_id: 'mobile',
+            user_id: 'u1',
+            scopes: ['openid'],
+            grantId: 'g1',
+          }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env2: MockEnv = { DB: { prepare: dbPrepare2 } };
+    const r2 = await onRequestPost(makeContext({
+      grant_type: 'refresh_token',
+      client_id: 'mobile',
+      refresh_token: 'tok',
+      scope: 'openid admin',
+    }, env2));
+    expect(r2.status).toBe(400);
+    expect(((await r2.json()) as { error: string }).error).toBe('invalid_scope');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 5th slice — extend \`server-token\` endpoint to handle \`grant_type=refresh_token\` with rotation per V2-P6 spec。

## Changes

- 抽 \`issueTokenPair()\` shared helper (DRY between authorization_code + refresh_token)
- 抽 \`tokenResponse()\` shared response builder
- Refactor onRequestPost to branch on grant_type
- New \`refresh_token\` flow with rotation

## Refresh flow

```
POST /api/oauth/server-token
Body:
  grant_type=refresh_token
  client_id=<id>
  refresh_token=<old>
  scope=<optional, narrower than original>

→ 1. Verify client (HTTP Basic OR body, secret if confidential)
→ 2. Lookup old refresh_token in D1
→ 3. Verify refresh.client_id === clientId (anti-theft)
→ 4. Optional scope downgrade (subset of stored only)
→ 5. DELETE old refresh (rotation)
→ 6. Issue new access + new refresh
→ 200 { access_token, refresh_token, ... }
```

## Why rotation

V2-P6 spec: refresh_token rotation 防 token theft replay。每次用 refresh_token 都換新 pair，舊 refresh 立即 invalidate。

## Scope downgrade

Caller 可請更窄 scope（防需要時降權），不能 widen（escalation attack）。

## Test

\`tests/api/oauth-server-token.test.ts\` 加 5 cases for refresh_token，總 15/15 TDD pass:
- Happy: rotate refresh + new access + DELETE old (rotation verified)
- invalid_grant: refresh unknown / expired
- invalid_grant: refresh belongs to other client (anti-theft)
- invalid_request: missing refresh_token
- Scope: downgrade allowed / widening rejected

## V2-P4 progress (5/N)

| # | Slice | Status |
|---|-------|--------|
| #278 | client_apps schema | ✓ |
| #280 | authorize validator | ✓ |
| #281 | server-authorize | ✓ |
| #282 | server-token (auth_code) | ✓ |
| **本 PR** | **server-token (refresh_token + rotation)** | ✓ |

OAuth Server core grant types complete。剩 ConsentPage UI + Developer dashboard。

🤖 Generated with [Claude Code](https://claude.com/claude-code)