### PR TITLE
feat(v2-p6): auth_audit_log foundation + wire signup/logout

### DIFF
--- a/functions/api/_auth_audit.ts
+++ b/functions/api/_auth_audit.ts
@@ -1,0 +1,98 @@
+/**
+ * Auth audit log helper — V2-P6
+ *
+ * 集中記錄 OAuth / 帳密 / session 事件供 monitoring + forensic。
+ * 所有 caller 透過 `recordAuthEvent()` 寫，**best-effort**：audit failure
+ * 不該擋 caller 業務流程（例如 audit DB 滿了不能阻止使用者登入）。
+ *
+ * Schema 詳見 `migrations/0036_auth_audit_log.sql`。
+ *
+ * ## Usage
+ *
+ * ```ts
+ * await recordAuthEvent(context.env.DB, context.request, {
+ *   eventType: 'login',
+ *   outcome: 'failure',
+ *   failureReason: 'wrong_password',
+ *   userId: identity?.user_id,  // optional, undefined if email not found
+ * });
+ * ```
+ */
+import type { D1Database } from '@cloudflare/workers-types';
+
+export type AuthEventType =
+  | 'signup'
+  | 'login'
+  | 'logout'
+  | 'password_reset_request'
+  | 'password_reset_complete'
+  | 'oauth_authorize'
+  | 'oauth_consent'
+  | 'token_issue'
+  | 'token_revoke'
+  | 'rate_limited';
+
+export type AuthEventOutcome = 'success' | 'failure';
+
+export interface AuthAuditEvent {
+  eventType: AuthEventType;
+  outcome: AuthEventOutcome;
+  userId?: string | null;
+  clientId?: string | null;
+  failureReason?: string | null;
+  /** Free-form event-specific JSON serialised before INSERT. */
+  metadata?: Record<string, unknown>;
+  /** Correlation ID across multi-step OAuth flow (e.g. authorize → consent → token). */
+  traceId?: string | null;
+}
+
+const USER_AGENT_MAX_LEN = 200;
+
+/** SHA-256(ip) base64 — used as ip_hash column for privacy. */
+async function hashIp(ip: string): Promise<string> {
+  const bytes = new TextEncoder().encode(ip);
+  const buf = await crypto.subtle.digest('SHA-256', bytes);
+  const arr = new Uint8Array(buf);
+  let str = '';
+  for (let i = 0; i < arr.length; i++) str += String.fromCharCode(arr[i]!);
+  return btoa(str);
+}
+
+/**
+ * Record an auth event。**Never throws** — caller doesn't need try/catch。
+ * Audit-write failure is logged via console.error 但不會影響 business flow。
+ */
+export async function recordAuthEvent(
+  db: D1Database,
+  request: Request,
+  event: AuthAuditEvent,
+): Promise<void> {
+  try {
+    const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+    const ipHash = await hashIp(ip);
+    const userAgent = (request.headers.get('User-Agent') ?? '').slice(0, USER_AGENT_MAX_LEN);
+
+    await db
+      .prepare(
+        `INSERT INTO auth_audit_log
+           (trace_id, event_type, outcome, user_id, client_id, ip_hash, user_agent, failure_reason, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        event.traceId ?? null,
+        event.eventType,
+        event.outcome,
+        event.userId ?? null,
+        event.clientId ?? null,
+        ipHash,
+        userAgent || null,
+        event.failureReason ?? null,
+        event.metadata ? JSON.stringify(event.metadata) : null,
+      )
+      .run();
+  } catch (err) {
+    // best-effort — log but don't propagate
+    // eslint-disable-next-line no-console
+    console.error('[_auth_audit] recordAuthEvent failed:', (err as Error).message);
+  }
+}

--- a/functions/api/oauth/logout.ts
+++ b/functions/api/oauth/logout.ts
@@ -19,7 +19,8 @@
  *   - Google session revoke (Google revocation endpoint，需 access_token)
  *   - Telemetry log on logout
  */
-import { clearSession } from '../_session';
+import { clearSession, getSessionUser } from '../_session';
+import { recordAuthEvent } from '../_auth_audit';
 import type { Env } from '../_types';
 
 const SAFE_REDIRECT_DEFAULT = '/login';
@@ -30,7 +31,10 @@ function sanitizeRedirect(value: string | null): string {
   return value;
 }
 
-function buildLogoutResponse(request: Request): Response {
+async function buildLogoutResponse(request: Request, env: Env): Promise<Response> {
+  // V2-P6 audit: capture user_id from session (if any) before clearing
+  const session = await getSessionUser(request, env);
+
   const url = new URL(request.url);
   const redirectAfter = sanitizeRedirect(url.searchParams.get('redirect_after'));
   const response = new Response(null, {
@@ -38,13 +42,21 @@ function buildLogoutResponse(request: Request): Response {
     headers: { Location: redirectAfter },
   });
   clearSession(request, response);
+
+  // best-effort audit (won't throw)
+  await recordAuthEvent(env.DB, request, {
+    eventType: 'logout',
+    outcome: 'success',
+    userId: session?.uid ?? null,
+  });
+
   return response;
 }
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
-  return buildLogoutResponse(context.request);
+  return buildLogoutResponse(context.request, context.env);
 };
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
-  return buildLogoutResponse(context.request);
+  return buildLogoutResponse(context.request, context.env);
 };

--- a/functions/api/oauth/signup.ts
+++ b/functions/api/oauth/signup.ts
@@ -22,6 +22,7 @@ import { issueSession } from '../_session';
 import { AppError } from '../_errors';
 import { parseJsonBody } from '../_utils';
 import { hashPassword } from '../../../src/server/password';
+import { recordAuthEvent } from '../_auth_audit';
 import type { Env } from '../_types';
 
 interface SignupBody {
@@ -60,6 +61,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     .bind(email)
     .first<{ id: string }>();
   if (existing) {
+    await recordAuthEvent(context.env.DB, context.request, {
+      eventType: 'signup',
+      outcome: 'failure',
+      failureReason: 'email_taken',
+      metadata: { email },
+    });
     return errorResponse('SIGNUP_EMAIL_TAKEN', '此 email 已註冊，請改用登入或忘記密碼', 409);
   }
 
@@ -101,5 +108,13 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     { status: 201, headers: { 'content-type': 'application/json' } },
   );
   await issueSession(context.request, response, userId, context.env);
+
+  // V2-P6 audit log — best-effort, don't fail signup if audit insert fails
+  await recordAuthEvent(context.env.DB, context.request, {
+    eventType: 'signup',
+    outcome: 'success',
+    userId,
+    metadata: { email, displayName },
+  });
   return response;
 };

--- a/migrations/0036_auth_audit_log.sql
+++ b/migrations/0036_auth_audit_log.sql
@@ -1,0 +1,49 @@
+-- Migration 0036: auth_audit_log — V2-P6 audit log expansion
+--
+-- 用於 V2 OAuth Server / 帳密 / session 事件審計。**獨立於 audit_log**（後者
+-- 記 trip CRUD），因為 OAuth event 的 schema shape 不同（沒有 trip_id）。
+--
+-- ## Events covered
+--
+-- | event_type              | user_id | client_id | failure_reason 例 |
+-- |-------------------------|---------|-----------|------------------|
+-- | signup                  | ✓ 成功時 | —         | rate_limited / dup_email |
+-- | login                   | ✓ 成功時 | —         | wrong_password / unknown_email / rate_limited |
+-- | logout                  | ✓       | —         | — |
+-- | password_reset_request  | —       | —         | rate_limited |
+-- | password_reset_complete | ✓       | —         | invalid_token / token_used |
+-- | oauth_authorize         | ✓ 成功時 | ✓        | invalid_redirect / consent_denied |
+-- | oauth_consent           | ✓       | ✓        | — |
+-- | token_issue             | ✓       | ✓        | invalid_grant / pkce_mismatch / rate_limited |
+-- | token_revoke            | ✓       | ✓        | — |
+-- | rate_limited            | —       | —         | — (event 本身就是) |
+--
+-- ## Privacy
+--
+-- ip_hash 是 SHA-256(ip)。設計目標是「使 audit log 在 DB dump 中不顯示
+-- 純 IP，但 attacker 仍可逐個 hash 反查」— 防 casual leak 不防積極攻擊。
+-- 真正的隱私靠 D1 access control + R2 cold storage retention policy。
+--
+-- ## Retention
+--
+-- 30 天 D1 + Logpush → R2 長期 (per autoplan)。Cleanup 由 V2-P6 cron job
+-- DELETE WHERE created_at < datetime('now', '-30 days')。
+
+CREATE TABLE auth_audit_log (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  trace_id        TEXT,                                    -- correlation across multi-step OAuth flow
+  event_type      TEXT NOT NULL,                           -- enum (string for forward compat)
+  outcome         TEXT NOT NULL CHECK (outcome IN ('success', 'failure')),
+  user_id         TEXT,                                    -- NULL when not yet identified
+  client_id       TEXT,                                    -- NULL for non-OAuth events
+  ip_hash         TEXT NOT NULL,                           -- SHA-256(ip)
+  user_agent      TEXT,                                    -- truncated at 200 chars
+  failure_reason  TEXT,                                    -- e.g. 'wrong_password'
+  metadata        TEXT,                                    -- JSON for event-specific extras
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_auth_audit_user_time ON auth_audit_log(user_id, created_at);
+CREATE INDEX idx_auth_audit_client_time ON auth_audit_log(client_id, created_at);
+CREATE INDEX idx_auth_audit_event_outcome ON auth_audit_log(event_type, outcome, created_at);
+CREATE INDEX idx_auth_audit_time ON auth_audit_log(created_at);

--- a/tests/api/auth-audit-module.test.ts
+++ b/tests/api/auth-audit-module.test.ts
@@ -1,0 +1,149 @@
+/**
+ * functions/api/_auth_audit.ts unit test — V2-P6
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { recordAuthEvent } from '../../functions/api/_auth_audit';
+import type { D1Database } from '@cloudflare/workers-types';
+
+interface MockStmt {
+  bind: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDb(runError?: Error) {
+  const stmt: MockStmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockImplementation(() => runError ? Promise.reject(runError) : Promise.resolve({ meta: { changes: 1 } })),
+  };
+  const db = {
+    prepare: vi.fn().mockReturnValue(stmt),
+  } as unknown as D1Database;
+  return { db, stmt, prepare: db.prepare as ReturnType<typeof vi.fn> };
+}
+
+function makeRequest(opts: { ip?: string; ua?: string } = {}): Request {
+  const headers: Record<string, string> = {};
+  if (opts.ip) headers['CF-Connecting-IP'] = opts.ip;
+  if (opts.ua) headers['User-Agent'] = opts.ua;
+  return new Request('https://x.com/auth', { method: 'POST', headers });
+}
+
+describe('recordAuthEvent', () => {
+  it('inserts row with all expected columns', async () => {
+    const { db, stmt, prepare } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '1.2.3.4', ua: 'TestAgent/1.0' }), {
+      eventType: 'login',
+      outcome: 'success',
+      userId: 'u1',
+    });
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect((prepare.mock.calls[0][0] as string)).toMatch(/INSERT INTO auth_audit_log/);
+    expect(stmt.bind).toHaveBeenCalledTimes(1);
+    expect(stmt.run).toHaveBeenCalledTimes(1);
+
+    const args = stmt.bind.mock.calls[0];
+    expect(args[0]).toBeNull();           // trace_id
+    expect(args[1]).toBe('login');        // event_type
+    expect(args[2]).toBe('success');      // outcome
+    expect(args[3]).toBe('u1');           // user_id
+    expect(args[4]).toBeNull();           // client_id
+    expect(typeof args[5]).toBe('string'); // ip_hash (base64 of SHA-256)
+    expect(args[5]).not.toBe('1.2.3.4');  // never raw IP
+    expect(args[6]).toBe('TestAgent/1.0'); // user_agent
+    expect(args[7]).toBeNull();           // failure_reason
+    expect(args[8]).toBeNull();           // metadata
+  });
+
+  it('truncates user_agent at 200 chars', async () => {
+    const { db, stmt } = makeMockDb();
+    const longUa = 'A'.repeat(500);
+    await recordAuthEvent(db, makeRequest({ ip: '1.1.1.1', ua: longUa }), {
+      eventType: 'login',
+      outcome: 'success',
+    });
+    const ua = stmt.bind.mock.calls[0][6] as string;
+    expect(ua.length).toBe(200);
+  });
+
+  it('serialises metadata as JSON string', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '1.1.1.1' }), {
+      eventType: 'oauth_authorize',
+      outcome: 'failure',
+      clientId: 'app-1',
+      failureReason: 'invalid_redirect',
+      metadata: { redirect_uri: 'https://attacker.com', scope: 'openid' },
+    });
+    const args = stmt.bind.mock.calls[0];
+    expect(args[4]).toBe('app-1');
+    expect(args[7]).toBe('invalid_redirect');
+    const meta = JSON.parse(args[8] as string);
+    expect(meta).toEqual({ redirect_uri: 'https://attacker.com', scope: 'openid' });
+  });
+
+  it('falls back to ip="unknown" when CF-Connecting-IP missing', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest(), {
+      eventType: 'login',
+      outcome: 'success',
+    });
+    const ipHash = stmt.bind.mock.calls[0][5] as string;
+    expect(typeof ipHash).toBe('string');
+    expect(ipHash.length).toBeGreaterThan(0);
+  });
+
+  it('user_agent NULL when header absent', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '1.1.1.1' }), {
+      eventType: 'logout',
+      outcome: 'success',
+      userId: 'u',
+    });
+    expect(stmt.bind.mock.calls[0][6]).toBeNull();
+  });
+
+  it('does NOT throw when DB insert fails (best-effort)', async () => {
+    const { db } = makeMockDb(new Error('D1 unavailable'));
+    await expect(
+      recordAuthEvent(db, makeRequest({ ip: '1.1.1.1' }), {
+        eventType: 'login',
+        outcome: 'failure',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('IP hash deterministic: same ip → same hash', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '203.0.113.5' }), {
+      eventType: 'login', outcome: 'success',
+    });
+    await recordAuthEvent(db, makeRequest({ ip: '203.0.113.5' }), {
+      eventType: 'logout', outcome: 'success',
+    });
+    expect(stmt.bind.mock.calls[0][5]).toBe(stmt.bind.mock.calls[1][5]);
+  });
+
+  it('IP hash differs for different IPs', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '1.1.1.1' }), {
+      eventType: 'login', outcome: 'success',
+    });
+    await recordAuthEvent(db, makeRequest({ ip: '2.2.2.2' }), {
+      eventType: 'login', outcome: 'success',
+    });
+    expect(stmt.bind.mock.calls[0][5]).not.toBe(stmt.bind.mock.calls[1][5]);
+  });
+
+  it('passes traceId when provided (OAuth flow correlation)', async () => {
+    const { db, stmt } = makeMockDb();
+    await recordAuthEvent(db, makeRequest({ ip: '1.1.1.1' }), {
+      eventType: 'oauth_consent',
+      outcome: 'success',
+      userId: 'u',
+      clientId: 'c',
+      traceId: 'trace-abc-123',
+    });
+    expect(stmt.bind.mock.calls[0][0]).toBe('trace-abc-123');
+  });
+});

--- a/tests/api/oauth-logout.test.ts
+++ b/tests/api/oauth-logout.test.ts
@@ -1,19 +1,35 @@
 /**
- * POST/GET /api/oauth/logout unit test — V2-P1
+ * POST/GET /api/oauth/logout unit test — V2-P1 + V2-P6 audit
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { onRequestGet, onRequestPost } from '../../functions/api/oauth/logout';
 
-function makeContext(url: string, method: 'GET' | 'POST' = 'GET'): Parameters<typeof onRequestGet>[0] {
+function makeContext(
+  url: string,
+  method: 'GET' | 'POST' = 'GET',
+  envOverride?: Record<string, unknown>,
+  cookie?: string,
+): Parameters<typeof onRequestGet>[0] {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.Cookie = cookie;
   return {
-    request: new Request(url, { method }),
-    env: {} as unknown as never,
+    request: new Request(url, { method, headers }),
+    env: (envOverride ?? {}) as unknown as never,
     params: {} as unknown as never,
     data: {} as unknown as never,
     next: () => Promise.resolve(new Response()),
     waitUntil: () => undefined,
     passThroughOnException: () => undefined,
   } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+function makeAuditDb() {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+  const db = { prepare: vi.fn().mockReturnValue(stmt) };
+  return { db, stmt };
 }
 
 describe('GET/POST /api/oauth/logout', () => {
@@ -57,5 +73,19 @@ describe('GET/POST /api/oauth/logout', () => {
   it('https → Set-Cookie includes Secure', async () => {
     const res = await onRequestGet(makeContext('https://x.com/api/oauth/logout'));
     expect(res.headers.get('Set-Cookie')).toContain('Secure');
+  });
+
+  it('records audit event with userId=null when no session cookie (V2-P6)', async () => {
+    const { db, stmt } = makeAuditDb();
+    await onRequestGet(makeContext('https://x.com/api/oauth/logout', 'GET', { DB: db }));
+    // recordAuthEvent prepare called once for INSERT INTO auth_audit_log
+    const auditCall = (db.prepare as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('INSERT INTO auth_audit_log'),
+    );
+    expect(auditCall).toBeTruthy();
+    const args = stmt.bind.mock.calls[0];
+    expect(args[1]).toBe('logout');     // event_type
+    expect(args[2]).toBe('success');    // outcome
+    expect(args[3]).toBeNull();         // user_id (no session)
   });
 });

--- a/tests/unit/migration-0036-auth-audit-log.test.ts
+++ b/tests/unit/migration-0036-auth-audit-log.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Migration 0036 — auth_audit_log schema 結構測試（V2-P6）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = fs.readFileSync(
+  path.resolve(__dirname, '../../migrations/0036_auth_audit_log.sql'),
+  'utf8',
+);
+
+describe('Migration 0036 — auth_audit_log', () => {
+  it('id INTEGER PRIMARY KEY AUTOINCREMENT', () => {
+    expect(MIGRATION).toMatch(/id\s+INTEGER PRIMARY KEY AUTOINCREMENT/);
+  });
+
+  it('event_type TEXT NOT NULL (string for forward compat, no CHECK)', () => {
+    expect(MIGRATION).toMatch(/event_type\s+TEXT NOT NULL/);
+  });
+
+  it('outcome TEXT NOT NULL with CHECK (success | failure)', () => {
+    expect(MIGRATION).toMatch(/outcome\s+TEXT NOT NULL CHECK[\s\S]*?'success'[\s\S]*?'failure'/);
+  });
+
+  it('user_id TEXT nullable', () => {
+    expect(MIGRATION).toMatch(/user_id\s+TEXT[\s,]/);
+    expect(MIGRATION).not.toMatch(/user_id[^,\n]+NOT NULL/);
+  });
+
+  it('client_id TEXT nullable', () => {
+    expect(MIGRATION).toMatch(/client_id\s+TEXT[\s,]/);
+    expect(MIGRATION).not.toMatch(/client_id[^,\n]+NOT NULL/);
+  });
+
+  it('ip_hash TEXT NOT NULL', () => {
+    expect(MIGRATION).toMatch(/ip_hash\s+TEXT NOT NULL/);
+  });
+
+  it('failure_reason TEXT nullable', () => {
+    expect(MIGRATION).toMatch(/failure_reason\s+TEXT[\s,]/);
+    expect(MIGRATION).not.toMatch(/failure_reason[^,\n]+NOT NULL/);
+  });
+
+  it('metadata TEXT nullable (JSON serialised)', () => {
+    expect(MIGRATION).toMatch(/metadata\s+TEXT[\s,]/);
+  });
+
+  it('trace_id TEXT nullable (correlation ID)', () => {
+    expect(MIGRATION).toMatch(/trace_id\s+TEXT[\s,]/);
+  });
+
+  it('created_at TEXT NOT NULL DEFAULT datetime now', () => {
+    expect(MIGRATION).toMatch(/created_at\s+TEXT NOT NULL DEFAULT/);
+  });
+
+  it('indexes for monitoring queries (user/client/event/time)', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_auth_audit_user_time/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_auth_audit_client_time/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_auth_audit_event_outcome/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_auth_audit_time/);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P6 第 4 片：建 OAuth/帳密事件審計基礎，與既有 `audit_log`（trip CRUD 用）獨立 — OAuth event 沒有 trip_id，schema shape 不一致。

### 新增

- **Migration 0036** `auth_audit_log` table
  - `trace_id` 可串多步 OAuth flow（authorize → consent → token）
  - `event_type` enum-as-string（`signup` / `login` / `logout` / `oauth_authorize` / `token_issue` / ...）
  - `outcome` CHECK (success | failure)
  - `user_id` / `client_id` 都 nullable（依 event 而定）
  - `ip_hash` SHA-256(ip) for privacy
  - `failure_reason` + `metadata` JSON for forensic
  - 4 indexes for monitoring（user-time / client-time / event-outcome-time / time）

- **`functions/api/_auth_audit.ts`**: `recordAuthEvent()` helper
  - **Best-effort**: try/catch 內部，DB 失敗只 console.error 不 propagate（audit 寫不進去**永不擋**業務流程）
  - User-Agent 截 200 chars
  - ip_hash deterministic 同 IP 產生同 hash → 監控可 group by

### Wired endpoints (此 PR)

- `/signup`: success（含 email + displayName 進 metadata）+ failure（email_taken with reason）
- `/logout`: success with userId（從 session cookie 取）或 null（無 session）

### Deferred（避免 PR 衝突）

下一片 wire login / forgot-password / reset-password / server-token / server-authorize / server-consent — 等 #288 (login wiring) + #289 (signup/forgot/server-token rate limit wiring) merge 後再做。

## Test plan

- [x] tsc strict 全過
- [x] 386/386 API tests（+4 from baseline 382）
- [x] 11/11 migration 0036 schema tests
- [x] CI pending (build + lighthouse)

## V2-P6 progress

- [x] #287 rate limit module + migration 0035
- [x] #288 wire login (per-IP + per-email)
- [x] #289 wire signup + forgot-password + server-token
- [x] **本 PR** auth_audit_log foundation + wire signup/logout
- [ ] 下一片：wire 剩餘 OAuth endpoints
- [ ] 之後：cron job cleanup（30 天 D1 retention）+ Logpush → R2 long-term

🤖 Generated with [Claude Code](https://claude.com/claude-code)