### PR TITLE
feat(v2-p6): wire rate limit into /api/oauth/login (per-IP + per-email)

### DIFF
--- a/functions/api/oauth/login.ts
+++ b/functions/api/oauth/login.ts
@@ -20,6 +20,13 @@
 import { issueSession } from '../_session';
 import { parseJsonBody } from '../_utils';
 import { verifyPassword } from '../../../src/server/password';
+import {
+  checkRateLimit,
+  bumpRateLimit,
+  resetRateLimit,
+  clientIp,
+  RATE_LIMITS,
+} from '../_rate_limit';
 import type { Env } from '../_types';
 
 interface LoginBody {
@@ -53,6 +60,25 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     return errorResponse('LOGIN_INVALID_INPUT', 'email + password 必填', 400);
   }
 
+  // V2-P6 rate limit: per-IP + per-email buckets (defence in depth)
+  const ipKey = `login:${clientIp(context.request)}`;
+  const emailKey = `login:${email}`;
+
+  const ipCheck = await checkRateLimit(context.env.DB, ipKey, RATE_LIMITS.LOGIN);
+  if (!ipCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: { code: 'LOGIN_RATE_LIMITED', message: '登入嘗試過多，請稍後再試' } }),
+      { status: 429, headers: { 'content-type': 'application/json', 'Retry-After': String(ipCheck.retryAfter) } },
+    );
+  }
+  const emailCheck = await checkRateLimit(context.env.DB, emailKey, RATE_LIMITS.LOGIN);
+  if (!emailCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: { code: 'LOGIN_RATE_LIMITED', message: '此 email 登入嘗試過多，請稍後再試' } }),
+      { status: 429, headers: { 'content-type': 'application/json', 'Retry-After': String(emailCheck.retryAfter) } },
+    );
+  }
+
   // Lookup local provider identity
   const identity = await context.env.DB
     .prepare(
@@ -67,8 +93,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   const passwordOk = await verifyPassword(password, hashToCheck);
 
   if (!identity || !passwordOk) {
+    // Bump both buckets on failure (defence in depth)
+    await bumpRateLimit(context.env.DB, ipKey, RATE_LIMITS.LOGIN);
+    await bumpRateLimit(context.env.DB, emailKey, RATE_LIMITS.LOGIN);
     return errorResponse('LOGIN_INVALID', 'email 或密碼錯誤', 401);
   }
+
+  // Success: reset counters (legitimate user not penalised by past failed attempts)
+  await resetRateLimit(context.env.DB, ipKey);
+  await resetRateLimit(context.env.DB, emailKey);
 
   // Update last_used_at (best effort, don't fail login if update errors)
   try {

--- a/tests/api/oauth-login.test.ts
+++ b/tests/api/oauth-login.test.ts
@@ -113,4 +113,74 @@ describe('POST /api/oauth/login', () => {
     const res = await onRequestPost(makeContext({ email: 'a@b.com', password: 'whatever' }, env));
     expect(res.status).toBe(401);
   }, 30_000);
+
+  it('429 LOGIN_RATE_LIMITED when IP locked', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) {
+        // Return locked row
+        return makeStmt({
+          bucket_key: 'login:unknown',
+          count: 6,
+          window_start: Date.now(),
+          locked_until: Date.now() + 60_000, // locked for 1min
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ email: 'a@b.com', password: 'pw1234' }, env));
+    expect(res.status).toBe(429);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('LOGIN_RATE_LIMITED');
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+    expect(Number(res.headers.get('Retry-After'))).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('Failed login bumps rate limit counters (defence in depth)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) return makeStmt(null); // not locked
+      if (sql.includes('SELECT user_id, password_hash')) return makeStmt(null); // user not found
+      if (sql.includes('INSERT OR REPLACE INTO rate_limit_buckets')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ email: 'unknown@x.com', password: 'wrong' }, env));
+    expect(res.status).toBe(401);
+
+    // Both ipKey + emailKey buckets should be bumped (INSERT OR REPLACE called twice)
+    const inserts = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO rate_limit_buckets'),
+    );
+    expect(inserts.length).toBe(2);
+  }, 30_000);
+
+  it('Successful login resets rate limit counters', async () => {
+    const real = await hashPassword('correct-pass');
+    const deletes: string[] = [];
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) return makeStmt(null); // not locked
+      if (sql.includes('SELECT user_id, password_hash')) {
+        return makeStmt({ user_id: 'u', password_hash: real });
+      }
+      if (sql.includes('DELETE FROM rate_limit_buckets')) {
+        return {
+          ...makeStmt(),
+          bind: vi.fn().mockImplementation(function(this: { lastBindArgs?: unknown[] }, ...args: unknown[]) {
+            deletes.push(args[0] as string);
+            return this;
+          }),
+        };
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { SESSION_SECRET: 'session-secret-test', DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ email: 'user@x.com', password: 'correct-pass' }, env));
+    expect(res.status).toBe(200);
+
+    // Both bucket keys reset
+    const deleteCount = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM rate_limit_buckets'),
+    ).length;
+    expect(deleteCount).toBe(2);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary

V2-P6 第 2 片：把 #287 接好的 rate limit module 接進 `/api/oauth/login` 第一個敏感 endpoint。

- 進場前 check 兩個 bucket：`login:<ip>` + `login:<email>`（defence in depth — 攻擊者無法只用一個維度繞）
- 失敗（email 找不到 / 密碼錯）→ 兩個 bucket 都 bump，回 generic 401（保留 anti-enumeration）
- 成功 → 兩個 bucket 都 reset（合法使用者不被自己之前的失敗拖累）
- Rate limit 觸發 → 429 + `Retry-After` header（RFC 6585）+ `LOGIN_RATE_LIMITED` code

預設值（`RATE_LIMITS.LOGIN`）：5 次 / 15 min window / 30 min lockout。

## Test plan

- [x] 9/9 vitest 全綠（新增 3 cases：IP locked → 429、failed login bumps both buckets、success resets both）
- [x] tsc strict 全過
- [x] Build 全過
- [ ] CI 過後 land + 監控（V2-P6 next slice：wire into /signup, /forgot-password, /server-token）

## Security notes

- 兩個維度都 bump 是刻意的：攻擊者輪換 IP 還會被 email bucket 擋；輪換 email 也會被 IP bucket 擋
- 失敗訊息 generic（`LOGIN_INVALID`）+ 鎖定訊息 generic（`LOGIN_RATE_LIMITED`）— 都不洩漏帳號是否存在
- Constant-time guarantee 保留：rate limit check 在 verifyPassword 前，但失敗路徑仍跑完整 PBKDF2 才 bump（timing oracle 不會 leak rate limit state）

🤖 Generated with [Claude Code](https://claude.com/claude-code)