### PR TITLE
feat(v2-p5): ConnectedAppsPage React UI (list + revoke)

### DIFF
--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -64,6 +64,7 @@ const ChatPage = lazyWithRetry(() => import('../pages/ChatPage'));
 const GlobalMapPage = lazyWithRetry(() => import('../pages/GlobalMapPage'));
 const ExplorePage = lazyWithRetry(() => import('../pages/ExplorePage'));
 const LoginPage = lazyWithRetry(() => import('../pages/LoginPage'));
+const ConnectedAppsPage = lazyWithRetry(() => import('../pages/ConnectedAppsPage'));
 const ConsentPage = lazyWithRetry(() => import('../pages/ConsentPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
@@ -107,6 +108,7 @@ if (el) {
               <Route path="/map" element={<GlobalMapPage />} />
               <Route path="/explore" element={<ExplorePage />} />
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/settings/connected-apps" element={<ConnectedAppsPage />} />
               <Route path="/oauth/consent" element={<ConsentPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />

--- a/src/pages/ConnectedAppsPage.tsx
+++ b/src/pages/ConnectedAppsPage.tsx
@@ -1,0 +1,365 @@
+/**
+ * ConnectedAppsPage — V2-P5 user-side OAuth grant management
+ *
+ * Route: /settings/connected-apps
+ * 列出 current user 授權的 OAuth client_apps + 撤銷功能。
+ *
+ * Auth required (依賴 /api/account/connected-apps requireSession)。
+ *
+ * 安全 UX：撤銷必須二次確認（modal）— 破壞性操作。
+ */
+import { useEffect, useState } from 'react';
+
+const SCOPED_STYLES = `
+.tp-settings-shell {
+  min-height: 100dvh; padding: 32px 16px 64px;
+  background: var(--color-secondary);
+}
+.tp-settings-inner {
+  max-width: 720px; margin: 0 auto;
+}
+.tp-page-heading { margin-bottom: 24px; }
+.tp-page-heading-crumb {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-muted); margin-bottom: 8px;
+}
+.tp-page-heading h1 {
+  font-size: var(--font-size-title); font-weight: 800;
+  letter-spacing: -0.02em; margin: 0 0 6px;
+}
+.tp-page-heading p {
+  color: var(--color-muted); font-size: var(--font-size-subheadline);
+  margin: 0;
+}
+
+.tp-section {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+.tp-section-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.tp-section-header h2 {
+  font-size: var(--font-size-headline); font-weight: 700;
+  margin: 0;
+}
+.tp-section-count {
+  font-size: var(--font-size-caption2); font-weight: 600;
+  color: var(--color-muted);
+  padding: 2px 8px;
+  background: var(--color-tertiary);
+  border-radius: var(--radius-full);
+}
+
+.tp-app-row {
+  display: flex; align-items: center; gap: 16px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.tp-app-row:last-child { border-bottom: none; }
+.tp-app-logo {
+  width: 48px; height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  display: grid; place-items: center;
+  font-weight: 700; font-size: 18px;
+  flex-shrink: 0;
+}
+.tp-app-info { flex: 1; min-width: 0; }
+.tp-app-name {
+  font-size: var(--font-size-callout); font-weight: 700;
+  margin-bottom: 2px;
+}
+.tp-app-meta {
+  font-size: var(--font-size-caption); color: var(--color-muted);
+  display: flex; gap: 12px; flex-wrap: wrap;
+}
+.tp-scope-pill {
+  background: var(--color-tertiary); padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  font-family: 'SF Mono', ui-monospace, monospace;
+  font-size: var(--font-size-caption2);
+  color: var(--color-foreground);
+}
+.tp-app-actions {
+  display: flex; gap: 8px; flex-shrink: 0;
+}
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 8px 14px; border-radius: var(--radius-sm);
+  font-family: inherit; font-size: var(--font-size-footnote);
+  font-weight: 600; border: 1px solid var(--color-border);
+  background: var(--color-background); color: var(--color-foreground);
+  cursor: pointer; min-height: 36px;
+  transition: background 120ms;
+}
+.tp-btn:hover:not(:disabled) { background: var(--color-hover); }
+.tp-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.tp-btn-destructive {
+  color: var(--color-destructive); border-color: var(--color-destructive);
+}
+.tp-btn-destructive:hover:not(:disabled) { background: var(--color-destructive-bg); }
+.tp-btn-primary { background: var(--color-accent); color: #fff; border: none; }
+.tp-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+.tp-btn-block { width: 100%; min-height: 48px; padding: 12px 20px; font-size: var(--font-size-callout); }
+
+.tp-empty {
+  padding: 48px 24px; text-align: center;
+}
+.tp-empty-icon-circle {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-full);
+  background: var(--color-tertiary);
+  color: var(--color-muted);
+  display: grid; place-items: center;
+  margin: 0 auto 16px;
+}
+.tp-empty-icon-circle svg { width: 28px; height: 28px; }
+.tp-empty h3 {
+  font-size: var(--font-size-headline); font-weight: 700;
+  margin: 0 0 6px;
+}
+.tp-empty p {
+  font-size: var(--font-size-footnote); color: var(--color-muted);
+  margin: 0;
+}
+
+.tp-modal-backdrop {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(42, 31, 24, 0.45);
+  display: grid; place-items: center;
+  padding: 24px;
+}
+.tp-modal {
+  background: var(--color-background);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  max-width: 420px; width: 100%;
+}
+.tp-modal-header { padding: 24px 28px 12px; text-align: center; }
+.tp-modal-icon {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-full);
+  background: var(--color-destructive-bg);
+  color: var(--color-destructive);
+  display: grid; place-items: center;
+  margin: 0 auto 12px;
+}
+.tp-modal-icon svg { width: 28px; height: 28px; }
+.tp-modal-header h3 {
+  font-size: var(--font-size-headline); font-weight: 800;
+  margin: 0 0 4px;
+}
+.tp-modal-body {
+  padding: 8px 28px 16px; text-align: center;
+  font-size: var(--font-size-subheadline); color: var(--color-muted);
+  line-height: 1.5;
+}
+.tp-modal-footer {
+  padding: 12px 24px 24px;
+  display: flex; gap: 8px;
+}
+.tp-modal-footer .tp-btn { flex: 1; min-height: 44px; }
+
+.tp-loading, .tp-error-banner {
+  padding: 32px; text-align: center;
+  color: var(--color-muted);
+}
+.tp-error-banner { color: var(--color-destructive); }
+`;
+
+interface ConnectedApp {
+  client_id: string;
+  app_name: string;
+  app_logo_url: string | null;
+  app_description: string | null;
+  homepage_url: string | null;
+  status: string;
+  scopes: string[];
+  granted_at: number;
+}
+
+function relativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return '剛才';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} 分鐘前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 小時前`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day} 天前`;
+  const month = Math.floor(day / 30);
+  if (month < 12) return `${month} 個月前`;
+  return `${Math.floor(month / 12)} 年前`;
+}
+
+export default function ConnectedAppsPage() {
+  const [apps, setApps] = useState<ConnectedApp[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokeBusy, setRevokeBusy] = useState(false);
+
+  async function load() {
+    setError(null);
+    try {
+      const res = await fetch('/api/account/connected-apps', { credentials: 'same-origin' });
+      if (!res.ok) {
+        setError('無法載入已連結應用，請重新整理頁面。');
+        return;
+      }
+      const json = (await res.json()) as { apps: ConnectedApp[] };
+      setApps(json.apps);
+    } catch {
+      setError('網路連線失敗，請重新整理頁面。');
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function confirmRevoke(clientId: string) {
+    setRevokeBusy(true);
+    try {
+      const res = await fetch(`/api/account/connected-apps/${encodeURIComponent(clientId)}`, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      if (res.ok) {
+        setApps((prev) => prev?.filter((a) => a.client_id !== clientId) ?? null);
+        setRevokingId(null);
+      } else {
+        setError('撤銷失敗，請稍後再試。');
+      }
+    } catch {
+      setError('網路連線失敗，請稍後再試。');
+    } finally {
+      setRevokeBusy(false);
+    }
+  }
+
+  const target = apps?.find((a) => a.client_id === revokingId);
+
+  return (
+    <main className="tp-settings-shell" data-testid="connected-apps-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-settings-inner">
+        <div className="tp-page-heading">
+          <div className="tp-page-heading-crumb">設定</div>
+          <h1>已連結的應用</h1>
+          <p>這些 app 可以使用你的 Tripline 帳號。撤銷後該 app 將立即失去存取權。</p>
+        </div>
+
+        {error && (
+          <div className="tp-error-banner" role="alert" data-testid="connected-apps-error">
+            {error}
+          </div>
+        )}
+
+        {apps === null && !error && (
+          <div className="tp-loading" data-testid="connected-apps-loading">載入中…</div>
+        )}
+
+        {apps !== null && apps.length === 0 && (
+          <div className="tp-section">
+            <div className="tp-empty" data-testid="connected-apps-empty">
+              <div className="tp-empty-icon-circle" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75}>
+                  <rect x="3" y="3" width="7" height="7" />
+                  <rect x="14" y="3" width="7" height="7" />
+                  <rect x="14" y="14" width="7" height="7" />
+                  <rect x="3" y="14" width="7" height="7" />
+                </svg>
+              </div>
+              <h3>還沒有任何應用連結到你的帳號</h3>
+              <p>當你第一次用「Sign in with Tripline」登入第三方 app 時，會出現在這裡。</p>
+            </div>
+          </div>
+        )}
+
+        {apps !== null && apps.length > 0 && (
+          <div className="tp-section">
+            <div className="tp-section-header">
+              <h2>授權中</h2>
+              <span className="tp-section-count">{apps.length} 個</span>
+            </div>
+            {apps.map((app) => (
+              <div className="tp-app-row" key={app.client_id} data-testid={`connected-apps-row-${app.client_id}`}>
+                <div className="tp-app-logo" aria-hidden="true">
+                  {app.app_name.slice(0, 1).toUpperCase()}
+                </div>
+                <div className="tp-app-info">
+                  <div className="tp-app-name">{app.app_name}</div>
+                  <div className="tp-app-meta">
+                    {app.scopes.slice(0, 3).map((s) => (
+                      <span className="tp-scope-pill" key={s}>{s}</span>
+                    ))}
+                    <span>授權 {relativeTime(app.granted_at)}</span>
+                  </div>
+                </div>
+                <div className="tp-app-actions">
+                  <button
+                    className="tp-btn tp-btn-destructive"
+                    onClick={() => setRevokingId(app.client_id)}
+                    data-testid={`connected-apps-revoke-${app.client_id}`}
+                  >
+                    撤銷
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {revokingId && target && (
+        <div className="tp-modal-backdrop" role="dialog" aria-modal="true" data-testid="connected-apps-confirm-modal">
+          <div className="tp-modal">
+            <div className="tp-modal-header">
+              <div className="tp-modal-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                  <line x1="12" y1="9" x2="12" y2="13" />
+                  <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+              </div>
+              <h3>撤銷 {target.app_name} 的存取權？</h3>
+            </div>
+            <div className="tp-modal-body">
+              撤銷後 {target.app_name} 將立即無法讀取或修改你的行程。<br />
+              未來想再使用必須重新授權。
+            </div>
+            <div className="tp-modal-footer">
+              <button
+                className="tp-btn"
+                onClick={() => setRevokingId(null)}
+                disabled={revokeBusy}
+                data-testid="connected-apps-cancel-revoke"
+              >
+                取消
+              </button>
+              <button
+                className="tp-btn tp-btn-destructive"
+                style={{ background: 'var(--color-destructive)', color: '#fff', borderColor: 'var(--color-destructive)' }}
+                onClick={() => confirmRevoke(revokingId)}
+                disabled={revokeBusy}
+                data-testid="connected-apps-confirm-revoke"
+              >
+                {revokeBusy ? '撤銷中…' : '確認撤銷'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/tests/unit/connected-apps-page.test.tsx
+++ b/tests/unit/connected-apps-page.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * ConnectedAppsPage unit test — V2-P5
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ConnectedAppsPage from '../../src/pages/ConnectedAppsPage';
+
+const SAMPLE_APPS = [
+  {
+    client_id: 'tp_abc',
+    app_name: 'Trip Buddy',
+    app_logo_url: null,
+    app_description: 'Travel app',
+    homepage_url: 'https://example.com',
+    status: 'active',
+    scopes: ['openid', 'profile', 'trips.read'],
+    granted_at: Date.now() - 7 * 24 * 60 * 60 * 1000, // 7 days ago
+  },
+  {
+    client_id: 'tp_xyz',
+    app_name: 'MapMate',
+    app_logo_url: null,
+    app_description: null,
+    homepage_url: null,
+    status: 'active',
+    scopes: ['openid'],
+    granted_at: Date.now() - 60 * 60 * 1000, // 1h ago
+  },
+];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('ConnectedAppsPage', () => {
+  it('shows loading initially', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    expect(screen.getByTestId('connected-apps-loading')).toBeTruthy();
+  });
+
+  it('renders empty state when no apps', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apps: [] }), { status: 200 }),
+    ));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-empty')).toBeTruthy());
+    expect(screen.getByText(/還沒有任何應用/)).toBeTruthy();
+  });
+
+  it('renders apps list with name + scopes', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apps: SAMPLE_APPS }), { status: 200 }),
+    ));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-row-tp_abc')).toBeTruthy());
+    expect(screen.getByText('Trip Buddy')).toBeTruthy();
+    expect(screen.getByText('MapMate')).toBeTruthy();
+    expect(screen.getAllByText('openid').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('trips.read')).toBeTruthy();
+  });
+
+  it('Revoke button → opens confirm modal (二次確認)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apps: SAMPLE_APPS }), { status: 200 }),
+    ));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-revoke-tp_abc')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('connected-apps-revoke-tp_abc'));
+    expect(screen.getByTestId('connected-apps-confirm-modal')).toBeTruthy();
+    expect(screen.getByText(/撤銷 Trip Buddy/)).toBeTruthy();
+  });
+
+  it('Cancel modal → no DELETE call', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apps: SAMPLE_APPS }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-revoke-tp_abc')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('connected-apps-revoke-tp_abc'));
+    fireEvent.click(screen.getByTestId('connected-apps-cancel-revoke'));
+
+    // Modal closed
+    expect(screen.queryByTestId('connected-apps-confirm-modal')).toBeNull();
+    // Only initial GET, no DELETE
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Confirm revoke → DELETE + remove from list', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ apps: SAMPLE_APPS }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, revoked_client_id: 'tp_abc' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-revoke-tp_abc')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('connected-apps-revoke-tp_abc'));
+    fireEvent.click(screen.getByTestId('connected-apps-confirm-revoke'));
+
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-row-tp_abc')).toBeNull());
+    // tp_xyz still there
+    expect(screen.queryByTestId('connected-apps-row-tp_xyz')).toBeTruthy();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const deleteCall = fetchMock.mock.calls[1]!;
+    expect(deleteCall[0]).toBe('/api/account/connected-apps/tp_abc');
+    expect((deleteCall[1] as RequestInit).method).toBe('DELETE');
+  });
+
+  it('GET fail → error banner', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('net')));
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-error')).toBeTruthy());
+  });
+
+  it('encodes client_id in DELETE URL (防 path injection)', async () => {
+    const trickyApp = {
+      ...SAMPLE_APPS[0]!,
+      client_id: 'tp_a/b?c=1',
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ apps: [trickyApp] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useRealTimers();
+
+    render(<MemoryRouter><ConnectedAppsPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('connected-apps-revoke-tp_a/b?c=1')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('connected-apps-revoke-tp_a/b?c=1'));
+    fireEvent.click(screen.getByTestId('connected-apps-confirm-revoke'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const url = fetchMock.mock.calls[1]![0] as string;
+    expect(url).toBe('/api/account/connected-apps/tp_a%2Fb%3Fc%3D1');
+  });
+});


### PR DESCRIPTION
## Summary

V2-P5 frontend：用戶端管理已授權的 OAuth client_apps。配合 mockup section 4「已連結的應用」+ PR #293 backend API。

| Route | Component | Backend |
|-------|-----------|---------|
| `/settings/connected-apps` | ConnectedAppsPage | #293 GET/DELETE /api/account/connected-apps |

### Features

- 載入 / 空狀態 / 列表 / 撤銷 modal 完整 state machine
- 二次確認 modal（破壞性操作）
- 撤銷成功 → optimistic remove from list
- 撤銷失敗 → error banner
- relativeTime 顯示授權時間（剛才 / N 分鐘前 / N 天前）

### Security 細節

- **encodeURIComponent client_id** 防 path injection（test 涵蓋 `tp_a/b?c=1` 邊界）
- 二次確認 modal 強制明確意圖
- 撤銷中按鈕 disabled 防 double-submit

## Test plan

- [x] tsc strict 全過
- [x] 902/902 vitest 全綠（+8 new cases）

### Test 涵蓋

- Loading initial state
- Empty state
- Apps list 渲染（name / scopes pills）
- Revoke 觸發 modal
- Cancel modal 不 DELETE
- Confirm → DELETE + optimistic remove
- GET 失敗 → error banner
- encodeURIComponent path injection guard

## V2-P5 progress

- [x] #293 Backend API
- [x] **本 PR** ConnectedAppsPage UI
- [ ] V2-P5 next：sidebar 導航連結到 /settings/connected-apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)