### PR TITLE
feat(v2-p6): rate limit middleware (D1-backed sliding window + lockout)

### DIFF
--- a/functions/api/_rate_limit.ts
+++ b/functions/api/_rate_limit.ts
@@ -1,0 +1,153 @@
+/**
+ * Rate limit middleware — V2-P6 brute force defence
+ *
+ * 用 D1 rate_limit_buckets table（migration 0035）做 sliding window + lockout。
+ *
+ * Usage:
+ *   const result = await checkRateLimit(env, `login:${ip}`, {
+ *     maxAttempts: 5, windowMs: 15 * 60 * 1000, lockoutMs: 30 * 60 * 1000,
+ *   });
+ *   if (!result.ok) {
+ *     return new Response(null, {
+ *       status: 429,
+ *       headers: { 'Retry-After': String(result.retryAfter) },
+ *     });
+ *   }
+ *
+ * 失敗時 caller 自己 increment（成功 login 不該 count；失敗 login 才 count）。
+ * 用法 pattern:
+ *   1. checkRateLimit() before processing
+ *   2. 若 process 成功 → resetRateLimit() 清 counter
+ *   3. 若 process 失敗 → bumpRateLimit() count++
+ */
+import type { D1Database } from '@cloudflare/workers-types';
+
+interface RateLimitConfig {
+  maxAttempts: number;
+  windowMs: number;
+  lockoutMs: number;
+}
+
+interface RateLimitRow {
+  bucket_key: string;
+  count: number;
+  window_start: number;
+  locked_until: number | null;
+}
+
+export interface RateLimitResult {
+  /** True if not currently locked + count within limit */
+  ok: boolean;
+  /** Seconds until next attempt allowed (only when ok=false) */
+  retryAfter?: number;
+  /** Current count in window */
+  count?: number;
+}
+
+/**
+ * Check rate limit for given bucket key。**Doesn't increment** — caller decides
+ * when to bump (typically on failed attempt only)。
+ */
+export async function checkRateLimit(
+  db: D1Database,
+  key: string,
+  config: RateLimitConfig,
+): Promise<RateLimitResult> {
+  const now = Date.now();
+  const row = await db
+    .prepare('SELECT bucket_key, count, window_start, locked_until FROM rate_limit_buckets WHERE bucket_key = ?')
+    .bind(key)
+    .first<RateLimitRow>();
+
+  if (!row) return { ok: true, count: 0 };
+
+  // Locked?
+  if (row.locked_until && row.locked_until > now) {
+    return { ok: false, retryAfter: Math.ceil((row.locked_until - now) / 1000) };
+  }
+
+  // Window expired? (count 視為 0 — bump 時會 reset window)
+  if (row.window_start + config.windowMs < now) {
+    return { ok: true, count: 0 };
+  }
+
+  return { ok: true, count: row.count };
+}
+
+/**
+ * Increment rate limit count + maybe lock if exceeded。Call after a failed attempt。
+ */
+export async function bumpRateLimit(
+  db: D1Database,
+  key: string,
+  config: RateLimitConfig,
+): Promise<RateLimitResult> {
+  const now = Date.now();
+  const row = await db
+    .prepare('SELECT bucket_key, count, window_start, locked_until FROM rate_limit_buckets WHERE bucket_key = ?')
+    .bind(key)
+    .first<RateLimitRow>();
+
+  let newCount: number;
+  let windowStart: number;
+
+  if (!row || row.window_start + config.windowMs < now) {
+    // New row or window expired — reset
+    newCount = 1;
+    windowStart = now;
+  } else {
+    newCount = row.count + 1;
+    windowStart = row.window_start;
+  }
+
+  // Determine lock
+  let lockedUntil: number | null = null;
+  if (newCount > config.maxAttempts) {
+    lockedUntil = now + config.lockoutMs;
+  }
+
+  // Upsert
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO rate_limit_buckets (bucket_key, count, window_start, locked_until)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .bind(key, newCount, windowStart, lockedUntil)
+    .run();
+
+  if (lockedUntil) {
+    return { ok: false, retryAfter: Math.ceil((lockedUntil - now) / 1000), count: newCount };
+  }
+  return { ok: true, count: newCount };
+}
+
+/**
+ * Reset counter on successful attempt — prevent legitimate user being locked
+ * out from accumulated previous failures。
+ */
+export async function resetRateLimit(db: D1Database, key: string): Promise<void> {
+  await db
+    .prepare('DELETE FROM rate_limit_buckets WHERE bucket_key = ?')
+    .bind(key)
+    .run();
+}
+
+/**
+ * Extract client IP from CF-Connecting-IP header (Cloudflare adds this on edge)。
+ * Fallback to 'unknown' so all attempts in dev share a bucket。
+ */
+export function clientIp(request: Request): string {
+  return request.headers.get('CF-Connecting-IP') ?? 'unknown';
+}
+
+/** Common config presets */
+export const RATE_LIMITS = {
+  // Anti brute-force login: 5 attempts / 15min window, 30min lockout
+  LOGIN: { maxAttempts: 5, windowMs: 15 * 60 * 1000, lockoutMs: 30 * 60 * 1000 },
+  // Signup spam protection: 3 attempts / 1h window, 1h lockout
+  SIGNUP: { maxAttempts: 3, windowMs: 60 * 60 * 1000, lockoutMs: 60 * 60 * 1000 },
+  // Password reset abuse: 3 attempts / 1h window, 1h lockout
+  FORGOT_PASSWORD: { maxAttempts: 3, windowMs: 60 * 60 * 1000, lockoutMs: 60 * 60 * 1000 },
+  // OAuth token endpoint per-client: 100 attempts / minute, 5min lockout
+  OAUTH_TOKEN: { maxAttempts: 100, windowMs: 60 * 1000, lockoutMs: 5 * 60 * 1000 },
+} as const;

