### PR TITLE
feat(v2-p2): /api/oauth/verify + /send-verification — email verify flow

### DIFF
--- a/functions/api/oauth/send-verification.ts
+++ b/functions/api/oauth/send-verification.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/oauth/send-verification
+ * Body: { email: string }
+ *
+ * V2-P2 — Generate email verification token + (V2-P3 email service 接通) send link。
+ *
+ * Anti-enumeration：response 永遠 generic 200。Email 不存在或已驗證的 case 都
+ * 不洩漏給 caller — 只有真正 unverified user 才產 token。
+ *
+ * Flow:
+ *   1. lowercase email
+ *   2. SELECT users WHERE email = ? AND email_verified_at IS NULL
+ *   3. 若 found：產 token + D1Adapter upsert (24h TTL per V2-P2 spec)
+ *   4. 若 not found / already verified：silently no-op
+ *   5. Always return 200 generic
+ *
+ * V2-P3 next slice：integrate email service to actually send link
+ *   {origin}/api/oauth/verify?token={token}
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import { parseJsonBody } from '../_utils';
+import type { Env } from '../_types';
+
+interface SendVerificationBody {
+  email?: string;
+}
+
+const TTL_SEC = 24 * 60 * 60; // 24h per V2-P2 spec
+
+function generateVerifyToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let str = '';
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const body = (await parseJsonBody<SendVerificationBody>(context.request)) ?? {};
+  const email = (body.email ?? '').trim().toLowerCase();
+
+  const genericResponse = new Response(
+    JSON.stringify({ ok: true, message: '若帳號需要驗證，驗證信會寄至信箱' }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+
+  if (!email) return genericResponse;
+
+  // Look up unverified user
+  const user = await context.env.DB
+    .prepare(
+      `SELECT id FROM users WHERE email = ? AND email_verified_at IS NULL LIMIT 1`,
+    )
+    .bind(email)
+    .first<{ id: string }>();
+
+  if (!user) {
+    // Either email doesn't exist or already verified — silent no-op
+    return genericResponse;
+  }
+
+  // Generate + store token
+  const token = generateVerifyToken();
+  const adapter = new D1Adapter(context.env.DB, 'EmailVerification');
+  await adapter.upsert(
+    token,
+    { userId: user.id, email, createdAt: Date.now(), used: false },
+    TTL_SEC,
+  );
+
+  // V2-P3 next slice: send email with verify link {origin}/api/oauth/verify?token={token}
+  // 目前 token 只 in D1, dev 用 wrangler d1 exec 看；prod 等 email send 接通。
+
+  return genericResponse;
+};

--- a/functions/api/oauth/verify.ts
+++ b/functions/api/oauth/verify.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/oauth/verify?token=<token>
+ *
+ * V2-P2 — Email verification endpoint。User 點 email 連結 → 驗 token →
+ * UPDATE users.email_verified_at → 302 redirect /login?verified=1。
+ *
+ * Flow:
+ *   1. Extract token from query
+ *   2. D1Adapter find token (oauth_models name='EmailVerification')
+ *   3. If not found / expired / used → 302 /login?verify_error=expired
+ *   4. UPDATE users SET email_verified_at = ISO_NOW WHERE id = userId
+ *   5. destroy token (one-time use)
+ *   6. 302 /login?verified=1
+ *
+ * 為什麼 GET 而不 POST：使用者點 email 連結觸發。標準 email-link 模式都用 GET。
+ * Token 在 URL（不在 body）的安全考量：
+ *   - referrer leak：依靠 V2-P5 callback page 加 Referrer-Policy: no-referrer
+ *   - browser history：token 確實會留 history。短 TTL (24h) + one-time-use 限制 risk
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import type { Env } from '../_types';
+
+interface VerifyTokenPayload {
+  userId: string;
+  email: string;
+  createdAt: number;
+  used?: boolean;
+  [key: string]: unknown;
+}
+
+function redirect(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const token = (url.searchParams.get('token') ?? '').trim();
+
+  if (!token) {
+    return redirect('/login?verify_error=missing_token');
+  }
+
+  const adapter = new D1Adapter(context.env.DB, 'EmailVerification');
+  const tokenRow = (await adapter.find(token)) as VerifyTokenPayload | undefined;
+
+  if (!tokenRow) {
+    return redirect('/login?verify_error=expired');
+  }
+  if (tokenRow.used) {
+    return redirect('/login?verify_error=used');
+  }
+
+  // Mark user verified
+  try {
+    await context.env.DB
+      .prepare('UPDATE users SET email_verified_at = ? WHERE id = ?')
+      .bind(new Date().toISOString(), tokenRow.userId)
+      .run();
+  } catch {
+    // DB failure — token still valid, user can retry. Don't burn token.
+    return redirect('/login?verify_error=server_error');
+  }
+
+  // Destroy token (one-time use)
+  await adapter.destroy(token);
+
+  return redirect('/login?verified=1');
+};

--- a/tests/api/oauth-verify.test.ts
+++ b/tests/api/oauth-verify.test.ts
@@ -1,0 +1,221 @@
+/**
+ * /api/oauth/verify + /api/oauth/send-verification — V2-P2 email verification
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/verify';
+import { onRequestPost as onSendVerification } from '../../functions/api/oauth/send-verification';
+
+interface MockEnv {
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+}
+
+function makeVerifyContext(query: string, env: MockEnv): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(`https://x.com/api/oauth/verify?${query}`, { method: 'GET' }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+function makeSendContext(body: unknown, env: MockEnv): Parameters<typeof onSendVerification>[0] {
+  return {
+    request: new Request('https://x.com/api/oauth/send-verification', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onSendVerification>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/oauth/verify', () => {
+  it('302 → /login?verify_error=missing_token when token query absent', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestGet(makeVerifyContext('', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=missing_token');
+  });
+
+  it('302 → /login?verify_error=expired when token not found', async () => {
+    const stmt = makeStmt(null); // adapter.find returns nothing
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestGet(makeVerifyContext('token=fake-token', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=expired');
+  });
+
+  it('302 → /login?verified=1 happy path + UPDATE email_verified_at', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            userId: 'u-1',
+            email: 'u@x.com',
+            createdAt: Date.now() - 1000,
+            used: false,
+          }),
+          expires_at: Date.now() + 60_000,
+        });
+      }
+      if (sql.includes('UPDATE users SET email_verified_at')) return makeStmt();
+      if (sql.includes('DELETE FROM oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=valid-token', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verified=1');
+
+    // Assert UPDATE called
+    const updateCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE users SET email_verified_at'),
+    );
+    expect(updateCall).toBeTruthy();
+    // Assert DELETE called (one-time use)
+    const deleteCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCall).toBeTruthy();
+  });
+
+  it('302 → /login?verify_error=expired when token expired (D1Adapter.find returns null)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        // Adapter find filters expired internally — null returned
+        return makeStmt(null);
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=expired-token', env));
+    expect(res.headers.get('Location')).toBe('/login?verify_error=expired');
+  });
+
+  it('does NOT destroy token if UPDATE fails (so user can retry)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u', email: 'u@x.com', createdAt: 0, used: false }),
+          expires_at: Date.now() + 60_000,
+        });
+      }
+      if (sql.includes('UPDATE users SET email_verified_at')) {
+        const stmt = makeStmt();
+        stmt.run = vi.fn().mockRejectedValue(new Error('DB unavailable'));
+        return stmt;
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=t', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=server_error');
+
+    // DELETE was NOT called (token preserved for retry)
+    const deleteCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCall).toBeFalsy();
+  });
+});
+
+describe('POST /api/oauth/send-verification', () => {
+  it('200 generic response when email empty (no enum leak)', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onSendVerification(makeSendContext({}, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; message: string };
+    expect(json.ok).toBe(true);
+    expect(json.message).toContain('若帳號');
+  });
+
+  it('200 generic when email not found (no enum leak)', async () => {
+    const stmt = makeStmt(null); // user not found
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onSendVerification(makeSendContext({ email: 'nobody@x.com' }, env));
+    expect(res.status).toBe(200);
+    // No INSERT — user not found means no token generated
+  });
+
+  it('200 generic when email already verified (silent no-op)', async () => {
+    // Filter SQL excludes verified users → SELECT returns null
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id FROM users')) {
+        // emulate WHERE email_verified_at IS NULL filter excluding verified user
+        return makeStmt(null);
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onSendVerification(makeSendContext({ email: 'verified@x.com' }, env));
+    expect(res.status).toBe(200);
+    const insertCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertCall).toBeFalsy();
+  });
+
+  it('200 + INSERT EmailVerification token when email is unverified user', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id FROM users')) {
+        return makeStmt({ id: 'u-1' });
+      }
+      if (sql.includes('INSERT OR REPLACE INTO oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onSendVerification(makeSendContext({ email: 'unverified@x.com' }, env));
+    expect(res.status).toBe(200);
+
+    // Verify INSERT called with name='EmailVerification'
+    const insertIdx = dbPrepare.mock.calls.findIndex(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+    const insertStmt = dbPrepare.mock.results[insertIdx].value as { bind: { mock: { calls: unknown[][] } } };
+    const bindArgs = insertStmt.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe('EmailVerification'); // name
+    // bindArgs[1] = id (token), bindArgs[2] = payload JSON, bindArgs[3] = expires_at
+    expect(bindArgs[3]).toBe(Date.now() + 24 * 60 * 60 * 1000); // 24h TTL
+  });
+
+  it('Filters by email_verified_at IS NULL (only unverified users get tokens)', async () => {
+    const stmt = makeStmt(null);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onSendVerification(makeSendContext({ email: 'u@x.com' }, env));
+
+    const sql = dbPrepare.mock.calls[0][0] as string;
+    expect(sql).toContain('email_verified_at IS NULL');
+  });
+
+  it('email lowercase + trim before lookup', async () => {
+    const stmt = makeStmt(null);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onSendVerification(makeSendContext({ email: '  Mixed@EXAMPLE.com  ' }, env));
+    expect(stmt.bind).toHaveBeenCalledWith('mixed@example.com');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P2 email verification 雙端落地，配合先前 mockup（`/tmp/tp-v2-auth-mockups.html` section 2）。Pure parallel work — 跟 V2-P6 PR (#288/#289/#290) 跟 V2-P4 (#291) 完全不衝突檔案。

### Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/oauth/verify?token=…` | 點 email 連結驗 token + UPDATE users.email_verified_at + destroy token |
| POST | `/api/oauth/send-verification` | request 寄驗證信（V2-P3 接 email service 後實際寄出） |

### Flow

1. 使用者 signup → 前端自動 call `POST /api/oauth/send-verification`（這個 PR 不改 signup.ts，避免跟 #289 衝突）
2. user 收信點連結 → `GET /api/oauth/verify?token=xxx` → 302 `/login?verified=1`
3. 失敗 case → 302 `/login?verify_error=<missing_token|expired|used|server_error>`
4. 前端讀 `?verified=1` 顯示 toast，讀 `?verify_error=…` 顯示對應錯誤訊息

### Security 細節

- **Anti-enumeration**: send-verification 永遠回 generic 200，不分 email 存在/不存在/已驗證
- **Only-unverified**: SQL `WHERE email_verified_at IS NULL` 確保已驗證 user 無法觸發新 token
- **Token preservation on failure**: UPDATE users 失敗時**不**destroy token，user 可重試
- **TTL 24h** per V2-P2 spec
- **One-time use**: token destroy on success（一次性）

## Test plan

- [x] tsc strict 全過
- [x] 387/387 vitest API 全綠（+11 new cases）
- [x] CI pending

## Deferred

- Email actual send → V2-P3 email service integration（Resend/Mailgun）
- Signup auto-trigger send-verification — 等 #289 merge 後合併（不要在這 PR 改 signup.ts）

🤖 Generated with [Claude Code](https://claude.com/claude-code)