### PR TITLE
feat(v2-p6): wire rate limit into /signup, /forgot-password, /server-token

### DIFF
--- a/functions/api/oauth/forgot-password.ts
+++ b/functions/api/oauth/forgot-password.ts
@@ -24,6 +24,12 @@
  */
 import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
 import { parseJsonBody } from '../_utils';
+import {
+  checkRateLimit,
+  bumpRateLimit,
+  clientIp,
+  RATE_LIMITS,
+} from '../_rate_limit';
 import type { Env } from '../_types';
 
 interface ForgotBody {
@@ -51,6 +57,31 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   );
 
   if (!email) return genericResponse;
+
+  // V2-P6 rate limit: per-IP + per-email buckets
+  // Per autoplan: 3/h/IP + 3/h/email — defence in depth
+  // Bump regardless of email-exists-or-not（response 永遠 generic，attacker 無從分辨）
+  const ipKey = `forgot-password:${clientIp(context.request)}`;
+  const emailKey = `forgot-password:${email}`;
+
+  const ipCheck = await checkRateLimit(context.env.DB, ipKey, RATE_LIMITS.FORGOT_PASSWORD);
+  if (!ipCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: { code: 'FORGOT_PASSWORD_RATE_LIMITED', message: '密碼重設請求過多，請稍後再試' } }),
+      { status: 429, headers: { 'content-type': 'application/json', 'Retry-After': String(ipCheck.retryAfter) } },
+    );
+  }
+  const emailCheck = await checkRateLimit(context.env.DB, emailKey, RATE_LIMITS.FORGOT_PASSWORD);
+  if (!emailCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: { code: 'FORGOT_PASSWORD_RATE_LIMITED', message: '此 email 重設請求過多，請稍後再試' } }),
+      { status: 429, headers: { 'content-type': 'application/json', 'Retry-After': String(emailCheck.retryAfter) } },
+    );
+  }
+
+  // Bump both buckets — every valid request counts (anti-enumeration: response is generic anyway)
+  await bumpRateLimit(context.env.DB, ipKey, RATE_LIMITS.FORGOT_PASSWORD);
+  await bumpRateLimit(context.env.DB, emailKey, RATE_LIMITS.FORGOT_PASSWORD);
 
   // Check if user exists with local provider
   const user = await context.env.DB

--- a/functions/api/oauth/server-token.ts
+++ b/functions/api/oauth/server-token.ts
@@ -22,6 +22,11 @@
  */
 import { D1Adapter, type AdapterPayload } from '../../../src/server/oauth-d1-adapter';
 import { verifyPassword } from '../../../src/server/password';
+import {
+  checkRateLimit,
+  bumpRateLimit,
+  RATE_LIMITS,
+} from '../_rate_limit';
 import type { Env } from '../_types';
 
 const ACCESS_TOKEN_TTL_SEC = 60 * 60;          // 1h
@@ -167,6 +172,26 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   if (!clientId) {
     return jsonError('invalid_client', 'Missing client_id');
   }