--- a/migrations/0035_rate_limit_buckets.sql
+++ b/migrations/0035_rate_limit_buckets.sql
@@ -1,0 +1,40 @@
+-- Migration 0035: rate_limit_buckets — V2-P6 brute force defence
+--
+-- Per-IP + per-key counters with sliding window + lockout。Caller (e.g.
+-- functions/api/oauth/login.ts) 透過 functions/api/_rate_limit.ts 的
+-- checkRateLimit() 操作。
+--
+-- ## Schema
+--
+-- bucket_key 範例:
+--   'login:1.2.3.4'                     — login attempts from IP
+--   'login:user@example.com'            — login attempts for email (anti-credential-stuffing)
+--   'signup:1.2.3.4'                    — signup spam
+--   'forgot-password:user@example.com'  — reset abuse
+--   'oauth-token:partner-x'             — token endpoint per-client
+--
+-- ## Algorithm
+--
+-- Sliding window with lockout:
+--   1. checkRateLimit(key, maxAttempts=5, windowMs=15min, lockoutMs=30min):
+--      - row exists 且 locked_until > now → 429 Retry-After: locked_until - now
+--      - row exists 且 window_start + windowMs < now → reset (window expired)
+--      - count++ atomically
+--      - 若 count > maxAttempts → set locked_until = now + lockoutMs, return locked
+--      - else: return ok
+--
+-- ## Cleanup
+--
+-- V2-P6 cron job 每小時跑 DELETE WHERE locked_until IS NULL AND
+-- window_start + 1h < now (清過期 unlocked rows 避無限長)。
+
+CREATE TABLE rate_limit_buckets (
+  bucket_key      TEXT PRIMARY KEY,                    -- e.g. 'login:1.2.3.4'
+  count           INTEGER NOT NULL DEFAULT 0,
+  window_start    INTEGER NOT NULL,                    -- unix ms
+  locked_until    INTEGER,                              -- unix ms, NULL = not locked
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_rate_limit_locked ON rate_limit_buckets(locked_until);
+CREATE INDEX idx_rate_limit_window ON rate_limit_buckets(window_start);

--- a/tests/api/rate-limit-module.test.ts
+++ b/tests/api/rate-limit-module.test.ts
@@ -1,0 +1,184 @@
+/**
+ * functions/api/_rate_limit.ts unit test — V2-P6
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  checkRateLimit,
+  bumpRateLimit,
+  resetRateLimit,
+  clientIp,
+  RATE_LIMITS,
+} from '../../functions/api/_rate_limit';
+import type { D1Database } from '@cloudflare/workers-types';
+
+interface MockStmt {
+  bind: ReturnType<typeof vi.fn>;
+  first: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDb(initialRow: unknown = null) {
+  let storedRow: unknown = initialRow;
+  const stmt: MockStmt = {
+    bind: vi.fn().mockImplementation(function(this: MockStmt, ...args: unknown[]) {
+      // Store latest bind args for inspection / state mutation
+      (this as MockStmt & { lastBindArgs?: unknown[] }).lastBindArgs = args;
+      return this;
+    }),
+    first: vi.fn().mockImplementation(async () => storedRow),
+    run: vi.fn().mockImplementation(async function() {
+      const args = (stmt as MockStmt & { lastBindArgs?: unknown[] }).lastBindArgs;
+      if (args && args.length === 4) {
+        storedRow = {
+          bucket_key: args[0],
+          count: args[1],
+          window_start: args[2],
+          locked_until: args[3],
+        };
+      } else if (args && args.length === 1) {
+        // DELETE
+        storedRow = null;
+      }
+      return { meta: { changes: 1 } };
+    }),
+  };
+  const db = {
+    prepare: vi.fn().mockReturnValue(stmt),
+  } as unknown as D1Database;
+  return { db, stmt };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('checkRateLimit', () => {
+  it('returns ok=true when no row exists (new bucket)', async () => {
+    const { db } = makeMockDb(null);
+    const result = await checkRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(0);
+  });
+
+  it('returns ok=false + retryAfter when locked', async () => {
+    const futureLock = Date.now() + 15 * 60 * 1000; // 15min future
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 5,
+      window_start: Date.now() - 1000,
+      locked_until: futureLock,
+    });
+    const result = await checkRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(false);
+    expect(result.retryAfter).toBeGreaterThan(800);
+    expect(result.retryAfter).toBeLessThanOrEqual(900);
+  });
+
+  it('returns ok=true when window expired (count resets)', async () => {
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 4,
+      window_start: Date.now() - (RATE_LIMITS.LOGIN.windowMs + 1000),
+      locked_until: null,
+    });
+    const result = await checkRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(0);
+  });
+
+  it('returns ok=true with current count when within window + not locked', async () => {
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 3,
+      window_start: Date.now() - 1000,
+      locked_until: null,
+    });
+    const result = await checkRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(3);
+  });
+});
+
+describe('bumpRateLimit', () => {
+  it('first attempt → count=1, no lock', async () => {
+    const { db } = makeMockDb(null);
+    const result = await bumpRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(1);
+  });
+
+  it('5 attempts within window → count=5, no lock yet (≤ maxAttempts)', async () => {
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 4,
+      window_start: Date.now() - 1000,
+      locked_until: null,
+    });
+    const result = await bumpRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(5);
+  });
+
+  it('6th attempt → count=6, locked', async () => {
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 5,
+      window_start: Date.now() - 1000,
+      locked_until: null,
+    });
+    const result = await bumpRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(false);
+    expect(result.retryAfter).toBeGreaterThan(0);
+    expect(result.count).toBe(6);
+  });
+
+  it('attempt after window expiry → reset count + window', async () => {
+    const { db } = makeMockDb({
+      bucket_key: 'login:1.2.3.4',
+      count: 5, // would be locked
+      window_start: Date.now() - (RATE_LIMITS.LOGIN.windowMs + 1000),
+      locked_until: null,
+    });
+    const result = await bumpRateLimit(db, 'login:1.2.3.4', RATE_LIMITS.LOGIN);
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(1); // reset
+  });
+});
+
+describe('resetRateLimit', () => {
+  it('DELETE the bucket row', async () => {
+    const { db, stmt } = makeMockDb({ bucket_key: 'k', count: 3, window_start: 0, locked_until: null });
+    await resetRateLimit(db, 'login:1.2.3.4');
+    expect(stmt.bind).toHaveBeenCalledWith('login:1.2.3.4');
+  });
+});
+
+describe('clientIp', () => {
+  it('reads CF-Connecting-IP header', () => {
+    const req = new Request('https://x.com', { headers: { 'CF-Connecting-IP': '203.0.113.5' } });
+    expect(clientIp(req)).toBe('203.0.113.5');
+  });
+
+  it('returns "unknown" if header missing', () => {
+    const req = new Request('https://x.com');
+    expect(clientIp(req)).toBe('unknown');
+  });
+});
+
+describe('RATE_LIMITS presets', () => {
+  it('LOGIN: 5 attempts / 15min / 30min lockout', () => {
+    expect(RATE_LIMITS.LOGIN.maxAttempts).toBe(5);
+    expect(RATE_LIMITS.LOGIN.windowMs).toBe(15 * 60 * 1000);
+    expect(RATE_LIMITS.LOGIN.lockoutMs).toBe(30 * 60 * 1000);
+  });
+
+  it('SIGNUP: more conservative (3 attempts / 1h)', () => {
+    expect(RATE_LIMITS.SIGNUP.maxAttempts).toBe(3);
+  });
+
+  it('OAUTH_TOKEN: high frequency (100 / min) for active client', () => {
+    expect(RATE_LIMITS.OAUTH_TOKEN.maxAttempts).toBe(100);
+    expect(RATE_LIMITS.OAUTH_TOKEN.windowMs).toBe(60 * 1000);
+  });
+});

--- a/tests/unit/migration-0035-rate-limit-buckets.test.ts
+++ b/tests/unit/migration-0035-rate-limit-buckets.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Migration 0035 — rate_limit_buckets schema 結構測試（V2-P6）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = fs.readFileSync(
+  path.resolve(__dirname, '../../migrations/0035_rate_limit_buckets.sql'),
+  'utf8',
+);
+
+describe('Migration 0035 — rate_limit_buckets', () => {
+  it('bucket_key TEXT PRIMARY KEY', () => {
+    expect(MIGRATION).toMatch(/bucket_key\s+TEXT PRIMARY KEY/);
+  });
+
+  it('count INTEGER default 0', () => {
+    expect(MIGRATION).toMatch(/count\s+INTEGER NOT NULL DEFAULT 0/);
+  });
+
+  it('window_start INTEGER NOT NULL (unix ms)', () => {
+    expect(MIGRATION).toMatch(/window_start\s+INTEGER NOT NULL/);
+  });
+
+  it('locked_until INTEGER nullable', () => {
+    expect(MIGRATION).toMatch(/locked_until\s+INTEGER[\s,]/);
+    expect(MIGRATION).not.toMatch(/locked_until[^,\n]+NOT NULL/);
+  });
+
+  it('created_at default datetime now', () => {
+    expect(MIGRATION).toMatch(/created_at\s+TEXT NOT NULL DEFAULT/);
+  });
+
+  it('indexes on locked_until + window_start', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_rate_limit_locked/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_rate_limit_window/);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P6 first slice — brute force defence。Migration 0035 + middleware helpers。Wire 進 endpoints 留 next slice。

## Schema (Migration 0035)

\`rate_limit_buckets\`:
- \`bucket_key\` TEXT PK (e.g. \`'login:1.2.3.4'\`, \`'signup:user@example.com'\`)
- \`count\` INTEGER (window-scoped attempt counter)
- \`window_start\` INTEGER unix ms
- \`locked_until\` INTEGER nullable

## API

```ts
import { checkRateLimit, bumpRateLimit, resetRateLimit, clientIp, RATE_LIMITS } from './_rate_limit';

// Pattern in endpoint:
const key = `login:${clientIp(request)}`;
const check = await checkRateLimit(env.DB, key, RATE_LIMITS.LOGIN);
if (!check.ok) return new Response(null, { status: 429, headers: { 'Retry-After': String(check.retryAfter) } });

// ...process login...
if (success) await resetRateLimit(env.DB, key);
else await bumpRateLimit(env.DB, key, RATE_LIMITS.LOGIN);
```

## Presets

| Preset | maxAttempts | window | lockout |
|--------|-------------|--------|---------|
| LOGIN | 5 | 15min | 30min |
| SIGNUP | 3 | 1h | 1h |
| FORGOT_PASSWORD | 3 | 1h | 1h |
| OAUTH_TOKEN | 100 | 1min | 5min |

## Algorithm

Sliding window with lockout：
- Window expired → reset count to 1, new window
- Within window → count++, if > maxAttempts → set locked_until=now+lockoutMs

## Test

\`tests/api/rate-limit-module.test.ts\` **14 cases TDD pass**:
- checkRateLimit: empty / locked / window expired / within window
- bumpRateLimit: first / within limit / exceeds → lock / after expiry → reset
- resetRateLimit DELETE
- clientIp CF header / fallback
- Presets validation

\`tests/unit/migration-0035-rate-limit-buckets.test.ts\` **6 cases TDD pass**.

## V2-P6 progress (1/N)

| # | Slice | Status |
|---|-------|--------|
| **本 PR** | **Rate limit middleware module** | ✓ |

Next: wire into login / signup / forgot-password / oauth-token endpoints。

🤖 Generated with [Claude Code](https://claude.com/claude-code)