### PR TITLE
feat(v2-p5): /api/account/connected-apps — list + revoke OAuth grants

### DIFF
--- a/functions/api/account/connected-apps.ts
+++ b/functions/api/account/connected-apps.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /api/account/connected-apps
+ *
+ * V2-P5 — User-side list of granted OAuth client apps（mockup section 4
+ * 「已連結的應用」）。配 client_apps registry + Consent payload。
+ *
+ * Auth: requireSessionUser
+ *
+ * Response: { apps: [{ client_id, app_name, app_logo_url?, app_description?,
+ *                       homepage_url?, status, scopes[], granted_at }] }
+ *
+ * Note: 不顯示 access_tokens / refresh_tokens — 那是內部實作細節。User 看到
+ * 的是「我同意了什麼 app 用我的帳號」。
+ */
+import { requireSessionUser } from '../_session';
+import type { Env } from '../_types';
+
+interface ConsentPayloadShape {
+  user_id: string;
+  client_id: string;
+  scopes: string[];
+  grantedAt: number;
+}
+
+interface ConnectedAppRow {
+  consent_payload: string;
+  client_id: string;
+  app_name: string;
+  app_description: string | null;
+  app_logo_url: string | null;
+  homepage_url: string | null;
+  status: string;
+}
+
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+
+  const result = await context.env.DB
+    .prepare(
+      `SELECT
+         om.payload AS consent_payload,
+         ca.client_id, ca.app_name, ca.app_description, ca.app_logo_url,
+         ca.homepage_url, ca.status
+       FROM oauth_models om
+       JOIN client_apps ca ON json_extract(om.payload, '$.client_id') = ca.client_id
+       WHERE om.name = 'Consent'
+         AND json_extract(om.payload, '$.user_id') = ?
+         AND (om.expires_at > ? OR om.expires_at IS NULL)
+       ORDER BY json_extract(om.payload, '$.grantedAt') DESC`,
+    )
+    .bind(session.uid, Date.now())
+    .all<ConnectedAppRow>();
+
+  const apps = (result.results ?? []).map((row) => {
+    const payload = JSON.parse(row.consent_payload) as ConsentPayloadShape;
+    return {
+      client_id: row.client_id,
+      app_name: row.app_name,
+      app_description: row.app_description,
+      app_logo_url: row.app_logo_url,
+      homepage_url: row.homepage_url,
+      status: row.status,
+      scopes: payload.scopes,
+      granted_at: payload.grantedAt,
+    };
+  });
+
+  return snakeJson({ apps });
+};

--- a/functions/api/account/connected-apps/[client_id].ts
+++ b/functions/api/account/connected-apps/[client_id].ts
@@ -1,0 +1,63 @@
+/**
+ * DELETE /api/account/connected-apps/:client_id
+ *
+ * V2-P5 — Revoke OAuth client_app access for current user。Mockup section 4
+ * 「撤銷確認」modal 觸發。
+ *
+ * Auth: requireSessionUser
+ *
+ * Behavior:
+ *   1. Verify consent exists for (session.uid, client_id) — 404 if not
+ *   2. Destroy consent row (D1Adapter.destroy)
+ *   3. Destroy all AccessToken + RefreshToken rows for (user_id, client_id)
+ *      — 立即生效，不等 access_token 1h TTL
+ *
+ * Response: { ok: true, revoked_client_id }
+ *
+ * Note: 不對外暴露 user_id（response 只有 client_id），caller 推斷自己 session
+ */
+import { D1Adapter } from '../../../../src/server/oauth-d1-adapter';
+import { requireSessionUser } from '../../_session';
+import { AppError } from '../../_errors';
+import type { Env } from '../../_types';
+
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const clientId = (context.params as { client_id?: string }).client_id;
+
+  if (!clientId || typeof clientId !== 'string') {
+    throw new AppError('DATA_VALIDATION', 'client_id 必填');
+  }
+
+  // Verify consent exists
+  const consentKey = `${session.uid}:${clientId}`;
+  const consentAdapter = new D1Adapter(context.env.DB, 'Consent');
+  const existing = await consentAdapter.find(consentKey);
+  if (!existing) {
+    return snakeJson({ error: { code: 'CONSENT_NOT_FOUND', message: '此 app 未授權給你的帳號' } }, 404);
+  }
+
+  // Destroy consent
+  await consentAdapter.destroy(consentKey);
+
+  // Destroy all access + refresh tokens for this (user, client) pair
+  // 立即生效（不等 access_token 1h TTL）
+  await context.env.DB
+    .prepare(
+      `DELETE FROM oauth_models
+       WHERE name IN ('AccessToken', 'RefreshToken')
+         AND json_extract(payload, '$.user_id') = ?
+         AND json_extract(payload, '$.client_id') = ?`,
+    )
+    .bind(session.uid, clientId)
+    .run();
+
+  return snakeJson({ ok: true, revoked_client_id: clientId });
+};

