### PR TITLE
feat(v2-p4): /api/dev/apps/:client_id — detail / patch / suspend

### DIFF
--- a/functions/api/dev/apps/[client_id].ts
+++ b/functions/api/dev/apps/[client_id].ts
@@ -1,0 +1,225 @@
+/**
+ * /api/dev/apps/:client_id — V2-P4 OAuth client_app detail / update / suspend
+ *
+ * GET /api/dev/apps/:client_id
+ *   require: session + ownership
+ *   return: full client_app row (no client_secret_hash)
+ *
+ * PATCH /api/dev/apps/:client_id
+ *   require: session + ownership
+ *   body: { app_name?, app_description?, app_logo_url?, homepage_url?,
+ *           redirect_uris?, allowed_scopes? }
+ *   cannot: change client_id / client_type / status / owner_user_id / secret hash
+ *
+ * DELETE /api/dev/apps/:client_id
+ *   require: session + ownership
+ *   soft-delete: UPDATE status='suspended'（保留 audit trail，server-authorize 會擋）
+ */
+import { parseJsonBody } from '../../_utils';
+import { requireSessionUser } from '../../_session';
+import { AppError } from '../../_errors';
+import type { Env } from '../../_types';
+
+interface ClientAppRow {
+  client_id: string;
+  client_type: string;
+  app_name: string;
+  app_description: string | null;
+  app_logo_url: string | null;
+  homepage_url: string | null;
+  redirect_uris: string;
+  allowed_scopes: string;
+  owner_user_id: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PatchAppBody {
+  app_name?: string;
+  app_description?: string | null;
+  app_logo_url?: string | null;
+  homepage_url?: string | null;
+  redirect_uris?: string[];
+  allowed_scopes?: string[];
+}
+
+const APP_NAME_MIN = 2;
+const APP_NAME_MAX = 80;
+
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function shapeAppRow(row: ClientAppRow): Record<string, unknown> {
+  return {
+    client_id: row.client_id,
+    client_type: row.client_type,
+    app_name: row.app_name,
+    app_description: row.app_description,
+    app_logo_url: row.app_logo_url,
+    homepage_url: row.homepage_url,
+    redirect_uris: JSON.parse(row.redirect_uris) as string[],
+    allowed_scopes: JSON.parse(row.allowed_scopes) as string[],
+    status: row.status,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function validateRedirectUris(uris: unknown): string[] {
+  if (!Array.isArray(uris) || uris.length === 0) {
+    throw new AppError('DATA_VALIDATION', 'redirect_uris 必填且至少 1 個');
+  }
+  if (uris.length > 10) {
+    throw new AppError('DATA_VALIDATION', 'redirect_uris 最多 10 個');
+  }
+  return uris.map((u, i) => {
+    if (typeof u !== 'string' || u.length === 0) {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 格式無效`);
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(u);
+    } catch {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 不是合法 URL`);
+    }
+    const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    if (parsed.protocol !== 'https:' && !isLocalhost) {
+      throw new AppError('DATA_VALIDATION', `redirect_uris[${i}] 必須是 HTTPS（localhost 例外）`);
+    }
+    return u;
+  });
+}
+
+async function loadOwnedApp(
+  db: Env['DB'],
+  clientId: string,
+  ownerUserId: string,
+): Promise<ClientAppRow | null> {
+  return db
+    .prepare(
+      `SELECT client_id, client_type, app_name, app_description, app_logo_url,
+              homepage_url, redirect_uris, allowed_scopes, owner_user_id, status,
+              created_at, updated_at
+       FROM client_apps
+       WHERE client_id = ? AND owner_user_id = ?`,
+    )
+    .bind(clientId, ownerUserId)
+    .first<ClientAppRow>();
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const clientId = (context.params as { client_id?: string }).client_id;
+  if (!clientId) throw new AppError('DATA_VALIDATION', 'client_id 必填');
+
+  const row = await loadOwnedApp(context.env.DB, clientId, session.uid);
+  if (!row) {
+    return snakeJson({ error: { code: 'APP_NOT_FOUND', message: '找不到此應用' } }, 404);
+  }
+  return snakeJson(shapeAppRow(row));
+};
+
+export const onRequestPatch: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const clientId = (context.params as { client_id?: string }).client_id;
+  if (!clientId) throw new AppError('DATA_VALIDATION', 'client_id 必填');
+
+  const existing = await loadOwnedApp(context.env.DB, clientId, session.uid);
+  if (!existing) {
+    return snakeJson({ error: { code: 'APP_NOT_FOUND', message: '找不到此應用' } }, 404);
+  }
+
+  const body = (await parseJsonBody<PatchAppBody>(context.request)) ?? {};
+
+  // Build dynamic UPDATE based on provided fields
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (body.app_name !== undefined) {
+    const name = body.app_name.trim();
+    if (name.length < APP_NAME_MIN || name.length > APP_NAME_MAX) {
+      throw new AppError('DATA_VALIDATION', `app_name 長度需 ${APP_NAME_MIN}-${APP_NAME_MAX} 字`);
+    }
+    updates.push('app_name = ?');
+    values.push(name);
+  }
+  if (body.app_description !== undefined) {
+    updates.push('app_description = ?');
+    values.push(body.app_description);
+  }
+  if (body.app_logo_url !== undefined) {
+    updates.push('app_logo_url = ?');
+    values.push(body.app_logo_url);
+  }
+  if (body.homepage_url !== undefined) {
+    updates.push('homepage_url = ?');
+    values.push(body.homepage_url);
+  }
+  if (body.redirect_uris !== undefined) {
+    const uris = validateRedirectUris(body.redirect_uris);
+    updates.push('redirect_uris = ?');
+    values.push(JSON.stringify(uris));
+  }
+  if (body.allowed_scopes !== undefined) {
+    if (!Array.isArray(body.allowed_scopes) || body.allowed_scopes.length === 0) {
+      throw new AppError('DATA_VALIDATION', 'allowed_scopes 必須是非空陣列');
+    }
+    const cleaned = body.allowed_scopes
+      .filter((s): s is string => typeof s === 'string' && s.length > 0)
+      .map((s) => s.trim());
+    if (cleaned.length === 0) {
+      throw new AppError('DATA_VALIDATION', 'allowed_scopes 必須包含有效字串');
+    }
+    updates.push('allowed_scopes = ?');
+    values.push(JSON.stringify(cleaned));
+  }
+
+  if (updates.length === 0) {
+    throw new AppError('DATA_VALIDATION', '沒有可更新的欄位');
+  }
+
+  updates.push("updated_at = datetime('now')");
+
+  await context.env.DB
+    .prepare(
+      `UPDATE client_apps SET ${updates.join(', ')} WHERE client_id = ? AND owner_user_id = ?`,
+    )
+    .bind(...values, clientId, session.uid)
+    .run();
+
+  // Return updated row
+  const updated = await loadOwnedApp(context.env.DB, clientId, session.uid);
+  if (!updated) {
+    throw new AppError('SYS_INTERNAL', 'app 更新後讀取失敗');
+  }
+  return snakeJson(shapeAppRow(updated));
+};
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const clientId = (context.params as { client_id?: string }).client_id;
+  if (!clientId) throw new AppError('DATA_VALIDATION', 'client_id 必填');
+
+  const existing = await loadOwnedApp(context.env.DB, clientId, session.uid);
+  if (!existing) {
+    return snakeJson({ error: { code: 'APP_NOT_FOUND', message: '找不到此應用' } }, 404);
+  }
+
+  // Soft-delete: status='suspended'。保留 audit trail；server-authorize.ts 會
+  // 擋 status != 'active'，所以 effective immediately。
+  await context.env.DB
+    .prepare(
+      `UPDATE client_apps
+       SET status = 'suspended', updated_at = datetime('now')
+       WHERE client_id = ? AND owner_user_id = ?`,
+    )
+    .bind(clientId, session.uid)
+    .run();
+
+  return snakeJson({ ok: true, suspended_client_id: clientId });
+};