+
+  // V2-P6 rate limit: per-client_id bucket — throughput cap
+  // Preset: 100 attempts / minute, 5min lockout (per RATE_LIMITS.OAUTH_TOKEN)
+  // Bump regardless of grant_type / outcome — total per-minute throughput cap
+  const tokenKey = `oauth-token:${clientId}`;
+  const tokenCheck = await checkRateLimit(context.env.DB, tokenKey, RATE_LIMITS.OAUTH_TOKEN);
+  if (!tokenCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: 'rate_limited', error_description: 'Too many token requests for this client' }),
+      {
+        status: 429,
+        headers: {
+          'content-type': 'application/json',
+          'cache-control': 'no-store',
+          'Retry-After': String(tokenCheck.retryAfter),
+        },
+      },
+    );
+  }
+  await bumpRateLimit(context.env.DB, tokenKey, RATE_LIMITS.OAUTH_TOKEN);
 
   const client = await context.env.DB
     .prepare(

--- a/functions/api/oauth/signup.ts
+++ b/functions/api/oauth/signup.ts
@@ -22,6 +22,12 @@ import { issueSession } from '../_session';
 import { AppError } from '../_errors';
 import { parseJsonBody } from '../_utils';
 import { hashPassword } from '../../../src/server/password';
+import {
+  checkRateLimit,
+  bumpRateLimit,
+  clientIp,
+  RATE_LIMITS,
+} from '../_rate_limit';
 import type { Env } from '../_types';
 
 interface SignupBody {
@@ -53,6 +59,19 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   if (!password || password.length < MIN_PASSWORD_LEN) {
     return errorResponse('SIGNUP_INVALID_PASSWORD', `密碼至少 ${MIN_PASSWORD_LEN} 字元`, 400);
   }
+
+  // V2-P6 rate limit: per-IP bucket — anti signup-spam
+  // Bump only after validation passes（garbage input 不浪費 bucket slot），
+  // 在 DB lookup 前 bump 確保即使 success path 也計入次數（per autoplan: 3/h/IP）
+  const ipKey = `signup:${clientIp(context.request)}`;
+  const ipCheck = await checkRateLimit(context.env.DB, ipKey, RATE_LIMITS.SIGNUP);
+  if (!ipCheck.ok) {
+    return new Response(
+      JSON.stringify({ error: { code: 'SIGNUP_RATE_LIMITED', message: '註冊嘗試過多，請稍後再試' } }),
+      { status: 429, headers: { 'content-type': 'application/json', 'Retry-After': String(ipCheck.retryAfter) } },
+    );
+  }
+  await bumpRateLimit(context.env.DB, ipKey, RATE_LIMITS.SIGNUP);
 
   // Duplicate email check
   const existing = await context.env.DB

--- a/tests/api/oauth-forgot-password.test.ts
+++ b/tests/api/oauth-forgot-password.test.ts
@@ -100,16 +100,16 @@ describe('POST /api/oauth/forgot-password', () => {
     const env: MockEnv = { DB: { prepare: dbPrepare } };
     await onRequestPost(makeContext({ email: 'u@x.com' }, env));
 
-    // 4th argument to bind on INSERT is expires_at = now + 3600 * 1000
-    const insertResult = dbPrepare.mock.results.find(
-      (_, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
-                (dbPrepare.mock.calls[i][0] as string).includes('INSERT OR REPLACE'),
+    // Find the INSERT OR REPLACE INTO oauth_models call (PasswordReset token store)
+    // — distinct from rate_limit_buckets INSERTs that share the prefix
+    const tokenInsertIdx = dbPrepare.mock.calls.findIndex(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('INSERT OR REPLACE INTO oauth_models'),
     );
-    if (insertResult) {
-      const bindArgs = (insertResult.value as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
-      const expiresAt = bindArgs[3] as number;
-      expect(expiresAt).toBe(Date.now() + 3600 * 1000);
-    }
+    expect(tokenInsertIdx).toBeGreaterThanOrEqual(0);
+    const stmt = dbPrepare.mock.results[tokenInsertIdx].value as { bind: { mock: { calls: unknown[][] } } };
+    const bindArgs = stmt.bind.mock.calls[0];
+    const expiresAt = bindArgs[3] as number;
+    expect(expiresAt).toBe(Date.now() + 3600 * 1000);
   });
 
   it('Local provider lookup filter: WHERE provider = "local" (not Google-only user)', async () => {
@@ -118,7 +118,50 @@ describe('POST /api/oauth/forgot-password', () => {
     const env: MockEnv = { DB: { prepare: dbPrepare } };
     await onRequestPost(makeContext({ email: 'u@x.com' }, env));
 
-    const sql = dbPrepare.mock.calls[0][0] as string;
-    expect(sql).toContain("provider = 'local'");
+    // Find the user lookup SQL — rate limit INSERTs come first now
+    const userLookupSql = dbPrepare.mock.calls
+      .map((c) => c[0] as string)
+      .find((s) => s.includes('SELECT u.id'));
+    expect(userLookupSql).toBeTruthy();
+    expect(userLookupSql).toContain("provider = 'local'");
+  });
+
+  it('429 FORGOT_PASSWORD_RATE_LIMITED when IP bucket locked', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) {
+        // Locked bucket
+        return makeStmt({
+          bucket_key: 'forgot-password:unknown',
+          count: 4,
+          window_start: Date.now(),
+          locked_until: Date.now() + 60_000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ email: 'u@x.com' }, env));
+    expect(res.status).toBe(429);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('FORGOT_PASSWORD_RATE_LIMITED');
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+    expect(Number(res.headers.get('Retry-After'))).toBeGreaterThan(0);
+  });
+
+  it('Bumps both ipKey + emailKey buckets on every valid request (defence in depth)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) return makeStmt(null); // not locked
+      if (sql.includes('SELECT u.id')) return makeStmt(null); // user not found
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({ email: 'u@x.com' }, env));
+    expect(res.status).toBe(200); // generic 200 regardless
+
+    // Both buckets bumped
+    const inserts = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO rate_limit_buckets'),
+    );
+    expect(inserts.length).toBe(2);
   });
 });

--- a/tests/api/oauth-server-token.test.ts
+++ b/tests/api/oauth-server-token.test.ts
@@ -400,4 +400,49 @@ describe('POST /api/oauth/server-token — refresh_token grant', () => {
     expect(r2.status).toBe(400);
     expect(((await r2.json()) as { error: string }).error).toBe('invalid_scope');
   });
+
+  it('429 rate_limited when client bucket locked (V2-P6 throughput cap)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) {
+        return makeStmt({
+          bucket_key: 'oauth-token:mobile',
+          count: 101,
+          window_start: Date.now(),
+          locked_until: Date.now() + 30_000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'authorization_code',
+      client_id: 'mobile',
+      code: 'c', redirect_uri: 'r',
+    }, env));
+    expect(res.status).toBe(429);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe('rate_limited');
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+    expect(Number(res.headers.get('Retry-After'))).toBeGreaterThan(0);
+  });
+
+  it('Bumps oauth-token bucket on every request (success or failure)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) return makeStmt(null); // not locked
+      if (sql.includes('FROM client_apps')) return makeStmt(null); // unknown client → 401
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      grant_type: 'authorization_code',
+      client_id: 'mobile',
+      code: 'c', redirect_uri: 'r',
+    }, env));
+    expect(res.status).toBe(401); // unknown client
+    // Bucket bumped even though request failed
+    const inserts = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO rate_limit_buckets'),
+    );
+    expect(inserts.length).toBe(1);
+  });
 });

