### PR TITLE
feat(v2-p4): /api/dev/apps — OAuth client_app register + list

### DIFF
--- a/functions/api/dev/apps.ts
+++ b/functions/api/dev/apps.ts
@@ -1,0 +1,200 @@
+/**
+ * /api/dev/apps — V2-P4 OAuth client_app registration (developer dashboard backend)
+ *
+ * POST /api/dev/apps
+ *   Body: { app_name, redirect_uris[], client_type, app_description?, homepage_url?, allowed_scopes? }
+ *   Auth: requireSession
+ *   產 client_id (always) + client_secret (confidential only, **一次回傳**)
+ *   寫 client_apps with status='pending_review', owner_user_id=current user
+ *
+ * GET /api/dev/apps
+ *   Auth: requireSession
+ *   回 current user 擁有的 apps（不含 client_secret_hash）
+ *
+ * Security:
+ *   - client_secret 只在 POST response 出現一次（hash 過後存 DB）
+ *   - redirect_uri HTTPS only，localhost 例外（dev compat）
+ *   - 新 app status='pending_review'，ops 手動核可才 active
+ *   - owner_user_id 用 session uid，不接受 body 指定（防 ownership 偽造）
+ */
+import { parseJsonBody } from '../_utils';
+import { requireSessionUser } from '../_session';
+import { hashPassword } from '../../../src/server/password';
+import { AppError } from '../_errors';
+import type { Env } from '../_types';
+
+// 不用 _utils.json() — 它會把 snake_case key auto-camelCase，破 OAuth wire convention
+// (client_id / client_secret / redirect_uris 必須保持 snake_case，per RFC 6749)
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const VALID_CLIENT_TYPES = ['public', 'confidential'] as const;
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'];
+const APP_NAME_MIN = 2;
+const APP_NAME_MAX = 80;
+
+interface CreateAppBody {
+  app_name?: string;
+  app_description?: string;
+  homepage_url?: string;
+  redirect_uris?: string[];
+  allowed_scopes?: string[];
+  client_type?: 'public' | 'confidential';
+}
+
+/** RFC 4648 base32 lowercase encoder for human-readable client_id / client_secret. */
+function base32(bytes: Uint8Array): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+  let bits = 0;
+  let value = 0;
+  let result = '';
+  for (let i = 0; i < bytes.length; i++) {
+    value = (value << 8) | bytes[i]!;
+    bits += 8;
+    while (bits >= 5) {
+      result += alphabet[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) result += alphabet[(value << (5 - bits)) & 31];
+  return result;
+}
+
+function generateClientId(): string {
+  const bytes = new Uint8Array(12); // 96 bits ≈ ~20 base32 chars
+  crypto.getRandomValues(bytes);
+  return `tp_${base32(bytes)}`;
+}
+
+function generateClientSecret(): string {
+  const bytes = new Uint8Array(32); // 256 bits
+  crypto.getRandomValues(bytes);
+  return `tps_${base32(bytes)}`;
+}
+
+function validateRedirectUris(uris: unknown): string[] {
+  if (!Array.isArray(uris) || uris.length === 0) {
+    throw new AppError('DATA_VALIDATION', 'redirect_uris 必填且至少 1 個');
+  }
+  if (uris.length > 10) {
+    throw new AppError('DATA_VALIDATION', 'redirect_uris 最多 10 個');
+  }
+  return uris.map((u, i) => {
+    if (typeof u !== 'string' || u.length === 0) {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 格式無效`);
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(u);
+    } catch {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 不是合法 URL`);
+    }
+    const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    if (parsed.protocol !== 'https:' && !isLocalhost) {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 必須是 HTTPS（localhost 例外）`);
+    }
+    return u;
+  });
+}
+
+function validateScopes(scopes: unknown): string[] {
+  if (!Array.isArray(scopes)) return DEFAULT_SCOPES;
+  if (scopes.length === 0) return DEFAULT_SCOPES;
+  const cleaned = scopes
+    .filter((s): s is string => typeof s === 'string' && s.length > 0)
+    .map((s) => s.trim());
+  return cleaned.length === 0 ? DEFAULT_SCOPES : cleaned;
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const body = (await parseJsonBody<CreateAppBody>(context.request)) ?? {};
+
+  const appName = (body.app_name ?? '').trim();
+  if (!appName || appName.length < APP_NAME_MIN || appName.length > APP_NAME_MAX) {
+    throw new AppError('DATA_VALIDATION', `app_name 長度需 ${APP_NAME_MIN}-${APP_NAME_MAX} 字`);
+  }
+
+  const clientType = body.client_type ?? 'public';
+  if (!VALID_CLIENT_TYPES.includes(clientType)) {
+    throw new AppError('DATA_VALIDATION', 'client_type 必須是 public 或 confidential');
+  }
+
+  const redirectUris = validateRedirectUris(body.redirect_uris);
+  const allowedScopes = validateScopes(body.allowed_scopes);
+
+  const clientId = generateClientId();
+  let clientSecret: string | null = null;
+  let clientSecretHash: string | null = null;
+  if (clientType === 'confidential') {
+    clientSecret = generateClientSecret();
+    clientSecretHash = await hashPassword(clientSecret);
+  }
+
+  await context.env.DB
+    .prepare(
+      `INSERT INTO client_apps
+         (client_id, client_secret_hash, client_type, app_name, app_description,
+          homepage_url, redirect_uris, allowed_scopes, owner_user_id, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      clientId,
+      clientSecretHash,
+      clientType,
+      appName,
+      body.app_description ?? null,
+      body.homepage_url ?? null,
+      JSON.stringify(redirectUris),
+      JSON.stringify(allowedScopes),
+      session.uid,
+      'pending_review',
+    )
+    .run();
+
+  return snakeJson(
+    {
+      client_id: clientId,
+      client_secret: clientSecret,
+      app_name: appName,
+      client_type: clientType,
+      status: 'pending_review',
+      redirect_uris: redirectUris,
+      allowed_scopes: allowedScopes,
+    },
+    201,
+  );
+};
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+
+  const result = await context.env.DB
+    .prepare(
+      `SELECT client_id, client_type, app_name, app_description, homepage_url,
+              redirect_uris, allowed_scopes, status, created_at, updated_at
+       FROM client_apps
+       WHERE owner_user_id = ?
+       ORDER BY created_at DESC`,
+    )
+    .bind(session.uid)
+    .all<Record<string, unknown>>();
+
+  const apps = (result.results ?? []).map((row) => ({
+    ...row,
+    redirect_uris: typeof row.redirect_uris === 'string'
+      ? JSON.parse(row.redirect_uris) as unknown
+      : row.redirect_uris,
+    allowed_scopes: typeof row.allowed_scopes === 'string'
+      ? JSON.parse(row.allowed_scopes) as unknown
+      : row.allowed_scopes,
+  }));
+
+  return snakeJson({ apps });
+};
+
+

--- a/tests/api/dev-apps.test.ts
+++ b/tests/api/dev-apps.test.ts
@@ -1,0 +1,231 @@
+/**
+ * /api/dev/apps unit test — V2-P4 OAuth client_app management
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestPost, onRequestGet } from '../../functions/api/dev/apps';
+import { issueSession } from '../../functions/api/_session';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null, allResults: unknown[] = []) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    all: vi.fn().mockResolvedValue({ results: allResults }),
+  };
+}
+
+async function makeAuthedRequest(url: string, method: 'GET' | 'POST', body?: unknown): Promise<Request> {
+  // issueSession on a Response, then steal the cookie
+  const r = new Response(null);
+  await issueSession(
+    new Request('https://x.com', { headers: { 'CF-Connecting-IP': '1.1.1.1' } }),
+    r,
+    'user-1',
+    { SESSION_SECRET: 'test-secret-32-chars-long-enough' } as never,
+  );
+  const setCookie = r.headers.get('Set-Cookie') ?? '';
+  const sessionCookie = setCookie.split(';')[0] ?? '';
+
+  return new Request(url, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      Cookie: sessionCookie,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeContext(request: Request, env: MockEnv): Parameters<typeof onRequestPost>[0] {
+  return {
+    request,
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestPost>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('POST /api/dev/apps', () => {
+  it('401 when no session cookie', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/dev/apps', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ app_name: 'X', redirect_uris: ['https://x.com/cb'] }),
+    });
+    await expect(onRequestPost(makeContext(req, env))).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('400 DATA_VALIDATION when app_name missing', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      redirect_uris: ['https://x.com/cb'],
+    });
+    await expect(onRequestPost(makeContext(req, env))).rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('400 DATA_VALIDATION when redirect_uris missing or empty', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req1 = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'My App', redirect_uris: [],
+    });
+    await expect(onRequestPost(makeContext(req1, env))).rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('400 DATA_VALIDATION when redirect_uri is non-https (except localhost)', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'My App',
+      redirect_uris: ['http://attacker.com/cb'],
+    });
+    await expect(onRequestPost(makeContext(req, env))).rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('localhost redirect_uri is allowed (dev compat)', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: dbPrepare } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'Dev App',
+      redirect_uris: ['http://localhost:3000/cb'],
+    });
+    const res = await onRequestPost(makeContext(req, env));
+    expect(res.status).toBe(201);
+  }, 30_000);
+
+  it('201 returns client_id (always) + null client_secret for public client', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: dbPrepare } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'Public Mobile App',
+      client_type: 'public',
+      redirect_uris: ['https://example.com/cb'],
+    });
+    const res = await onRequestPost(makeContext(req, env));
+    expect(res.status).toBe(201);
+    const json = await res.json() as Record<string, unknown>;
+    expect(typeof json.client_id).toBe('string');
+    expect((json.client_id as string).startsWith('tp_')).toBe(true);
+    expect(json.client_secret).toBeNull();
+    expect(json.client_type).toBe('public');
+    expect(json.status).toBe('pending_review');
+  }, 30_000);
+
+  it('201 returns client_secret ONCE for confidential client', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: dbPrepare } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'Server Side App',
+      client_type: 'confidential',
+      redirect_uris: ['https://example.com/cb'],
+    });
+    const res = await onRequestPost(makeContext(req, env));
+    expect(res.status).toBe(201);
+    const json = await res.json() as Record<string, unknown>;
+    expect(typeof json.client_secret).toBe('string');
+    expect((json.client_secret as string).startsWith('tps_')).toBe(true);
+    // Verify hash (not plaintext) was stored in DB
+    const insertCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO client_apps'),
+    );
+    expect(insertCall).toBeTruthy();
+    // bind args: client_id, client_secret_hash, client_type, ...
+    const insertStmt = dbPrepare.mock.results.find(
+      (_, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
+                (dbPrepare.mock.calls[i][0] as string).includes('INSERT INTO client_apps'),
+    )?.value;
+    const bindArgs = (insertStmt as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
+    expect(bindArgs[1]).not.toBe(json.client_secret); // hash, not plaintext
+    expect(typeof bindArgs[1]).toBe('string'); // pbkdf2$... format
+  }, 30_000);
+
+  it('owner_user_id = session uid (cannot override via body)', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: dbPrepare } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'Test App',
+      redirect_uris: ['https://x.com/cb'],
+      owner_user_id: 'attacker-user-id', // ignored
+    } as Record<string, unknown>);
+    const res = await onRequestPost(makeContext(req, env));
+    expect(res.status).toBe(201);
+    const insertStmt = dbPrepare.mock.results.find(
+      (_, i) => typeof dbPrepare.mock.calls[i][0] === 'string' &&
+                (dbPrepare.mock.calls[i][0] as string).includes('INSERT INTO client_apps'),
+    )?.value;
+    const bindArgs = (insertStmt as { bind: { mock: { calls: unknown[][] } } }).bind.mock.calls[0];
+    // owner_user_id is the 9th positional bind arg (0-indexed: 8)
+    expect(bindArgs[8]).toBe('user-1'); // session uid, not 'attacker-user-id'
+  }, 30_000);
+
+  it('default scopes used when allowed_scopes not provided', async () => {
+    const dbPrepare = vi.fn().mockReturnValue(makeStmt());
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: dbPrepare } };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'POST', {
+      app_name: 'Test App',
+      redirect_uris: ['https://x.com/cb'],
+    });
+    const res = await onRequestPost(makeContext(req, env));
+    const json = await res.json() as { allowed_scopes: string[] };
+    expect(json.allowed_scopes).toEqual(['openid', 'profile', 'email']);
+  }, 30_000);
+});
+
+describe('GET /api/dev/apps', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/dev/apps', { method: 'GET' });
+    await expect(onRequestGet(makeContext(req, env))).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('200 returns user-owned apps with redirect_uris parsed from JSON', async () => {
+    const stmt = makeStmt(null, [
+      {
+        client_id: 'tp_abc',
+        client_type: 'public',
+        app_name: 'My App',
+        redirect_uris: '["https://example.com/cb"]',
+        allowed_scopes: '["openid","profile"]',
+        status: 'active',
+        created_at: '2026-04-20',
+      },
+    ]);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'GET');
+    const res = await onRequestGet(makeContext(req, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { apps: Array<Record<string, unknown>> };
+    expect(json.apps).toHaveLength(1);
+    expect(json.apps[0]?.redirect_uris).toEqual(['https://example.com/cb']);
+    expect(json.apps[0]?.allowed_scopes).toEqual(['openid', 'profile']);
+  });
+
+  it('filters by owner_user_id (session.uid)', async () => {
+    const stmt = makeStmt(null, []);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps', 'GET');
+    await onRequestGet(makeContext(req, env));
+    expect(stmt.bind).toHaveBeenCalledWith('user-1');
+    const sql = dbPrepare.mock.calls[0][0] as string;
+    expect(sql).toContain('WHERE owner_user_id = ?');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 第一片：開發者後台 backend，配合 2026-04-25 mockup（`docs/design-sessions` 第 5 surface — Developer Dashboard）落地。Pure parallel work，跟 V2-P6 PR (#288/#289/#290) 完全不衝突檔案。

### Endpoints

| Method | Path | Body / Response |
|--------|------|-----------------|
| POST | `/api/dev/apps` | 建 client_app，回 `client_id` + 一次性 `client_secret` |
| GET | `/api/dev/apps` | 列 current user 擁有的 apps |

### Security

- `requireSessionUser` 限定登入 user
- client_secret 用 PBKDF2 600k iterations hash 存 DB（reuse `src/server/password.ts`）
- client_secret 只在 POST response **回傳一次**，之後永不顯示
- `owner_user_id` 強制用 session.uid（body 試圖塞 `owner_user_id: 'attacker'` 會被忽略）
- redirect_uri 必須 HTTPS（localhost 例外 dev compat）
- 新 app 預設 `status='pending_review'`，ops 手動 active 才能用

### Wire format 細節

不用 `_utils.json()`：它會把 `client_id` 自動轉成 `clientId`（破 OAuth RFC 6749 wire convention）。改用 `snakeJson()` helper 保留 snake_case。

## Test plan

- [x] tsc strict 全過
- [x] 388/388 vitest API 全綠（+12 new dev/apps cases）
- [x] CI pending（build / lighthouse）

### Test 涵蓋

- 401 when no session
- 400 validation (app_name / redirect_uris / non-HTTPS / etc.)
- localhost redirect 允許
- 201 public client (no secret)
- 201 confidential client (secret returned once + hash, not plaintext, in DB)
- owner_user_id 強制 = session uid（body override 失效）
- 預設 scopes = `[openid, profile, email]`
- GET filter by owner_user_id
- redirect_uris JSON.parse from DB

## V2-P4 progress

- [x] **本 PR** POST + GET list
- [ ] 下一片 GET /api/dev/apps/:client_id detail + PATCH update + DELETE suspend
- [ ] React UI（mockup 已在 `/tmp/tp-v2-auth-mockups.html` section 5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)