--- a/tests/api/account-connected-apps.test.ts
+++ b/tests/api/account-connected-apps.test.ts
@@ -1,0 +1,241 @@
+/**
+ * /api/account/connected-apps — V2-P5 user-side OAuth grant management
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/account/connected-apps';
+import { onRequestDelete } from '../../functions/api/account/connected-apps/[client_id]';
+import { issueSession } from '../../functions/api/_session';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null, allResults: unknown[] = []) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    all: vi.fn().mockResolvedValue({ results: allResults }),
+  };
+}
+
+async function makeAuthedRequest(url: string, method: 'GET' | 'DELETE'): Promise<Request> {
+  const r = new Response(null);
+  await issueSession(
+    new Request('https://x.com', { headers: { 'CF-Connecting-IP': '1.1.1.1' } }),
+    r,
+    'user-1',
+    { SESSION_SECRET: 'test-secret-32-chars-long-enough' } as never,
+  );
+  const setCookie = r.headers.get('Set-Cookie') ?? '';
+  const sessionCookie = setCookie.split(';')[0] ?? '';
+  return new Request(url, {
+    method,
+    headers: { Cookie: sessionCookie },
+  });
+}
+
+function makeGetContext(request: Request, env: MockEnv): Parameters<typeof onRequestGet>[0] {
+  return {
+    request,
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+function makeDeleteContext(
+  request: Request,
+  env: MockEnv,
+  clientId: string,
+): Parameters<typeof onRequestDelete>[0] {
+  return {
+    request,
+    env: env as unknown as never,
+    params: { client_id: clientId } as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestDelete>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/account/connected-apps', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/account/connected-apps', { method: 'GET' });
+    await expect(onRequestGet(makeGetContext(req, env))).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('200 returns empty list when no consents', async () => {
+    const stmt = makeStmt(null, []);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps', 'GET');
+    const res = await onRequestGet(makeGetContext(req, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { apps: unknown[] };
+    expect(json.apps).toEqual([]);
+  });
+
+  it('200 returns connected apps with merged consent + client_app data', async () => {
+    const consentPayload = JSON.stringify({
+      user_id: 'user-1',
+      client_id: 'tp_abc',
+      scopes: ['openid', 'profile', 'trips.read'],
+      grantedAt: 1700000000000,
+    });
+    const stmt = makeStmt(null, [
+      {
+        consent_payload: consentPayload,
+        client_id: 'tp_abc',
+        app_name: 'Trip Buddy',
+        app_description: 'Trip companion app',
+        app_logo_url: null,
+        homepage_url: 'https://tripbuddy.example.com',
+        status: 'active',
+      },
+    ]);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps', 'GET');
+    const res = await onRequestGet(makeGetContext(req, env));
+    const json = await res.json() as { apps: Array<Record<string, unknown>> };
+
+    expect(json.apps).toHaveLength(1);
+    expect(json.apps[0]).toMatchObject({
+      client_id: 'tp_abc',
+      app_name: 'Trip Buddy',
+      scopes: ['openid', 'profile', 'trips.read'],
+      granted_at: 1700000000000,
+      status: 'active',
+    });
+  });
+
+  it('SQL filters by user_id from session (not from query)', async () => {
+    const stmt = makeStmt(null, []);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps', 'GET');
+    await onRequestGet(makeGetContext(req, env));
+
+    // bind args: session.uid + Date.now()
+    const bindCall = stmt.bind.mock.calls[0];
+    expect(bindCall[0]).toBe('user-1');
+    expect(typeof bindCall[1]).toBe('number');
+  });
+});
+
+describe('DELETE /api/account/connected-apps/:client_id', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/account/connected-apps/tp_abc', { method: 'DELETE' });
+    await expect(onRequestDelete(makeDeleteContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('400 DATA_VALIDATION when client_id param missing', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps/', 'DELETE');
+    await expect(onRequestDelete(makeDeleteContext(req, env, '')))
+      .rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('404 CONSENT_NOT_FOUND when no consent for (user, client)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt(null); // no consent
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps/unknown_app', 'DELETE');
+    const res = await onRequestDelete(makeDeleteContext(req, env, 'unknown_app'));
+    expect(res.status).toBe(404);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('CONSENT_NOT_FOUND');
+  });
+
+  it('200 destroys consent + all tokens for (user, client) pair', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            user_id: 'user-1',
+            client_id: 'tp_abc',
+            scopes: ['openid'],
+            grantedAt: Date.now(),
+          }),
+          expires_at: Date.now() + 60_000,
+        });
+      }
+      if (sql.includes('DELETE FROM oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps/tp_abc', 'DELETE');
+    const res = await onRequestDelete(makeDeleteContext(req, env, 'tp_abc'));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; revoked_client_id: string };
+    expect(json.ok).toBe(true);
+    expect(json.revoked_client_id).toBe('tp_abc');
+
+    // Two DELETE calls: consent destroy + bulk token cleanup
+    const deleteCalls = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCalls.length).toBe(2);
+
+    // Bulk token cleanup must filter by both user_id + client_id
+    const bulkCleanup = deleteCalls.find(
+      (c) => (c[0] as string).includes("name IN ('AccessToken', 'RefreshToken')"),
+    );
+    expect(bulkCleanup).toBeTruthy();
+  });
+
+  it('Cannot revoke another user\'s consent (cross-user attack)', async () => {
+    // user-1 tries to revoke client tp_abc; consent stored for user-2:tp_abc only
+    // adapter.find(`${session.uid}:tp_abc`) → key 'user-1:tp_abc' returns null
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt(null); // user-1 has no consent for tp_abc
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/connected-apps/tp_abc', 'DELETE');
+    const res = await onRequestDelete(makeDeleteContext(req, env, 'tp_abc'));
+    expect(res.status).toBe(404);
+
+    // No DELETE calls should have run (we 404'd before)
+    const deleteCalls = dbPrepare.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

V2-P5 user-side OAuth grant management，配合 mockup section 4「已連結的應用」(`/tmp/tp-v2-auth-mockups.html#connected`)。Pure parallel — 不衝突任何 in-flight PR。

### Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/account/connected-apps` | 列出 current user 授權的 client_apps |
| DELETE | `/api/account/connected-apps/:client_id` | 撤銷授權 + 立即殺 access_token + refresh_token |

### 重點實作

**Revocation effective immediately**：不只刪 consent row，還用 `json_extract(payload, ...)` 一次 `DELETE FROM oauth_models WHERE name IN ('AccessToken', 'RefreshToken') AND user_id=? AND client_id=?` — 不等 access_token 1h TTL。

**Cross-user attack 防禦**：撤銷時用 `consentKey = ${session.uid}:${clientId}` lookup。即使 user A 嘗試 DELETE client_id=tp_xyz（屬於 user B 的 grant），lookup user-A:tp_xyz 找不到 → 404，不會誤砍 user B 的資料。

**Wire format**：用 `snakeJson()` helper 保留 snake_case（不走 `_utils.json()` 的 camelCase 轉換 — OAuth RFC 6749 要求 client_id / granted_at 這類 key 保持 snake_case）。

## Test plan

- [x] tsc strict 全過
- [x] 385/385 vitest API 全綠（+9 new cases）
- [x] CI pending

### Test 涵蓋

- 401 when no session（GET / DELETE 都驗）
- GET empty list / JOIN-merged data / SQL filter by user_id from session
- DELETE 400 missing param / 404 not found / 200 destroys both consent + tokens
- DELETE cross-user attack: user-1 嘗試 revoke user-2 的 grant → 404

## V2-P5 progress

- [x] **本 PR** Connected apps API（user-side list + revoke）
- [ ] React UI（mockup section 4 已就緒，等本 API merge）
- [ ] RS256 JWT id_token signing（下一片）

🤖 Generated with [Claude Code](https://claude.com/claude-code)