--- a/tests/api/oauth-signup.test.ts
+++ b/tests/api/oauth-signup.test.ts
@@ -115,9 +115,13 @@ describe('POST /api/oauth/signup', () => {
       password: 'password123',
     }, env));
 
-    // First DB call should be lookup with lowercased email
-    const firstStmt = dbPrepare.mock.results[0].value;
-    expect(firstStmt.bind).toHaveBeenCalledWith('mixed.case@example.com');
+    // Find the user-lookup stmt by SQL pattern (rate limit calls now precede it)
+    const userLookupIdx = dbPrepare.mock.calls.findIndex(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('SELECT id FROM users'),
+    );
+    expect(userLookupIdx).toBeGreaterThanOrEqual(0);
+    const lookupStmt = dbPrepare.mock.results[userLookupIdx].value;
+    expect(lookupStmt.bind).toHaveBeenCalledWith('mixed.case@example.com');
   }, 30_000);
 
   it('UNIQUE constraint race condition → 409 SIGNUP_EMAIL_TAKEN', async () => {
@@ -139,4 +143,47 @@ describe('POST /api/oauth/signup', () => {
     expect(res.status).toBe(409);
     expect((await res.json() as { error: { code: string } }).error.code).toBe('SIGNUP_EMAIL_TAKEN');
   }, 30_000);
+
+  it('429 SIGNUP_RATE_LIMITED when IP bucket locked', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) {
+        return makeStmt({
+          bucket_key: 'signup:unknown',
+          count: 4,
+          window_start: Date.now(),
+          locked_until: Date.now() + 60_000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      email: 'a@b.com',
+      password: 'longenough',
+    }, env));
+    expect(res.status).toBe(429);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('SIGNUP_RATE_LIMITED');
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+    expect(Number(res.headers.get('Retry-After'))).toBeGreaterThan(0);
+  });
+
+  it('Bumps signup ipKey bucket on every valid attempt (anti spam)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM rate_limit_buckets')) return makeStmt(null); // not locked
+      if (sql.includes('SELECT id FROM users')) return makeStmt({ id: 'existing' }); // dup → 409
+      return makeStmt();
+    });
+    const env: MockEnv = { SESSION_SECRET: 's', DB: { prepare: dbPrepare } };
+    const res = await onRequestPost(makeContext({
+      email: 'taken@example.com',
+      password: 'longenough',
+    }, env));
+    // dup email → 409, but rate limit bucket should still be bumped
+    expect(res.status).toBe(409);
+    const inserts = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO rate_limit_buckets'),
+    );
+    expect(inserts.length).toBe(1); // single ipKey bucket (no per-email for signup)
+  });
 });


### PR DESCRIPTION
## Summary

V2-P6 第 3 片：把 #287 的 rate limit module 接進剩下 3 個敏感 endpoint，跟 #288 (login) 一起完成 V2-P6 的 endpoint 覆蓋。

每個 endpoint 依不同 attack model 用不同 bucket dimension：

| Endpoint | Bucket key | Preset | Bump 時機 |
|----------|-----------|--------|-----------|
| `/signup` | `signup:<ip>` | 3/h/IP, 1h lockout | validation 過後、INSERT 前（success 或 dup email 都計） |
| `/forgot-password` | `forgot-password:<ip>` + `forgot-password:<email>` | 3/h, 1h lockout | 每個 valid request（response 永遠 generic，無 enumeration leak） |
| `/server-token` | `oauth-token:<client_id>` | 100/min, 5min lockout | 取出 clientId 後（即使 unknown client 也計，防 client_id probe） |

429 全部帶 `Retry-After` header（RFC 6585）。

## Test plan

- [x] tsc strict 全過
- [x] 382/382 vitest API 全綠（含本 PR 9 個新 case）
- [x] Build 全過（pending CI 確認）

## 既有 test 修正

Rate limit `SELECT FROM rate_limit_buckets` 進場後，`dbPrepare.mock.calls[0]` 不再是 user lookup。改用 `findIndex(c => c[0].includes('SELECT id FROM users'))` pattern 取 stmt（forgot-password / signup 各 1 處）。

## 安全 rationale

- **/signup per-IP only**：signup 沒有 per-email 概念（攻擊者本來就在創 email）；per-IP 阻 spam-account 注入
- **/forgot-password per-IP + per-email**：兩維度都 bump，攻擊者無法只輪換一個維度繞過
- **/server-token per-client_id**：throughput cap，不分 grant_type / outcome；unknown client 也計入（防 client_id 字典攻擊）

## V2-P6 progress

- [x] #287 rate limit module + migration 0035
- [x] #288 wire login (per-IP + per-email)
- [x] **本 PR** wire signup + forgot-password + server-token
- [ ] 下一片：audit log expansion（user_id / client_id columns）+ key rotation infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)