### PR TITLE
feat(v2-p3): ForgotPasswordPage + ResetPasswordPage React UI

### DIFF
--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -64,6 +64,8 @@ const ChatPage = lazyWithRetry(() => import('../pages/ChatPage'));
 const GlobalMapPage = lazyWithRetry(() => import('../pages/GlobalMapPage'));
 const ExplorePage = lazyWithRetry(() => import('../pages/ExplorePage'));
 const LoginPage = lazyWithRetry(() => import('../pages/LoginPage'));
+const ForgotPasswordPage = lazyWithRetry(() => import('../pages/ForgotPasswordPage'));
+const ResetPasswordPage = lazyWithRetry(() => import('../pages/ResetPasswordPage'));
 const ConsentPage = lazyWithRetry(() => import('../pages/ConsentPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
@@ -107,6 +109,8 @@ if (el) {
               <Route path="/map" element={<GlobalMapPage />} />
               <Route path="/explore" element={<ExplorePage />} />
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/login/forgot" element={<ForgotPasswordPage />} />
+              <Route path="/auth/password/reset" element={<ResetPasswordPage />} />
               <Route path="/oauth/consent" element={<ConsentPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,215 @@
+/**
+ * ForgotPasswordPage — V2-P3 password reset request
+ *
+ * Route: /login/forgot
+ * Form: email → POST /api/oauth/forgot-password
+ *
+ * Anti-enumeration: API 永遠回 generic 200，不分 email 存在/不存在。
+ * 此頁也跟 API 對齊：成功狀態說「若帳號存在，重設連結已寄出」。
+ *
+ * Rate limit (V2-P6): 429 FORGOT_PASSWORD_RATE_LIMITED → 顯示 retry-after。
+ */
+import { useState } from 'react';
+
+const SCOPED_STYLES = `
+.tp-auth-shell {
+  display: flex; align-items: center; justify-content: center;
+  min-height: 100dvh; padding: 48px 24px;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    var(--color-secondary);
+}
+.tp-auth-card {
+  width: 100%; max-width: 440px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+.tp-auth-brand {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  margin-bottom: 28px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.tp-auth-brand-dot { color: var(--color-accent); }
+.tp-auth-headline { text-align: center; margin-bottom: 28px; }
+.tp-auth-headline h1 {
+  font-size: var(--font-size-title2); font-weight: 800;
+  letter-spacing: -0.01em; margin: 0 0 6px;
+}
+.tp-auth-headline p {
+  color: var(--color-muted); font-size: var(--font-size-subheadline);
+  margin: 0; line-height: 1.5;
+}
+
+.tp-form { display: flex; flex-direction: column; gap: 16px; }
+.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
+.tp-form-row label {
+  font-size: var(--font-size-footnote); font-weight: 600;
+}
+.tp-form-row input {
+  font-family: inherit; font-size: var(--font-size-callout);
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  min-height: 48px;
+}
+.tp-form-row input:focus {
+  outline: 2px solid var(--color-accent); outline-offset: -2px;
+  border-color: var(--color-accent);
+}
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: var(--font-size-callout); font-weight: 600;
+  border: none; cursor: pointer; min-height: 48px;
+  transition: background 120ms;
+}
+.tp-btn-primary { background: var(--color-accent); color: #fff; width: 100%; }
+.tp-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+.tp-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.tp-banner {
+  display: flex; gap: 12px; padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-subheadline); line-height: 1.5;
+  margin-bottom: 16px;
+}
+.tp-banner-success { background: var(--color-success-bg); color: var(--color-success); }
+.tp-banner-warning { background: var(--color-warning-bg); color: var(--color-warning); }
+.tp-banner-error { background: var(--color-destructive-bg); color: var(--color-destructive); }
+
+.tp-success-icon-circle {
+  width: 64px; height: 64px;
+  border-radius: var(--radius-full);
+  background: var(--color-success-bg); color: var(--color-success);
+  display: grid; place-items: center;
+  margin: 0 auto 16px;
+}
+.tp-success-icon-circle svg { width: 32px; height: 32px; }
+
+.tp-auth-footer {
+  text-align: center; margin-top: 24px;
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+}
+.tp-auth-footer a {
+  color: var(--color-accent);
+  font-weight: 600; text-decoration: none;
+}
+.tp-auth-footer a:hover { text-decoration: underline; }
+`;
+
+interface ApiError {
+  error: { code: string; message: string };
+}
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [warning, setWarning] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setWarning(null);
+    try {
+      const res = await fetch('/api/oauth/forgot-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      if (res.ok) {
+        setSubmitted(true);
+        return;
+      }
+      const errJson = (await res.json().catch(() => null)) as ApiError | null;
+      const code = errJson?.error?.code ?? 'UNKNOWN';
+      if (code === 'FORGOT_PASSWORD_RATE_LIMITED') {
+        const retryAfter = res.headers.get('Retry-After');
+        setWarning(`重設請求過多。請 ${retryAfter ?? '幾分鐘'} 秒後再試。`);
+      } else {
+        setWarning('暫時無法處理，請稍後再試。');
+      }
+    } catch {
+      setWarning('網路連線失敗，請稍後再試。');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="tp-auth-shell" data-testid="forgot-password-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-auth-card">
+        <div className="tp-auth-brand">
+          <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
+          <span>Tripline</span>
+        </div>
+
+        {submitted ? (
+          <>
+            <div className="tp-success-icon-circle" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </div>
+            <div className="tp-auth-headline">
+              <h1>查看你的信箱</h1>
+              <p>若 <strong>{email.trim()}</strong> 已註冊，重設連結已寄出。<br />連結 1 小時內有效。</p>
+            </div>
+            <div className="tp-auth-footer">
+              <a href="/login">回登入</a>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="tp-auth-headline">
+              <h1>忘記密碼</h1>
+              <p>輸入您註冊的 email，我們會寄重設連結給您。</p>
+            </div>
+
+            {warning && (
+              <div className="tp-banner tp-banner-warning" role="alert" data-testid="forgot-banner-warning">
+                {warning}
+              </div>
+            )}
+
+            <form className="tp-form" onSubmit={handleSubmit} noValidate>
+              <div className="tp-form-row">
+                <label htmlFor="forgot-email">Email</label>
+                <input
+                  id="forgot-email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  data-testid="forgot-email"
+                />
+              </div>
+              <button
+                type="submit"
+                className="tp-btn tp-btn-primary"
+                disabled={submitting}
+                data-testid="forgot-submit"
+              >
+                {submitting ? '寄送中…' : '寄送重設連結'}
+              </button>
+            </form>
+
+            <div className="tp-auth-footer">
+              想起密碼了？<a href="/login">回登入</a>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,394 @@
+/**
+ * ResetPasswordPage — V2-P3 password reset complete
+ *
+ * Route: /auth/password/reset?token=...
+ * Form: new password + confirm + strength feedback
+ * → POST /api/oauth/reset-password { token, password }
+ *
+ * States:
+ *   - token missing → redirect-error UI
+ *   - submitting form
+ *   - success: '密碼已更新' + 提示「為了安全，所有裝置已登出」
+ *   - token invalid/expired (RESET_TOKEN_INVALID): error UI + 重新申請連結
+ *   - bad password (RESET_INVALID_PASSWORD): inline field error
+ */
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const SCOPED_STYLES = `
+.tp-auth-shell {
+  display: flex; align-items: center; justify-content: center;
+  min-height: 100dvh; padding: 48px 24px;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    var(--color-secondary);
+}
+.tp-auth-card {
+  width: 100%; max-width: 440px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-md);
+}
+.tp-auth-brand {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  margin-bottom: 28px;
+  font-size: 18px; font-weight: 800; letter-spacing: -0.02em;
+}
+.tp-auth-brand-dot { color: var(--color-accent); }
+.tp-auth-headline { text-align: center; margin-bottom: 28px; }
+.tp-auth-headline h1 {
+  font-size: var(--font-size-title2); font-weight: 800;
+  letter-spacing: -0.01em; margin: 0 0 6px;
+}
+.tp-auth-headline p {
+  color: var(--color-muted); font-size: var(--font-size-subheadline);
+  margin: 0;
+}
+
+.tp-form { display: flex; flex-direction: column; gap: 16px; }
+.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
+.tp-form-row label {
+  font-size: var(--font-size-footnote); font-weight: 600;
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.tp-form-row .tp-hint {
+  font-size: var(--font-size-caption2);
+  color: var(--color-muted); font-weight: 500;
+}
+.tp-form-row input {
+  font-family: inherit; font-size: var(--font-size-callout);
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  min-height: 48px;
+}
+.tp-form-row input:focus {
+  outline: 2px solid var(--color-accent); outline-offset: -2px;
+  border-color: var(--color-accent);
+}
+.tp-form-row .tp-error {
+  font-size: var(--font-size-caption);
+  color: var(--color-destructive);
+}
+
+.tp-pw-strength {
+  display: flex; flex-direction: column; gap: 8px; margin-top: 4px;
+}
+.tp-pw-bars {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;
+}
+.tp-pw-bar {
+  height: 4px; border-radius: 2px;
+  background: var(--color-tertiary);
+}
+.tp-pw-bar-weak { background: var(--color-destructive); }
+.tp-pw-bar-medium { background: var(--color-warning); }
+.tp-pw-bar-strong { background: var(--color-success); }
+
+.tp-pw-checks {
+  display: flex; flex-direction: column; gap: 4px;
+  font-size: var(--font-size-caption);
+}
+.tp-pw-check {
+  display: flex; align-items: center; gap: 6px;
+  color: var(--color-muted);
+}
+.tp-pw-check-ok { color: var(--color-success); }
+.tp-pw-check svg { width: 14px; height: 14px; }
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: var(--font-size-callout); font-weight: 600;
+  border: none; cursor: pointer; min-height: 48px;
+  transition: background 120ms;
+}
+.tp-btn-primary { background: var(--color-accent); color: #fff; width: 100%; }
+.tp-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+.tp-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.tp-banner {
+  display: flex; gap: 12px; padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-subheadline); line-height: 1.5;
+  margin-bottom: 16px;
+}
+.tp-banner-info { background: var(--color-accent-subtle); color: var(--color-accent); }
+.tp-banner-error { background: var(--color-destructive-bg); color: var(--color-destructive); }
+
+.tp-result-icon {
+  width: 64px; height: 64px;
+  border-radius: var(--radius-full);
+  display: grid; place-items: center;
+  margin: 0 auto 16px;
+}
+.tp-result-icon svg { width: 32px; height: 32px; }
+.tp-result-icon-success { background: var(--color-success-bg); color: var(--color-success); }
+.tp-result-icon-error { background: var(--color-destructive-bg); color: var(--color-destructive); }
+
+.tp-auth-footer {
+  text-align: center; margin-top: 24px;
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+}
+.tp-auth-footer a {
+  color: var(--color-accent);
+  font-weight: 600; text-decoration: none;
+}
+.tp-auth-footer a:hover { text-decoration: underline; }
+`;
+
+interface ApiError {
+  error: { code: string; message: string };
+}
+
+interface PasswordChecks {
+  lengthOk: boolean;
+  hasLetter: boolean;
+  hasNumber: boolean;
+}
+
+function checkPassword(pw: string): PasswordChecks {
+  return {
+    lengthOk: pw.length >= 8,
+    hasLetter: /[A-Za-z]/.test(pw),
+    hasNumber: /\d/.test(pw),
+  };
+}
+
+function strengthLevel(checks: PasswordChecks): 0 | 1 | 2 | 3 | 4 {
+  let score: 0 | 1 | 2 | 3 | 4 = 0;
+  if (checks.lengthOk) score = (score + 1) as typeof score;
+  if (checks.hasLetter) score = (score + 1) as typeof score;
+  if (checks.hasNumber) score = (score + 1) as typeof score;
+  if (checks.lengthOk && checks.hasLetter && checks.hasNumber) {
+    score = 4;
+  }
+  return score;
+}
+
+export default function ResetPasswordPage() {
+  const [params] = useSearchParams();
+  const token = params.get('token') ?? '';
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [tokenInvalid, setTokenInvalid] = useState(false);
+  const [pwError, setPwError] = useState<string | null>(null);
+  const [bannerError, setBannerError] = useState<string | null>(null);
+
+  const checks = useMemo(() => checkPassword(password), [password]);
+  const strength = useMemo(() => strengthLevel(checks), [checks]);
+  const passwordsMatch = password.length > 0 && password === confirm;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPwError(null);
+    setBannerError(null);
+
+    if (!checks.lengthOk) {
+      setPwError('密碼至少 8 字元');
+      return;
+    }
+    if (!passwordsMatch) {
+      setPwError('兩次輸入的密碼不一致');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/oauth/reset-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      });
+      if (res.ok) {
+        setSuccess(true);
+        return;
+      }
+      const errJson = (await res.json().catch(() => null)) as ApiError | null;
+      const code = errJson?.error?.code ?? 'UNKNOWN';
+      switch (code) {
+        case 'RESET_TOKEN_INVALID':
+        case 'RESET_TOKEN_MISSING':
+          setTokenInvalid(true);
+          break;
+        case 'RESET_INVALID_PASSWORD':
+          setPwError('密碼格式不符（至少 8 字元）');
+          break;
+        default:
+          setBannerError('暫時無法處理，請稍後再試。');
+      }
+    } catch {
+      setBannerError('網路連線失敗，請稍後再試。');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Token missing in URL → render error directly
+  if (!token || tokenInvalid) {
+    return (
+      <main className="tp-auth-shell" data-testid="reset-password-page">
+        <style>{SCOPED_STYLES}</style>
+        <div className="tp-auth-card">
+          <div className="tp-auth-brand">
+            <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
+            <span>Tripline</span>
+          </div>
+          <div className="tp-result-icon tp-result-icon-error" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <circle cx="12" cy="12" r="10" />
+              <line x1="15" y1="9" x2="9" y2="15" />
+              <line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+          </div>
+          <div className="tp-auth-headline">
+            <h1>這個連結無法使用了</h1>
+            <p>重設連結已失效或已被使用過。為了安全，連結只在 1 小時內有效，且只能使用一次。</p>
+          </div>
+          <a href="/login/forgot" className="tp-btn tp-btn-primary" data-testid="reset-retry">重新申請重設密碼</a>
+          <div className="tp-auth-footer">
+            想起密碼了？<a href="/login">回登入</a>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (success) {
+    return (
+      <main className="tp-auth-shell" data-testid="reset-password-page">
+        <style>{SCOPED_STYLES}</style>
+        <div className="tp-auth-card">
+          <div className="tp-auth-brand">
+            <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
+            <span>Tripline</span>
+          </div>
+          <div className="tp-result-icon tp-result-icon-success" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </div>
+          <div className="tp-auth-headline">
+            <h1>密碼已更新</h1>
+            <p>為了安全，您所有裝置上的登入已自動登出。</p>
+          </div>
+          <a href="/login" className="tp-btn tp-btn-primary" data-testid="reset-go-login">前往登入</a>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="tp-auth-shell" data-testid="reset-password-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-auth-card">
+        <div className="tp-auth-brand">
+          <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
+          <span>Tripline</span>
+        </div>
+        <div className="tp-auth-headline">
+          <h1>設定新密碼</h1>
+          <p>建立一組新密碼，至少 8 字元，包含字母與數字。</p>
+        </div>
+
+        {bannerError && (
+          <div className="tp-banner tp-banner-error" role="alert" data-testid="reset-banner-error">
+            {bannerError}
+          </div>
+        )}
+
+        <form className="tp-form" onSubmit={handleSubmit} noValidate>
+          <div className="tp-form-row">
+            <label htmlFor="reset-password">
+              新密碼 <span className="tp-hint">至少 8 字元</span>
+            </label>
+            <input
+              id="reset-password"
+              type="password"
+              autoComplete="new-password"
+              minLength={8}
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              data-testid="reset-password-input"
+            />
+            <div className="tp-pw-strength" data-testid="reset-pw-strength">
+              <div className="tp-pw-bars">
+                {([0, 1, 2, 3] as const).map((i) => (
+                  <div
+                    key={i}
+                    className={
+                      'tp-pw-bar ' +
+                      (i < strength
+                        ? strength <= 2
+                          ? 'tp-pw-bar-weak'
+                          : strength === 3
+                            ? 'tp-pw-bar-medium'
+                            : 'tp-pw-bar-strong'
+                        : '')
+                    }
+                  />
+                ))}
+              </div>
+              <div className="tp-pw-checks">
+                <span className={`tp-pw-check ${checks.lengthOk ? 'tp-pw-check-ok' : ''}`} data-testid="reset-check-length">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                    {checks.lengthOk
+                      ? <polyline points="20 6 9 17 4 12" />
+                      : <circle cx="12" cy="12" r="10" />}
+                  </svg>
+                  長度 ≥ 8 字
+                </span>
+                <span className={`tp-pw-check ${checks.hasLetter && checks.hasNumber ? 'tp-pw-check-ok' : ''}`} data-testid="reset-check-mix">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                    {checks.hasLetter && checks.hasNumber
+                      ? <polyline points="20 6 9 17 4 12" />
+                      : <circle cx="12" cy="12" r="10" />}
+                  </svg>
+                  包含字母與數字
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="tp-form-row">
+            <label htmlFor="reset-confirm">再次輸入新密碼</label>
+            <input
+              id="reset-confirm"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              data-testid="reset-confirm"
+            />
+            {pwError && (
+              <div className="tp-error" data-testid="reset-pw-error">{pwError}</div>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            className="tp-btn tp-btn-primary"
+            disabled={submitting}
+            data-testid="reset-submit"
+          >
+            {submitting ? '更新中…' : '重設密碼'}
+          </button>
+        </form>
+
+        <div className="tp-auth-footer">
+          想起密碼了？<a href="/login">回登入</a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/tests/unit/forgot-password-page.test.tsx
+++ b/tests/unit/forgot-password-page.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * ForgotPasswordPage unit test — V2-P3
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ForgotPasswordPage from '../../src/pages/ForgotPasswordPage';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('ForgotPasswordPage', () => {
+  it('renders email input + submit', () => {
+    render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>);
+    expect(screen.getByTestId('forgot-email')).toBeTruthy();
+    expect(screen.getByTestId('forgot-submit')).toBeTruthy();
+  });
+
+  it('200 response → success state with generic message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, message: '若 email 已註冊...' }), { status: 200 }),
+    ));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>);
+    fireEvent.change(screen.getByTestId('forgot-email'), { target: { value: 'u@x.com' } });
+    fireEvent.click(screen.getByTestId('forgot-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('forgot-email')).toBeNull());
+    expect(screen.getByText(/查看你的信箱/)).toBeTruthy();
+    expect(screen.getByText(/u@x\.com/)).toBeTruthy();
+  });
+
+  it('429 → warning banner with retry-after', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'FORGOT_PASSWORD_RATE_LIMITED', message: 'too many' } }),
+        { status: 429, headers: { 'Retry-After': '120' } },
+      ),
+    ));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>);
+    fireEvent.change(screen.getByTestId('forgot-email'), { target: { value: 'u@x.com' } });
+    fireEvent.click(screen.getByTestId('forgot-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('forgot-banner-warning')).toBeTruthy());
+    expect(screen.getByTestId('forgot-banner-warning').textContent).toContain('120');
+  });
+
+  it('Network error → warning banner', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('net')));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>);
+    fireEvent.change(screen.getByTestId('forgot-email'), { target: { value: 'u@x.com' } });
+    fireEvent.click(screen.getByTestId('forgot-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('forgot-banner-warning')).toBeTruthy());
+    expect(screen.getByTestId('forgot-banner-warning').textContent).toContain('網路');
+  });
+
+  it('trims email before POST', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>);
+    fireEvent.change(screen.getByTestId('forgot-email'), { target: { value: '  u@x.com  ' } });
+    fireEvent.click(screen.getByTestId('forgot-submit'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string) as { email: string };
+    expect(body.email).toBe('u@x.com');
+  });
+});

--- a/tests/unit/reset-password-page.test.tsx
+++ b/tests/unit/reset-password-page.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ResetPasswordPage unit test — V2-P3
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPasswordPage from '../../src/pages/ResetPasswordPage';
+
+function renderAt(query: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/password/reset?${query}`]}>
+      <ResetPasswordPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('ResetPasswordPage', () => {
+  it('renders error when token missing from query', () => {
+    renderAt('');
+    expect(screen.getByText(/連結無法使用/)).toBeTruthy();
+    expect(screen.getByTestId('reset-retry')).toBeTruthy();
+  });
+
+  it('renders form when token present', () => {
+    renderAt('token=abc');
+    expect(screen.getByTestId('reset-password-input')).toBeTruthy();
+    expect(screen.getByTestId('reset-confirm')).toBeTruthy();
+  });
+
+  it('shows password strength indicators (length + letter+number)', () => {
+    renderAt('token=t');
+    const pwInput = screen.getByTestId('reset-password-input');
+    fireEvent.change(pwInput, { target: { value: 'short' } });
+    expect(screen.getByTestId('reset-check-length').className).not.toContain('tp-pw-check-ok');
+    fireEvent.change(pwInput, { target: { value: 'longenough123' } });
+    expect(screen.getByTestId('reset-check-length').className).toContain('tp-pw-check-ok');
+    expect(screen.getByTestId('reset-check-mix').className).toContain('tp-pw-check-ok');
+  });
+
+  it('Submit with mismatched passwords → inline error', async () => {
+    vi.useRealTimers();
+    renderAt('token=t');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'longpassword1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'different1234' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+    await waitFor(() => expect(screen.queryByTestId('reset-pw-error')).toBeTruthy());
+    expect(screen.getByTestId('reset-pw-error').textContent).toContain('不一致');
+  });
+
+  it('Submit with too short password → inline error (前端 guard)', async () => {
+    vi.useRealTimers();
+    renderAt('token=t');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'short1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'short1' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+    await waitFor(() => expect(screen.queryByTestId('reset-pw-error')).toBeTruthy());
+    expect(screen.getByTestId('reset-pw-error').textContent).toContain('8 字');
+  });
+
+  it('Successful reset → success state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    renderAt('token=t');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'goodpassword1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'goodpassword1' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('reset-go-login')).toBeTruthy());
+    expect(screen.getByText(/密碼已更新/)).toBeTruthy();
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/oauth/reset-password', expect.objectContaining({ method: 'POST' }));
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string) as { token: string; password: string };
+    expect(body.token).toBe('t');
+    expect(body.password).toBe('goodpassword1');
+  });
+
+  it('RESET_TOKEN_INVALID → switches to error state with retry link', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'RESET_TOKEN_INVALID', message: '無效' } }),
+        { status: 400 },
+      ),
+    ));
+    vi.useRealTimers();
+
+    renderAt('token=expired');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'goodpassword1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'goodpassword1' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('reset-retry')).toBeTruthy());
+  });
+
+  it('RESET_INVALID_PASSWORD → inline pw-error (邊界 case)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: 'RESET_INVALID_PASSWORD', message: 'bad' } }),
+        { status: 400 },
+      ),
+    ));
+    vi.useRealTimers();
+
+    renderAt('token=t');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'goodpassword1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'goodpassword1' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('reset-pw-error')).toBeTruthy());
+  });
+
+  it('Network failure → banner-error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('net')));
+    vi.useRealTimers();
+
+    renderAt('token=t');
+    fireEvent.change(screen.getByTestId('reset-password-input'), { target: { value: 'goodpassword1' } });
+    fireEvent.change(screen.getByTestId('reset-confirm'), { target: { value: 'goodpassword1' } });
+    fireEvent.click(screen.getByTestId('reset-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('reset-banner-error')).toBeTruthy());
+  });
+});


### PR DESCRIPTION
## Summary

V2-P3 frontend 完成：密碼重設使用者流程兩端 UI。

| Route | Component | mockup ref |
|-------|-----------|-----------|
| `/login/forgot` | ForgotPasswordPage | mockup-forgot-v2.html |
| `/auth/password/reset?token=…` | ResetPasswordPage | section 1（V2 mockups index） |

### ForgotPasswordPage 重點

- email → POST → 200 切成 generic success（"若 email 已註冊..."），對齊後端 anti-enum
- 429 → warning banner 讀 Retry-After
- 自動 trim email

### ResetPasswordPage 重點

- 兩個 dedicated UI state（form / success / token-invalid）
- 即時 password strength：4-bar 顏色 + 兩個 check（長度 / 字母+數字 mix）
- 前端 guard 防無謂 API call（未滿 8 字 / 兩次不一致）
- TOKEN_INVALID → 切「連結無法使用」UI + 重新申請按鈕
- 無 token query 直接 render error UI
- 成功 → 提示「所有裝置已登出」（對齊後端 reset 行為）

## Test plan

- [x] tsc strict 全過
- [x] 908/908 vitest 全綠（+14 new cases）
- [x] CI pending

## V2-P3 progress

- [x] **本 PR** ForgotPasswordPage + ResetPasswordPage UI
- [ ] V2-P3 next：wire email 寄送進 forgot-password endpoint（等 #289 + #296 merge）

🤖 Generated with [Claude Code](https://claude.com/claude-code)