--- a/tests/api/dev-apps-detail.test.ts
+++ b/tests/api/dev-apps-detail.test.ts
@@ -1,0 +1,306 @@
+/**
+ * /api/dev/apps/:client_id — V2-P4 detail / update / suspend
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  onRequestGet,
+  onRequestPatch,
+  onRequestDelete,
+} from '../../functions/api/dev/apps/[client_id]';
+import { issueSession } from '../../functions/api/_session';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+}
+
+const SAMPLE_APP_ROW = {
+  client_id: 'tp_abc',
+  client_type: 'public',
+  app_name: 'Trip Buddy',
+  app_description: 'Travel companion',
+  app_logo_url: null,
+  homepage_url: 'https://example.com',
+  redirect_uris: '["https://example.com/cb"]',
+  allowed_scopes: '["openid","profile"]',
+  owner_user_id: 'user-1',
+  status: 'active',
+  created_at: '2026-04-20',
+  updated_at: '2026-04-22',
+};
+
+async function makeAuthedRequest(url: string, method: string, body?: unknown): Promise<Request> {
+  const r = new Response(null);
+  await issueSession(
+    new Request('https://x.com', { headers: { 'CF-Connecting-IP': '1.1.1.1' } }),
+    r,
+    'user-1',
+    { SESSION_SECRET: 'test-secret-32-chars-long-enough' } as never,
+  );
+  const setCookie = r.headers.get('Set-Cookie') ?? '';
+  const sessionCookie = setCookie.split(';')[0] ?? '';
+  return new Request(url, {
+    method,
+    headers: {
+      Cookie: sessionCookie,
+      'content-type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeContext(
+  request: Request,
+  env: MockEnv,
+  clientId: string,
+): Parameters<typeof onRequestGet>[0] {
+  return {
+    request,
+    env: env as unknown as never,
+    params: { client_id: clientId } as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/dev/apps/:client_id', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/dev/apps/tp_abc', { method: 'GET' });
+    await expect(onRequestGet(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('404 APP_NOT_FOUND when client_id not owned by user', async () => {
+    const stmt = makeStmt(null); // not found
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_xyz', 'GET');
+    const res = await onRequestGet(makeContext(req, env, 'tp_xyz'));
+    expect(res.status).toBe(404);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('APP_NOT_FOUND');
+  });
+
+  it('200 returns full row with parsed redirect_uris + allowed_scopes', async () => {
+    const stmt = makeStmt(SAMPLE_APP_ROW);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'GET');
+    const res = await onRequestGet(makeContext(req, env, 'tp_abc'));
+    expect(res.status).toBe(200);
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.client_id).toBe('tp_abc');
+    expect(json.app_name).toBe('Trip Buddy');
+    expect(json.redirect_uris).toEqual(['https://example.com/cb']);
+    expect(json.allowed_scopes).toEqual(['openid', 'profile']);
+  });
+
+  it('SQL filters by both client_id AND owner_user_id (cross-user attack defence)', async () => {
+    const stmt = makeStmt(SAMPLE_APP_ROW);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'GET');
+    await onRequestGet(makeContext(req, env, 'tp_abc'));
+
+    const sql = dbPrepare.mock.calls[0][0] as string;
+    expect(sql).toContain('WHERE client_id = ? AND owner_user_id = ?');
+    expect(stmt.bind).toHaveBeenCalledWith('tp_abc', 'user-1');
+  });
+});
+
+describe('PATCH /api/dev/apps/:client_id', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/dev/apps/tp_abc', { method: 'PATCH' });
+    await expect(onRequestPatch(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('404 when client_id not owned', async () => {
+    const stmt = makeStmt(null);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_xyz', 'PATCH', {
+      app_name: 'New Name',
+    });
+    const res = await onRequestPatch(makeContext(req, env, 'tp_xyz'));
+    expect(res.status).toBe(404);
+  });
+
+  it('400 when no patchable fields provided', async () => {
+    const dbPrepare = vi.fn().mockImplementation(() => makeStmt(SAMPLE_APP_ROW));
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'PATCH', {});
+    await expect(onRequestPatch(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('400 when app_name too short', async () => {
+    const dbPrepare = vi.fn().mockImplementation(() => makeStmt(SAMPLE_APP_ROW));
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'PATCH', {
+      app_name: 'X',
+    });
+    await expect(onRequestPatch(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('400 when redirect_uris contains non-HTTPS', async () => {
+    const dbPrepare = vi.fn().mockImplementation(() => makeStmt(SAMPLE_APP_ROW));
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'PATCH', {
+      redirect_uris: ['http://attacker.com/cb'],
+    });
+    await expect(onRequestPatch(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('200 updates allowed fields + returns updated row', async () => {
+    let callCount = 0;
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT')) {
+        // First select returns existing, second select returns updated
+        callCount++;
+        if (callCount === 1) return makeStmt(SAMPLE_APP_ROW);
+        return makeStmt({ ...SAMPLE_APP_ROW, app_name: 'New Name' });
+      }
+      if (sql.includes('UPDATE client_apps')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'PATCH', {
+      app_name: 'New Name',
+      app_description: 'Updated description',
+    });
+    const res = await onRequestPatch(makeContext(req, env, 'tp_abc'));
+    expect(res.status).toBe(200);
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.app_name).toBe('New Name');
+
+    // Verify UPDATE called with the right fields
+    const updateCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE client_apps'),
+    );
+    expect(updateCall).toBeTruthy();
+    const updateSql = updateCall![0] as string;
+    expect(updateSql).toContain('app_name = ?');
+    expect(updateSql).toContain('app_description = ?');
+    expect(updateSql).toContain('updated_at = datetime');
+  });
+
+  it('Cannot update protected fields (client_id / client_type / status / owner_user_id)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT')) return makeStmt(SAMPLE_APP_ROW);
+      if (sql.includes('UPDATE')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'PATCH', {
+      app_name: 'New',
+      client_id: 'malicious',          // ignored
+      client_type: 'confidential',      // ignored
+      status: 'active',                 // ignored
+      owner_user_id: 'attacker',        // ignored
+    } as Record<string, unknown>);
+    await onRequestPatch(makeContext(req, env, 'tp_abc'));
+
+    const updateCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE client_apps'),
+    );
+    const sql = updateCall![0] as string;
+    // None of the protected columns should appear in UPDATE SET clause
+    expect(sql).not.toMatch(/SET[^W]*client_id\s*=/);
+    expect(sql).not.toMatch(/SET[^W]*client_type\s*=/);
+    expect(sql).not.toMatch(/SET[^W]*status\s*=/);
+    expect(sql).not.toMatch(/SET[^W]*owner_user_id\s*=/);
+  });
+});
+
+describe('DELETE /api/dev/apps/:client_id', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/dev/apps/tp_abc', { method: 'DELETE' });
+    await expect(onRequestDelete(makeContext(req, env, 'tp_abc')))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('404 when client_id not owned', async () => {
+    const stmt = makeStmt(null);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: vi.fn().mockReturnValue(stmt) },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_xyz', 'DELETE');
+    const res = await onRequestDelete(makeContext(req, env, 'tp_xyz'));
+    expect(res.status).toBe(404);
+  });
+
+  it('200 soft-deletes (status=suspended) preserving audit trail', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT')) return makeStmt(SAMPLE_APP_ROW);
+      if (sql.includes('UPDATE client_apps')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/dev/apps/tp_abc', 'DELETE');
+    const res = await onRequestDelete(makeContext(req, env, 'tp_abc'));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; suspended_client_id: string };
+    expect(json.ok).toBe(true);
+    expect(json.suspended_client_id).toBe('tp_abc');
+
+    // Verify UPDATE status='suspended' (NOT physical DELETE)
+    const updateCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes("status = 'suspended'"),
+    );
+    expect(updateCall).toBeTruthy();
+    // No DELETE FROM client_apps anywhere
+    const deleteCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM client_apps'),
+    );
+    expect(deleteCall).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

V2-P4 dev dashboard backend 收尾：補齊 `:client_id` 動態路由的 GET / PATCH / DELETE。配合 PR #291（POST + GET list）就形成完整 CRUD。

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/dev/apps/:client_id` | 詳情 |
| PATCH | `/api/dev/apps/:client_id` | 部分更新 |
| DELETE | `/api/dev/apps/:client_id` | soft-delete (status='suspended') |

### 安全要點

- **Ownership 強制**：所有 endpoint SQL `WHERE client_id = ? AND owner_user_id = ?` — user A 拿不到 / 改不到 user B 的 app（即使 client_id 對）
- **Protected fields**：PATCH body 試圖改 `client_id` / `client_type` / `status` / `owner_user_id` 全部被忽略（dynamic UPDATE 只取 whitelist 欄位）
- **Soft delete**：DELETE 改 `status='suspended'` 而非 `DELETE FROM`，保留 audit trail；server-authorize 已會擋 status != 'active'
- **Validation 重用 POST 規則**：app_name 2-80 字、redirect_uris HTTPS only（localhost 例外）

### 依賴

依賴 PR #291（建 `functions/api/dev/apps.ts` 父路徑）。**Merge 順序：先 #291 → 本 PR。**

## Test plan

- [x] tsc strict 全過
- [x] 390/390 vitest API 全綠（+14 new cases）

### Test 涵蓋

- GET: 401 / 404 / JSON parse / cross-user SQL filter
- PATCH: 401 / 404 / 400 no-fields / 400 short-name / 400 non-https-uri / 200 happy / 200 protected-fields-ignored
- DELETE: 401 / 404 / 200 soft-delete (UPDATE not DELETE FROM)

## V2-P4 progress

- [x] #291 POST + GET list
- [x] **本 PR** GET detail + PATCH + DELETE
- [ ] React UI（mockup section 5「開發者後台」已就緒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)