### PR TITLE
feat(v2-p2): SignupPage + EmailVerifyPendingPage React UI

### DIFF
--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -64,6 +64,8 @@ const ChatPage = lazyWithRetry(() => import('../pages/ChatPage'));
 const GlobalMapPage = lazyWithRetry(() => import('../pages/GlobalMapPage'));
 const ExplorePage = lazyWithRetry(() => import('../pages/ExplorePage'));
 const LoginPage = lazyWithRetry(() => import('../pages/LoginPage'));
+const SignupPage = lazyWithRetry(() => import('../pages/SignupPage'));
+const EmailVerifyPendingPage = lazyWithRetry(() => import('../pages/EmailVerifyPendingPage'));
 const ConsentPage = lazyWithRetry(() => import('../pages/ConsentPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
@@ -107,6 +109,8 @@ if (el) {
               <Route path="/map" element={<GlobalMapPage />} />
               <Route path="/explore" element={<ExplorePage />} />
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/signup" element={<SignupPage />} />
+              <Route path="/signup/check-email" element={<EmailVerifyPendingPage />} />
               <Route path="/oauth/consent" element={<ConsentPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />

--- a/src/pages/EmailVerifyPendingPage.tsx
+++ b/src/pages/EmailVerifyPendingPage.tsx
@@ -1,0 +1,201 @@
+/**
+ * EmailVerifyPendingPage — V2-P2 顯示「查看你的信箱」+ 60s cooldown 重寄
+ *
+ * Route: /signup/check-email?email=...
+ * 進來情境：
+ *   1. SignupPage 註冊成功後 navigate 過來
+ *   2. 直接訪問（refresh / bookmark）→ 仍可運作，按「重寄」就行
+ *
+ * 設計：
+ *   - 顯示信箱（從 query 取，escape）
+ *   - 「重寄」按鈕有 60s cooldown 防濫用 (前端 throttle，後端有 rate limit 層)
+ *   - mobile：「打開信箱 App」mailto: deep link
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const SCOPED_STYLES = `
+.tp-verify-shell {
+  display: flex; align-items: center; justify-content: center;
+  min-height: 100dvh; padding: 48px 24px;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    var(--color-secondary);
+}
+.tp-verify-card {
+  width: 100%; max-width: 440px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+  text-align: center;
+}
+.tp-verify-icon-circle {
+  width: 72px; height: 72px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  display: grid; place-items: center;
+  margin: 0 auto 20px;
+}
+.tp-verify-icon-circle svg { width: 36px; height: 36px; }
+.tp-verify-title {
+  font-size: var(--font-size-title2);
+  font-weight: 800;
+  margin: 0 0 8px;
+}
+.tp-verify-subtitle {
+  font-size: var(--font-size-subheadline);
+  color: var(--color-muted);
+  margin: 0 0 4px;
+}
+.tp-verify-email {
+  font-size: var(--font-size-body);
+  font-weight: 700;
+  color: var(--color-foreground);
+  margin: 0 0 24px;
+}
+.tp-verify-banner {
+  display: flex; gap: 12px;
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-subheadline);
+  text-align: left;
+  margin-bottom: 20px;
+}
+.tp-verify-banner svg { flex-shrink: 0; width: 20px; height: 20px; margin-top: 1px; }
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 100%; gap: 8px;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-family: inherit; font-size: var(--font-size-callout); font-weight: 600;
+  border: 1px solid var(--color-border);
+  background: var(--color-background); color: var(--color-foreground);
+  cursor: pointer; min-height: 48px;
+  transition: background 120ms;
+  margin-bottom: 12px;
+  text-decoration: none;
+}
+.tp-btn-primary {
+  background: var(--color-accent); color: #fff; border: none;
+}
+.tp-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+.tp-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.tp-verify-footer {
+  text-align: center; margin-top: 16px;
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+}
+.tp-verify-footer a {
+  color: var(--color-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+`;
+
+const COOLDOWN_SEC = 60;
+
+export default function EmailVerifyPendingPage() {
+  const [params] = useSearchParams();
+  const email = params.get('email') ?? '';
+  const [cooldownEndsAt, setCooldownEndsAt] = useState(() => Date.now() + COOLDOWN_SEC * 1000);
+  const [tick, setTick] = useState(0);
+  const [resending, setResending] = useState(false);
+  const [resendStatus, setResendStatus] = useState<'idle' | 'sent' | 'error'>('idle');
+
+  // Single 1Hz interval re-renders to update countdown; cleaner than chained setTimeout
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const cooldown = Math.max(0, Math.ceil((cooldownEndsAt - Date.now()) / 1000));
+  // Suppress unused-var lint; tick triggers re-render so cooldown recomputes
+  void tick;
+
+  const safeEmail = useMemo(() => email.trim().toLowerCase(), [email]);
+
+  async function handleResend() {
+    if (cooldown > 0 || !safeEmail) return;
+    setResending(true);
+    setResendStatus('idle');
+    try {
+      await fetch('/api/oauth/send-verification', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: safeEmail }),
+      });
+      setResendStatus('sent');
+      setCooldownEndsAt(Date.now() + COOLDOWN_SEC * 1000);
+    } catch {
+      setResendStatus('error');
+    } finally {
+      setResending(false);
+    }
+  }
+
+  return (
+    <main className="tp-verify-shell" data-testid="verify-pending-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-verify-card">
+        <div className="tp-verify-icon-circle">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+            <polyline points="22,6 12,13 2,6" />
+          </svg>
+        </div>
+        <h1 className="tp-verify-title">查看你的信箱</h1>
+        <p className="tp-verify-subtitle">我們已寄出驗證信到</p>
+        <p className="tp-verify-email" data-testid="verify-email">{safeEmail || '（沒有 email）'}</p>
+
+        <div className="tp-verify-banner" role="status">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+          </svg>
+          <div>連結 24 小時內有效。記得檢查垃圾信件夾。</div>
+        </div>
+
+        <a className="tp-btn tp-btn-primary" href="mailto:" data-testid="verify-open-mail">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+          </svg>
+          打開信箱
+        </a>
+
+        <button
+          className="tp-btn"
+          onClick={handleResend}
+          disabled={cooldown > 0 || resending || !safeEmail}
+          data-testid="verify-resend"
+        >
+          {cooldown > 0
+            ? `重新寄送（${cooldown} 秒後可重寄）`
+            : resending
+              ? '寄送中…'
+              : '重新寄送驗證信'}
+        </button>
+
+        {resendStatus === 'sent' && (
+          <p className="tp-verify-footer" data-testid="verify-resend-sent">
+            已重寄。請查看信箱。
+          </p>
+        )}
+        {resendStatus === 'error' && (
+          <p className="tp-verify-footer" style={{ color: 'var(--color-destructive)' }} data-testid="verify-resend-error">
+            重寄失敗，請稍後再試。
+          </p>
+        )}
+
+        <p className="tp-verify-footer">
+          打錯 email？<a href="/signup">改用其他信箱</a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,295 @@
+/**
+ * SignupPage — V2-P2 local password account creation
+ *
+ * Form fields: email + password + displayName (optional)
+ * → POST /api/oauth/signup
+ * → on success: POST /api/oauth/send-verification (best-effort)
+ * → navigate /signup/check-email?email=...
+ *
+ * Error handling:
+ *   - SIGNUP_INVALID_EMAIL / SIGNUP_INVALID_PASSWORD → inline field error
+ *   - SIGNUP_EMAIL_TAKEN → suggest /login or /forgot-password
+ *   - SIGNUP_RATE_LIMITED → 429 banner with retry-after countdown
+ *   - Network failure → generic banner
+ */
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SCOPED_STYLES = `
+.tp-auth-shell {
+  display: flex; align-items: center; justify-content: center;
+  min-height: 100dvh; padding: 48px 24px;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    radial-gradient(circle at 80% 100%, rgba(0, 119, 182, 0.04), transparent 50%),
+    var(--color-secondary);
+}
+.tp-auth-card {
+  width: 100%; max-width: 440px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+.tp-auth-brand {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  margin-bottom: 28px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.tp-auth-brand-dot { color: var(--color-accent); }
+.tp-auth-headline { text-align: center; margin-bottom: 28px; }
+.tp-auth-headline h1 {
+  font-size: var(--font-size-title2); font-weight: 800;
+  letter-spacing: -0.01em; margin: 0 0 6px;
+}
+.tp-auth-headline p {
+  color: var(--color-muted);
+  font-size: var(--font-size-subheadline);
+  margin: 0;
+}
+
+.tp-form { display: flex; flex-direction: column; gap: 16px; }
+.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
+.tp-form-row label {
+  font-size: var(--font-size-footnote); font-weight: 600;
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.tp-form-row .tp-hint { font-size: var(--font-size-caption2); color: var(--color-muted); font-weight: 500; }
+.tp-form-row input {
+  font-family: inherit; font-size: var(--font-size-callout);
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  min-height: 48px;
+}
+.tp-form-row input:focus {
+  outline: 2px solid var(--color-accent); outline-offset: -2px;
+  border-color: var(--color-accent);
+}
+.tp-form-row .tp-error {
+  font-size: 12px; color: var(--color-destructive);
+}
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: var(--font-size-callout); font-weight: 600;
+  border: none; cursor: pointer; min-height: 48px;
+  transition: background 120ms;
+}
+.tp-btn-primary { background: var(--color-accent); color: #fff; width: 100%; }
+.tp-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+.tp-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.tp-banner {
+  display: flex; gap: 12px; padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-subheadline);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.tp-banner-error { background: var(--color-destructive-bg); color: var(--color-destructive); }
+.tp-banner-warning { background: var(--color-warning-bg); color: var(--color-warning); }
+.tp-banner a { color: inherit; text-decoration: underline; font-weight: 600; }
+
+.tp-auth-footer {
+  text-align: center; margin-top: 24px;
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+}
+.tp-auth-footer a {
+  color: var(--color-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+.tp-auth-footer a:hover { text-decoration: underline; }
+`;
+
+interface ApiError {
+  error: { code: string; message: string };
+}
+
+interface SignupOk {
+  ok: true;
+  userId: string;
+  email: string;
+  requiresVerification: boolean;
+}
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [banner, setBanner] = useState<{ kind: 'error' | 'warning'; node: React.ReactNode } | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setEmailError(null);
+    setPasswordError(null);
+    setBanner(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/api/oauth/signup', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          email: email.trim(),
+          password,
+          displayName: displayName.trim() || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        const json = (await res.json()) as SignupOk;
+        // Best-effort send-verification (don't block on failure)
+        try {
+          await fetch('/api/oauth/send-verification', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email: json.email }),
+          });
+        } catch {
+          /* ignore */
+        }
+        navigate(`/signup/check-email?email=${encodeURIComponent(json.email)}`);
+        return;
+      }
+
+      const errJson = (await res.json().catch(() => null)) as ApiError | null;
+      const code = errJson?.error?.code ?? 'UNKNOWN';
+      switch (code) {
+        case 'SIGNUP_INVALID_EMAIL':
+          setEmailError('Email 格式無效');
+          break;
+        case 'SIGNUP_INVALID_PASSWORD':
+          setPasswordError('密碼至少 8 字元');
+          break;
+        case 'SIGNUP_EMAIL_TAKEN':
+          setBanner({
+            kind: 'error',
+            node: (
+              <span>
+                此 email 已註冊。<a href="/login">改用登入</a> 或{' '}
+                <a href="/login/forgot">忘記密碼</a>。
+              </span>
+            ),
+          });
+          break;
+        case 'SIGNUP_RATE_LIMITED': {
+          const retryAfter = res.headers.get('Retry-After');
+          setBanner({
+            kind: 'warning',
+            node: <span>註冊請求過多。請 {retryAfter ?? '幾分鐘'} 秒後再試。</span>,
+          });
+          break;
+        }
+        default:
+          setBanner({ kind: 'error', node: <span>註冊失敗，請稍後再試。</span> });
+      }
+    } catch {
+      setBanner({ kind: 'error', node: <span>網路連線失敗，請檢查後再試。</span> });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="tp-auth-shell" data-testid="signup-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-auth-card">
+        <div className="tp-auth-brand">
+          <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
+          <span>Tripline</span>
+        </div>
+        <div className="tp-auth-headline">
+          <h1>建立帳號</h1>
+          <p>用 email + 密碼註冊，開始規劃你的旅行</p>
+        </div>
+
+        {banner && (
+          <div
+            className={`tp-banner tp-banner-${banner.kind}`}
+            role="alert"
+            data-testid={`signup-banner-${banner.kind}`}
+          >
+            <div>{banner.node}</div>
+          </div>
+        )}
+
+        <form className="tp-form" onSubmit={handleSubmit} noValidate>
+          <div className="tp-form-row">
+            <label htmlFor="signup-email">Email</label>
+            <input
+              id="signup-email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              data-testid="signup-email"
+            />
+            {emailError && (
+              <div className="tp-error" data-testid="signup-email-error">{emailError}</div>
+            )}
+          </div>
+
+          <div className="tp-form-row">
+            <label htmlFor="signup-password">
+              密碼 <span className="tp-hint">至少 8 字元</span>
+            </label>
+            <input
+              id="signup-password"
+              type="password"
+              autoComplete="new-password"
+              minLength={8}
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              data-testid="signup-password"
+            />
+            {passwordError && (
+              <div className="tp-error" data-testid="signup-password-error">{passwordError}</div>
+            )}
+          </div>
+
+          <div className="tp-form-row">
+            <label htmlFor="signup-display-name">
+              名稱 <span className="tp-hint">選填</span>
+            </label>
+            <input
+              id="signup-display-name"
+              type="text"
+              autoComplete="name"
+              maxLength={80}
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              data-testid="signup-display-name"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="tp-btn tp-btn-primary"
+            disabled={submitting}
+            data-testid="signup-submit"
+          >
+            {submitting ? '建立中…' : '建立帳號'}
+          </button>
+        </form>
+
+        <div className="tp-auth-footer">
+          已有帳號？<a href="/login">直接登入</a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/tests/unit/email-verify-pending-page.test.tsx
+++ b/tests/unit/email-verify-pending-page.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * EmailVerifyPendingPage unit test — V2-P2
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import EmailVerifyPendingPage from '../../src/pages/EmailVerifyPendingPage';
+
+function renderAt(query: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/signup/check-email?${query}`]}>
+      <EmailVerifyPendingPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('EmailVerifyPendingPage', () => {
+  it('renders email from query', () => {
+    renderAt('email=test%40example.com');
+    expect(screen.getByTestId('verify-email').textContent).toBe('test@example.com');
+  });
+
+  it('lowercases + trims email', () => {
+    renderAt('email=%20Mixed%40EXAMPLE.com%20');
+    expect(screen.getByTestId('verify-email').textContent).toBe('mixed@example.com');
+  });
+
+  it('renders fallback text when email query missing', () => {
+    renderAt('');
+    expect(screen.getByTestId('verify-email').textContent).toContain('沒有');
+  });
+
+  it('"打開信箱" link uses mailto:', () => {
+    renderAt('email=u@x.com');
+    const link = screen.getByTestId('verify-open-mail') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('mailto:');
+  });
+
+  it('Resend button disabled until 60s cooldown elapses', async () => {
+    renderAt('email=u@x.com');
+    const btn = screen.getByTestId('verify-resend') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain('60 秒');
+
+    // Advance 60s in 1s steps — chained setTimeout needs microtask flush per fire
+    for (let i = 0; i < 60; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+    }
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain('重新寄送');
+  });
+
+  it('Resend → POST send-verification + reset cooldown + show sent message', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderAt('email=u@x.com');
+    // Tick past cooldown
+    await act(async () => {
+      vi.advanceTimersByTime(60 * 1000);
+    });
+
+    const btn = screen.getByTestId('verify-resend') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+
+    vi.useRealTimers();
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(screen.queryByTestId('verify-resend-sent')).toBeTruthy());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/oauth/send-verification');
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string) as { email: string };
+    expect(body.email).toBe('u@x.com');
+  });
+
+  it('Resend network failure → error message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('net')));
+    renderAt('email=u@x.com');
+    for (let i = 0; i < 60; i++) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    }
+
+    vi.useRealTimers();
+    fireEvent.click(screen.getByTestId('verify-resend'));
+
+    await waitFor(() => expect(screen.queryByTestId('verify-resend-error')).toBeTruthy());
+  });
+});

--- a/tests/unit/signup-page.test.tsx
+++ b/tests/unit/signup-page.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * SignupPage unit test — V2-P2
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SignupPage from '../../src/pages/SignupPage';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function fillForm({ email, password, name }: { email?: string; password?: string; name?: string }) {
+  if (email !== undefined) {
+    fireEvent.change(screen.getByTestId('signup-email'), { target: { value: email } });
+  }
+  if (password !== undefined) {
+    fireEvent.change(screen.getByTestId('signup-password'), { target: { value: password } });
+  }
+  if (name !== undefined) {
+    fireEvent.change(screen.getByTestId('signup-display-name'), { target: { value: name } });
+  }
+}
+
+beforeEach(() => {
+  navigateMock.mockClear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('SignupPage', () => {
+  it('renders form fields', () => {
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('signup-email')).toBeTruthy();
+    expect(screen.getByTestId('signup-password')).toBeTruthy();
+    expect(screen.getByTestId('signup-display-name')).toBeTruthy();
+    expect(screen.getByTestId('signup-submit')).toBeTruthy();
+  });
+
+  it('successful signup → navigates to /signup/check-email + sends verification', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ ok: true, userId: 'u1', email: 'new@example.com', requiresVerification: true }),
+        { status: 201 },
+      ))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, message: 'sent' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+
+    fillForm({ email: 'new@example.com', password: 'longpassword123', name: 'New' });
+    fireEvent.click(screen.getByTestId('signup-submit'));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+    expect(navigateMock.mock.calls[0]![0]).toBe('/signup/check-email?email=new%40example.com');
+
+    // Verify both endpoints called
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/oauth/signup');
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/oauth/send-verification');
+  });
+
+  it('SIGNUP_INVALID_EMAIL → inline email error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'SIGNUP_INVALID_EMAIL', message: 'bad' } }),
+        { status: 400 },
+      ),
+    ));
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    fillForm({ email: 'bad', password: 'longenough' });
+    fireEvent.click(screen.getByTestId('signup-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('signup-email-error')).toBeTruthy());
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('SIGNUP_EMAIL_TAKEN → banner with login + forgot links', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'SIGNUP_EMAIL_TAKEN', message: 'taken' } }),
+        { status: 409 },
+      ),
+    ));
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    fillForm({ email: 'taken@x.com', password: 'longenough' });
+    fireEvent.click(screen.getByTestId('signup-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('signup-banner-error')).toBeTruthy());
+    const banner = screen.getByTestId('signup-banner-error');
+    expect(banner.textContent).toContain('已註冊');
+    expect(banner.querySelector('a[href="/login"]')).toBeTruthy();
+    expect(banner.querySelector('a[href="/login/forgot"]')).toBeTruthy();
+  });
+
+  it('SIGNUP_RATE_LIMITED → warning banner with retry-after', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'SIGNUP_RATE_LIMITED', message: 'too many' } }),
+        { status: 429, headers: { 'Retry-After': '300' } },
+      ),
+    ));
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    fillForm({ email: 'x@y.com', password: 'longenough' });
+    fireEvent.click(screen.getByTestId('signup-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('signup-banner-warning')).toBeTruthy());
+    expect(screen.getByTestId('signup-banner-warning').textContent).toContain('300');
+  });
+
+  it('Network failure → generic error banner', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    fillForm({ email: 'x@y.com', password: 'longenough' });
+    fireEvent.click(screen.getByTestId('signup-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('signup-banner-error')).toBeTruthy());
+    expect(screen.getByTestId('signup-banner-error').textContent).toContain('網路');
+  });
+
+  it('Submit button disabled while submitting', async () => {
+    let resolve: (v: Response) => void;
+    const promise = new Promise<Response>((r) => { resolve = r; });
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(promise));
+    vi.useRealTimers();
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+    fillForm({ email: 'x@y.com', password: 'longenough' });
+    const btn = screen.getByTestId('signup-submit') as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(btn.disabled).toBe(true));
+    resolve!(new Response(JSON.stringify({ ok: true, userId: 'u', email: 'x@y.com', requiresVerification: true }), { status: 201 }));
+  });
+});


### PR DESCRIPTION
## Summary

V2-P2 frontend：實作 mockup section 2「Email 驗證」配合 mockup section 中的「建立帳號」表單，wire 進 React router。

| Route | Component | mockup ref |
|-------|-----------|-----------|
| `/signup` | SignupPage | section 2 (mockup-signup-v2.html) |
| `/signup/check-email?email=…` | EmailVerifyPendingPage | section 2 (待收信狀態) |

### SignupPage 重點

- **完整 form**：email + password (≥8) + 名稱（選填）
- **2-step submit flow**：POST /api/oauth/signup → 成功後 best-effort POST /api/oauth/send-verification → navigate `/signup/check-email`
- **錯誤對映**：API error code → 對應 UX
  - `SIGNUP_INVALID_EMAIL` / `SIGNUP_INVALID_PASSWORD` → inline field error
  - `SIGNUP_EMAIL_TAKEN` → banner 含 /login + /login/forgot 連結
  - `SIGNUP_RATE_LIMITED` → warning banner 讀 Retry-After
  - 網路錯 → generic error banner
- 防 double-submit：submitting 時 button disabled

### EmailVerifyPendingPage 重點

- 60s cooldown 後可重寄，倒數即時更新
- 用 `Date.now() + interval` 而非 chained `setTimeout`（後者在 fake timer 下難測，且 race-prone）
- mobile mailto: deep link「打開信箱」
- email lowercase + trim 從 query 取，escape 防 XSS

## Test plan

- [x] tsc strict 全過
- [x] 908/908 vitest 全綠（+14 new — SignupPage 7 / EmailVerifyPending 7）

### Test 涵蓋

- SignupPage: 渲染 / 成功 navigate / 各種 error code mapping / network failure / double-submit prevention
- EmailVerifyPending: email render / lowercase trim / fallback / mailto link / cooldown elapses / resend success / resend failure

## V2-P2 progress

- [x] **本 PR** SignupPage + EmailVerifyPendingPage
- [ ] V2-P2 next：wire signup auto-trigger send-verification（需先 #289 merge 釋放 signup.ts）

🤖 Generated with [Claude Code](https://claude.com/claude-code)