### PR TITLE
feat(v2-p3): email service module + transactional templates (Resend)

### DIFF
--- a/functions/api/_types.ts
+++ b/functions/api/_types.ts
@@ -20,4 +20,7 @@ export interface Env {
   SESSION_SECRET?: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
+  // V2-P3 email service (Resend)
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string; // e.g. 'Tripline <no-reply@trip-planner-dby.pages.dev>'
 }

--- a/src/server/email-templates.ts
+++ b/src/server/email-templates.ts
@@ -1,0 +1,131 @@
+/**
+ * Email HTML templates — V2-P3 transactional emails (繁體中文)
+ *
+ * 設計原則 (per V2 design doc Email section)：
+ *   - Inline CSS（外部 CSS 在 email client 不可靠）
+ *   - Table-based layout（max compatibility）
+ *   - Terracotta brand color（#D97848）
+ *   - 簡單 HTML，不用 image / external font
+ *   - 同時提供 plain text fallback（spam filter 友好）
+ *
+ * Templates:
+ *   - emailVerification(verifyUrl, displayName?) — 註冊後驗 email
+ *   - passwordReset(resetUrl, displayName?) — 忘記密碼重設
+ *   - passwordChangedConfirm(displayName?) — 密碼已更改通知
+ *
+ * 不放 user-controlled HTML 進 template — 全部 user input (displayName) 過
+ * `escapeHtml` 防 XSS。連結 URL 由 caller 組好（已 encodeURIComponent token）。
+ */
+
+export interface EmailTemplate {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const BRAND_COLOR = '#D97848';
+const BRAND_DEEP = '#B85C2E';
+const BG_COLOR = '#FFFBF5';
+const TEXT_COLOR = '#2A1F18';
+const MUTED_COLOR = '#6F5A47';
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function shellHtml(innerHtml: string): string {
+  return `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0; padding:24px; font-family: 'Helvetica Neue', Arial, 'Noto Sans TC', sans-serif; background:${BG_COLOR}; color:${TEXT_COLOR}; line-height:1.5;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px; margin:0 auto;">
+<tr><td>
+<div style="text-align:center; padding:24px 0; font-size:18px; font-weight:800; letter-spacing:-0.02em;">
+  <span style="color:${BRAND_COLOR};">●</span> Tripline
+</div>
+${innerHtml}
+<div style="text-align:center; padding:24px 0 0; font-size:12px; color:${MUTED_COLOR};">
+  本信件自動發出，請勿直接回覆。<br>
+  Tripline · 行程共享網站
+</div>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function ctaButton(url: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px auto;">
+<tr><td style="border-radius:10px; background:${BRAND_COLOR};">
+<a href="${escapeHtml(url)}" style="display:inline-block; padding:14px 32px; color:#fff; text-decoration:none; font-size:15px; font-weight:600; border-radius:10px;">${escapeHtml(label)}</a>
+</td></tr>
+</table>`;
+}
+
+export function emailVerification(verifyUrl: string, displayName?: string | null): EmailTemplate {
+  const greetName = displayName ? `${escapeHtml(displayName)}，` : '';
+  return {
+    subject: '驗證您的 Tripline 帳號',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">歡迎加入 Tripline${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">${greetName}請點擊下方按鈕驗證您的 email，完成註冊。</p>
+  ${ctaButton(verifyUrl, '驗證 Email')}
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">或複製以下連結到瀏覽器：</p>
+  <p style="margin:0 0 16px; font-size:12px; color:${MUTED_COLOR}; word-break:break-all;"><a href="${escapeHtml(verifyUrl)}" style="color:${BRAND_DEEP}; text-decoration:none;">${escapeHtml(verifyUrl)}</a></p>
+  <p style="margin:0; font-size:12px; color:${MUTED_COLOR};">此連結 24 小時內有效。如果不是您本人申請，請忽略此信件。</p>
+</div>
+`),
+    text: `歡迎加入 Tripline${displayName ? `，${displayName}` : ''}\n\n請點擊以下連結驗證您的 email：\n${verifyUrl}\n\n連結 24 小時內有效。如果不是您本人申請，請忽略此信件。\n\n— Tripline`,
+  };
+}
+
+export function passwordReset(resetUrl: string, displayName?: string | null): EmailTemplate {
+  return {
+    subject: '重設您的 Tripline 密碼',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">重設密碼${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">我們收到您重設密碼的請求。點擊下方按鈕設定新密碼：</p>
+  ${ctaButton(resetUrl, '重設密碼')}
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">或複製以下連結到瀏覽器：</p>
+  <p style="margin:0 0 16px; font-size:12px; color:${MUTED_COLOR}; word-break:break-all;"><a href="${escapeHtml(resetUrl)}" style="color:${BRAND_DEEP}; text-decoration:none;">${escapeHtml(resetUrl)}</a></p>
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">為了您的帳號安全：</p>
+  <ul style="margin:0; padding-left:20px; font-size:12px; color:${MUTED_COLOR};">
+    <li>此連結 1 小時內有效</li>
+    <li>連結只能使用一次</li>
+    <li>重設後您所有裝置將被登出，需重新登入</li>
+  </ul>
+  <p style="margin:16px 0 0; font-size:12px; color:${MUTED_COLOR};">如果不是您本人申請，可忽略此信件。您的密碼不會變更。</p>
+</div>
+`),
+    text: `重設密碼${displayName ? `，${displayName}` : ''}\n\n我們收到您重設密碼的請求。請點擊以下連結設定新密碼：\n${resetUrl}\n\n· 此連結 1 小時內有效\n· 連結只能使用一次\n· 重設後您所有裝置將被登出\n\n如果不是您本人申請，可忽略此信件。\n\n— Tripline`,
+  };
+}
+
+export function passwordChangedConfirm(displayName?: string | null): EmailTemplate {
+  return {
+    subject: 'Tripline 密碼已更改',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">密碼已更改${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">您的 Tripline 帳號密碼已成功更改。為了安全，您所有裝置上的登入已自動登出。</p>
+  <p style="margin:0 0 8px; font-size:14px; color:${MUTED_COLOR};">如果不是您本人操作：</p>
+  <ul style="margin:0; padding-left:20px; font-size:13px; color:${MUTED_COLOR};">
+    <li>立即重設密碼防止帳號被盜用</li>
+    <li>檢查最近的登入裝置（設定 → 登入裝置）</li>
+    <li>有疑問請聯絡我們</li>
+  </ul>
+</div>
+`),
+    text: `密碼已更改${displayName ? `，${displayName}` : ''}\n\n您的 Tripline 帳號密碼已成功更改。為了安全，您所有裝置已自動登出。\n\n如果不是您本人操作：\n· 立即重設密碼\n· 檢查最近的登入裝置\n· 有疑問請聯絡我們\n\n— Tripline`,
+  };
+}

--- a/src/server/email.ts
+++ b/src/server/email.ts
@@ -1,0 +1,100 @@
+/**
+ * Email service — V2-P3 transactional email send via Resend API
+ *
+ * 為何 Resend：Workers fetch-friendly、3k/月免費、developer-first docs（per
+ * V2-OAuth design doc Open Question #1 + autoplan finding）。
+ *
+ * 為何不 Cloudflare Email Routing：forward-only (inbound)，outbound 仍 beta，
+ * 不適合 production 主流程。
+ *
+ * Usage:
+ *   import { sendEmail, type EmailEnv } from 'src/server/email';
+ *   await sendEmail(env, {
+ *     to: 'user@example.com',
+ *     subject: '驗證您的 Tripline 帳號',
+ *     html: ...,
+ *     text: ...,
+ *   });
+ *
+ * Best-effort：Resend API 失敗 → 拋 EmailError，caller 決定是否阻擋業務流程。
+ *   - signup verify email failure → user 看 fallback 訊息「無法寄信，請使用重寄」
+ *   - password reset failure → 同樣 fallback
+ *   - 視為「不影響 user 帳號狀態」的 best-effort，但 audit log 仍記錄 failure
+ */
+
+export interface EmailEnv {
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string; // e.g. 'Tripline <no-reply@trip-planner-dby.pages.dev>'
+}
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface SendEmailResult {
+  ok: true;
+  /** Resend message id (for tracking) */
+  id: string;
+}
+
+export class EmailError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+
+export async function sendEmail(
+  env: EmailEnv,
+  params: SendEmailParams,
+): Promise<SendEmailResult> {
+  if (!env.RESEND_API_KEY) {
+    throw new EmailError('RESEND_API_KEY not configured', 500, null);
+  }
+  if (!env.EMAIL_FROM) {
+    throw new EmailError('EMAIL_FROM not configured', 500, null);
+  }
+
+  const body = {
+    from: env.EMAIL_FROM,
+    to: [params.to],
+    subject: params.subject,
+    html: params.html,
+    ...(params.text ? { text: params.text } : {}),
+  };
+
+  const res = await fetch(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  let respBody: unknown = null;
+  try {
+    respBody = await res.json();
+  } catch {
+    /* non-json response — keep null */
+  }
+
+  if (!res.ok) {
+    throw new EmailError(`Resend API ${res.status}`, res.status, respBody);
+  }
+
+  const idVal = (respBody as Record<string, unknown> | null)?.id;
+  if (typeof idVal !== 'string') {
+    throw new EmailError('Resend response missing id', res.status, respBody);
+  }
+  return { ok: true, id: idVal };
+}

--- a/tests/api/email-module.test.ts
+++ b/tests/api/email-module.test.ts
@@ -1,0 +1,171 @@
+/**
+ * src/server/email.ts + email-templates.ts unit test — V2-P3
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendEmail, EmailError } from '../../src/server/email';
+import {
+  emailVerification,
+  passwordReset,
+  passwordChangedConfirm,
+} from '../../src/server/email-templates';
+
+const ENV_OK = {
+  RESEND_API_KEY: 're_test_key_123',
+  EMAIL_FROM: 'Tripline <no-reply@example.com>',
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sendEmail', () => {
+  it('throws EmailError when RESEND_API_KEY missing', async () => {
+    await expect(sendEmail({ EMAIL_FROM: 'a@b.com' }, {
+      to: 'u@x.com', subject: 's', html: '<p>x</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+
+  it('throws EmailError when EMAIL_FROM missing', async () => {
+    await expect(sendEmail({ RESEND_API_KEY: 'k' }, {
+      to: 'u@x.com', subject: 's', html: '<p>x</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+
+  it('POSTs to Resend API with Bearer auth + JSON body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg-123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await sendEmail(ENV_OK, {
+      to: 'user@example.com',
+      subject: 'Test',
+      html: '<p>hello</p>',
+      text: 'hello',
+    });
+
+    expect(result.id).toBe('msg-123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(opts.method).toBe('POST');
+    expect((opts.headers as Record<string, string>).Authorization).toBe(
+      'Bearer re_test_key_123',
+    );
+    expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body.from).toBe('Tripline <no-reply@example.com>');
+    expect(body.to).toEqual(['user@example.com']);
+    expect(body.subject).toBe('Test');
+    expect(body.html).toBe('<p>hello</p>');
+    expect(body.text).toBe('hello');
+  });
+
+  it('omits text field when not provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'm' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await sendEmail(ENV_OK, { to: 'u@x.com', subject: 's', html: '<p>h</p>' });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+    ) as Record<string, unknown>;
+    expect(body.text).toBeUndefined();
+  });
+
+  it('throws EmailError on Resend API error (4xx/5xx)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_api_key' }), { status: 401 }),
+    ));
+    await expect(sendEmail(ENV_OK, {
+      to: 'u@x.com', subject: 's', html: '<p>h</p>',
+    })).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('throws EmailError when response missing id', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    ));
+    await expect(sendEmail(ENV_OK, {
+      to: 'u@x.com', subject: 's', html: '<p>h</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+});
+
+describe('email-templates', () => {
+  describe('emailVerification', () => {
+    it('subject + URL embedded in html + text', () => {
+      const tpl = emailVerification('https://x.com/verify?token=abc', 'Ray');
+      expect(tpl.subject).toContain('驗證');
+      expect(tpl.html).toContain('https://x.com/verify?token=abc');
+      expect(tpl.html).toContain('Ray');
+      expect(tpl.text).toContain('https://x.com/verify?token=abc');
+    });
+
+    it('no displayName works (anonymous greeting)', () => {
+      const tpl = emailVerification('https://x.com/v?t=t');
+      expect(tpl.html).toContain('歡迎加入 Tripline');
+    });
+
+    it('escapes HTML in displayName (XSS defence)', () => {
+      const tpl = emailVerification('https://x.com/v?t=t', '<script>alert(1)</script>');
+      expect(tpl.html).not.toContain('<script>alert(1)</script>');
+      expect(tpl.html).toContain('&lt;script&gt;');
+    });
+
+    it('escapes HTML in URL (anti-injection)', () => {
+      const tpl = emailVerification('https://x.com/v?t=" onclick=alert(1)');
+      expect(tpl.html).not.toContain('" onclick=alert(1)');
+      expect(tpl.html).toContain('&quot;');
+    });
+  });
+
+  describe('passwordReset', () => {
+    it('embeds reset URL + mentions 1h validity', () => {
+      const tpl = passwordReset('https://x.com/reset?token=xyz');
+      expect(tpl.html).toContain('https://x.com/reset?token=xyz');
+      expect(tpl.html).toContain('1 小時');
+      expect(tpl.html).toContain('一次');
+    });
+
+    it('mentions all-device logout', () => {
+      const tpl = passwordReset('https://x.com/r');
+      expect(tpl.html).toContain('登出');
+    });
+
+    it('escapes HTML in displayName', () => {
+      const tpl = passwordReset('https://x.com/r', '"><img src=x>');
+      expect(tpl.html).not.toContain('"><img src=x>');
+      expect(tpl.html).toContain('&quot;');
+    });
+  });
+
+  describe('passwordChangedConfirm', () => {
+    it('subject + recovery instructions if not user', () => {
+      const tpl = passwordChangedConfirm('Ray');
+      expect(tpl.subject).toContain('密碼');
+      expect(tpl.html).toContain('Ray');
+      expect(tpl.html).toContain('立即');
+      expect(tpl.text).toContain('登入');
+    });
+  });
+
+  describe('all templates produce non-empty plain-text fallback', () => {
+    it.each([
+      emailVerification('https://x.com/v?t=a'),
+      passwordReset('https://x.com/r?t=b'),
+      passwordChangedConfirm('user'),
+    ])('template has both html and text', (tpl) => {
+      expect(tpl.html.length).toBeGreaterThan(50);
+      expect(tpl.text.length).toBeGreaterThan(20);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

V2-P3 email infrastructure：`sendEmail()` helper + 3 transactional templates（驗證 / 重設 / 密碼已改通知）。為 V2 OAuth flow 接通 email 寄送 — 下一片 wire 進 signup / forgot-password / reset-password / send-verification。

### Modules

| File | Purpose |
|------|---------|
| `src/server/email.ts` | `sendEmail(env, params)` — Resend API client (fetch + Bearer auth), throws `EmailError` on failure |
| `src/server/email-templates.ts` | 3 templates 繁中：`emailVerification`, `passwordReset`, `passwordChangedConfirm` |

### Design 原則

- **Inline CSS**（外部 CSS 在 email client 不可靠）
- **Table-based layout**（最大相容性）
- **Terracotta** brand color `#D97848`
- **Plain text fallback**（spam filter 友好）
- **escapeHtml 所有 user input + URL**（測試 cover script tag / img onclick / quote injection）

### Env vars

```
RESEND_API_KEY=re_xxx                                  # resend.com signup
EMAIL_FROM=Tripline <no-reply@trip-planner-dby.pages.dev>
```

兩個都未設 → 寄信失敗 throws EmailError，caller 決定 best-effort vs blocking。

## Test plan

- [x] tsc strict 全過
- [x] 17 vitest cases 全綠
- [x] CI pending

### Test 涵蓋

- **sendEmail** (6): 缺 RESEND_API_KEY / 缺 EMAIL_FROM / Resend POST shape / text 可選 / Resend API error / 缺 id field
- **emailVerification** (4): subject 含驗證 / URL embed / 無 displayName 也行 / **XSS escape**（script + URL injection）
- **passwordReset** (3): URL embed / 1h + 一次性 + 全裝置登出 copy / displayName XSS escape
- **passwordChangedConfirm** (1): recovery 指引 copy
- **all templates non-empty fallback** (3 it.each)

## V2-P3 progress

- [x] **本 PR** email service module + templates
- [ ] Wire `sendEmail()` into signup → emailVerification（等 #289 merge）
- [ ] Wire into forgot-password → passwordReset（等 #289 merge）
- [ ] Wire into reset-password → passwordChangedConfirm
- [ ] Wire into /api/oauth/send-verification → emailVerification（等 #292 merge）

🤖 Generated with [Claude Code](https://claude.com/claude-code)