### PR TITLE
feat(v2-p5): /api/oauth/server-consent — record consent + redirect back

### DIFF
--- a/functions/api/oauth/server-consent.ts
+++ b/functions/api/oauth/server-consent.ts
@@ -1,0 +1,141 @@
+/**
+ * POST /api/oauth/server-consent
+ *
+ * V2-P5 — Record user consent for client_id + scopes，then redirect back to
+ * /api/oauth/server-authorize（this time will skip consent check + issue code）。
+ *
+ * Body (form-urlencoded or JSON):
+ *   client_id
+ *   redirect_uri
+ *   scope (space-separated)
+ *   state
+ *   response_type
+ *   code_challenge?
+ *   code_challenge_method?
+ *   decision: 'allow' | 'deny'
+ *
+ * Auth required (session)。
+ *
+ * Behavior:
+ *   - decision='allow' + session: store Consent in D1 oauth_models + 302 to
+ *     /api/oauth/server-authorize?... (server-authorize 下次跑時 see consent + issue code)
+ *   - decision='deny' + redirect_uri: 302 to redirect_uri?error=access_denied&state=
+ *   - No session: 302 to /login?redirect_after=...
+ *
+ * V2-P5 next slice: server-authorize.ts integrate consent check (read D1 Consent
+ * before code gen + redirect to /oauth/consent if missing or scopes incomplete).
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import { getSessionUser } from '../_session';
+import type { Env } from '../_types';
+
+const CONSENT_TTL_SEC = 365 * 24 * 60 * 60; // 1 year — user manually revokes via 帳號設定
+
+interface ConsentBody {
+  client_id?: string;
+  redirect_uri?: string;
+  scope?: string;
+  state?: string;
+  response_type?: string;
+  code_challenge?: string;
+  code_challenge_method?: string;
+  decision?: string;
+}
+
+async function parseBody(request: Request): Promise<ConsentBody> {
+  const ct = request.headers.get('content-type') ?? '';
+  if (ct.includes('application/x-www-form-urlencoded')) {
+    const text = await request.text();
+    const params = new URLSearchParams(text);
+    const out: ConsentBody = {};
+    for (const [k, v] of params) (out as Record<string, string>)[k] = v;
+    return out;
+  }
+  if (ct.includes('application/json')) {
+    return (await request.json()) as ConsentBody;
+  }
+  return {};
+}
+
+function safeRedirect(redirectUri: string | undefined, errorCode: string, state?: string): Response {
+  if (!redirectUri || !redirectUri.startsWith('https://') && !redirectUri.startsWith('http://')) {
+    return new Response(
+      JSON.stringify({ error: errorCode }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  const params = new URLSearchParams({ error: errorCode });
+  if (state) params.set('state', state);
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${redirectUri}?${params.toString()}` },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const session = await getSessionUser(context.request, context.env);
+  const body = await parseBody(context.request);
+
+  if (!session) {
+    // 302 to login，preserve full original authorize URL via redirect_after
+    const params = new URLSearchParams();
+    if (body.client_id) params.set('client_id', body.client_id);
+    if (body.redirect_uri) params.set('redirect_uri', body.redirect_uri);
+    if (body.response_type) params.set('response_type', body.response_type);
+    if (body.scope) params.set('scope', body.scope);
+    if (body.state) params.set('state', body.state);
+    if (body.code_challenge) params.set('code_challenge', body.code_challenge);
+    if (body.code_challenge_method) params.set('code_challenge_method', body.code_challenge_method);
+    const consentUrl = `/oauth/consent?${params.toString()}`;
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `/login?redirect_after=${encodeURIComponent(consentUrl)}` },
+    });
+  }
+
+  if (body.decision === 'deny') {
+    return safeRedirect(body.redirect_uri, 'access_denied', body.state);
+  }
+
+  if (body.decision !== 'allow') {
+    return new Response(
+      JSON.stringify({ error: 'invalid_request', error_description: 'decision must be allow or deny' }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // decision='allow'
+  if (!body.client_id) {
+    return new Response(
+      JSON.stringify({ error: 'invalid_request', error_description: 'Missing client_id' }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  const scopes = (body.scope ?? '').split(/\s+/).filter(Boolean);
+
+  // Store consent (idempotent upsert)
+  const consentKey = `${session.uid}:${body.client_id}`;
+  const adapter = new D1Adapter(context.env.DB, 'Consent');
+  await adapter.upsert(
+    consentKey,
+    { user_id: session.uid, client_id: body.client_id, scopes, grantedAt: Date.now() },
+    CONSENT_TTL_SEC,
+  );
+
+  // Redirect back to server-authorize with original params — this time will
+  // pick up consent and proceed to code gen
+  const params = new URLSearchParams();
+  if (body.client_id) params.set('client_id', body.client_id);
+  if (body.redirect_uri) params.set('redirect_uri', body.redirect_uri);
+  if (body.response_type) params.set('response_type', body.response_type);
+  if (body.scope) params.set('scope', body.scope);
+  if (body.state) params.set('state', body.state);
+  if (body.code_challenge) params.set('code_challenge', body.code_challenge);
+  if (body.code_challenge_method) params.set('code_challenge_method', body.code_challenge_method);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `/api/oauth/server-authorize?${params.toString()}` },
+  });
+};

--- a/tests/api/oauth-server-consent.test.ts
+++ b/tests/api/oauth-server-consent.test.ts
@@ -1,0 +1,173 @@
+/**
+ * POST /api/oauth/server-consent unit test — V2-P5
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestPost } from '../../functions/api/oauth/server-consent';
+import { signSessionToken } from '../../src/server/session';
+
+const SECRET = 'session-secret-test';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt() {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(null),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  return stmt;
+}
+
+function makeContext(body: Record<string, string>, env: MockEnv, cookie?: string): Parameters<typeof onRequestPost>[0] {
+  return {
+    request: new Request('https://x.com/api/oauth/server-consent', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+      body: new URLSearchParams(body).toString(),
+    }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestPost>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('POST /api/oauth/server-consent', () => {
+  it('302 to /login when no session (preserve params via redirect_after)', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestPost(makeContext({
+      client_id: 'partner', redirect_uri: 'https://x.com/cb', scope: 'openid', state: 's',
+      response_type: 'code', decision: 'allow',
+    }, env));
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toMatch(/^\/login\?redirect_after=/);
+    expect(decodeURIComponent(loc)).toContain('/oauth/consent?');
+    expect(decodeURIComponent(loc)).toContain('client_id=partner');
+  });
+
+  it('decision=deny → 302 redirect_uri?error=access_denied&state=', async () => {
+    const token = await signSessionToken('u1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt()) },
+    };
+    const res = await onRequestPost(makeContext({
+      client_id: 'partner', redirect_uri: 'https://x.com/cb',
+      scope: 'openid', state: 'csrf-1', decision: 'deny',
+    }, env, `tripline_session=${token}`));
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toContain('https://x.com/cb');
+    expect(loc).toContain('error=access_denied');
+    expect(loc).toContain('state=csrf-1');
+  });
+
+  it('decision=allow → store Consent in D1 + 302 back to server-authorize', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const token = await signSessionToken('u1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: dbPrepare },
+    };
+    const res = await onRequestPost(makeContext({
+      client_id: 'partner',
+      redirect_uri: 'https://x.com/cb',
+      response_type: 'code',
+      scope: 'openid profile',
+      state: 'csrf-x',
+      decision: 'allow',
+    }, env, `tripline_session=${token}`));
+
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location') ?? '';
+    expect(loc).toContain('/api/oauth/server-authorize?');
+    expect(loc).toContain('client_id=partner');
+    expect(loc).toContain('state=csrf-x');
+
+    // INSERT Consent
+    const insertCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertCall).toBeTruthy();
+    const stmt = dbPrepare.mock.results.find(
+      (_, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
+                (dbPrepare.mock.calls[i][0] as string).includes('INSERT OR REPLACE'),
+    )?.value;
+    if (stmt) {
+      const bindArgs = (stmt as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
+      expect(bindArgs[0]).toBe('Consent');
+      expect(bindArgs[1]).toBe('u1:partner'); // key = uid:client_id
+      const payload = JSON.parse(bindArgs[2] as string);
+      expect(payload.user_id).toBe('u1');
+      expect(payload.client_id).toBe('partner');
+      expect(payload.scopes).toEqual(['openid', 'profile']);
+    }
+  });
+
+  it('400 invalid_request when decision missing or unknown', async () => {
+    const token = await signSessionToken('u1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt()) },
+    };
+    const r1 = await onRequestPost(makeContext({
+      client_id: 'p', redirect_uri: 'r', scope: 'openid',
+    }, env, `tripline_session=${token}`));
+    expect(r1.status).toBe(400);
+
+    const r2 = await onRequestPost(makeContext({
+      client_id: 'p', redirect_uri: 'r', scope: 'openid', decision: 'maybe',
+    }, env, `tripline_session=${token}`));
+    expect(r2.status).toBe(400);
+  });
+
+  it('400 when decision=allow but client_id missing', async () => {
+    const token = await signSessionToken('u1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: vi.fn().mockReturnValue(makeStmt()) },
+    };
+    const res = await onRequestPost(makeContext({
+      decision: 'allow', scope: 'openid',
+    }, env, `tripline_session=${token}`));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error_description: string }).error_description).toContain('client_id');
+  });
+
+  it('Consent TTL = 1 year', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const token = await signSessionToken('u1', SECRET);
+    const env: MockEnv = {
+      SESSION_SECRET: SECRET,
+      DB: { prepare: dbPrepare },
+    };
+    await onRequestPost(makeContext({
+      client_id: 'p', redirect_uri: 'r', scope: 'openid',
+      decision: 'allow', response_type: 'code', state: 's',
+    }, env, `tripline_session=${token}`));
+    const stmt = dbPrepare.mock.results.find(
+      (_, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
+                (dbPrepare.mock.calls[i][0] as string).includes('INSERT OR REPLACE'),
+    )?.value;
+    if (stmt) {
+      const bindArgs = (stmt as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
+      const expiresAt = bindArgs[3] as number;
+      // 1 year in ms
+      expect(expiresAt).toBe(Date.now() + 365 * 24 * 60 * 60 * 1000);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

V2-P5 2nd slice — consent endpoint that records user's allow/deny + redirects back to server-authorize（which next slice will check Consent before issuing code）。

## API

```
POST /api/oauth/server-consent
Body (form or JSON):
  client_id, redirect_uri, scope, state, response_type
  code_challenge?, code_challenge_method?
  decision: 'allow' | 'deny'

→ 302 /login?redirect_after=...     (no session)
→ 302 redirect_uri?error=access_denied&state=  (decision=deny)
→ 302 /api/oauth/server-authorize?...  (decision=allow + Consent recorded)
→ 400 invalid_request  (decision missing or invalid)
```

## D1 Consent storage

\`oauth_models\` name='Consent'，key=\`\${user_id}:\${client_id}\`，1-year TTL，idempotent upsert。User 之後可在「帳號設定 → 已連結應用」revoke (V2-P5 next slice)。

## Test

\`tests/api/oauth-server-consent.test.ts\` **6 cases TDD pass**:
- No session → 302 /login + preserve params
- deny → redirect_uri?error=access_denied
- allow → INSERT Consent + 302 server-authorize
- decision missing/unknown → 400
- allow without client_id → 400
- TTL = 1 year

## V2-P5 progress (2/N)

| # | Slice |
|---|-------|
| #284 | ConsentPage UI scaffold |
| **本 PR** | **server-consent endpoint** |

Next: server-authorize integrate Consent check / 帳號設定 已連結應用撤銷頁 / JWT id_token + RS256 signing。

🤖 Generated with [Claude Code](https://claude.com/claude-code)