### PR TITLE
feat(v2): sidebar nav — settings/connected-apps + developer/apps entries

### DIFF
--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import Icon from '../shared/Icon';
 
 interface NavItemConfig {
-  key: 'chat' | 'trips' | 'map' | 'explore' | 'login';
+  key: 'chat' | 'trips' | 'map' | 'explore' | 'login' | 'settings' | 'developer';
   label: string;
   href: string;
   icon: string;
@@ -21,12 +21,17 @@ interface NavItemConfig {
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItemConfig> = [
-  { key: 'chat',    label: '聊天', href: '/chat',    icon: 'chat',   matchPrefixes: ['/chat'] },
-  { key: 'trips',   label: '行程', href: '/manage',  icon: 'home',   matchPrefixes: ['/manage', '/trip'] },
-  { key: 'map',     label: '地圖', href: '/map',     icon: 'map',    matchPrefixes: ['/map'], exactOnly: true },
-  { key: 'explore', label: '探索', href: '/explore', icon: 'search', matchPrefixes: ['/explore'] },
-  { key: 'login',   label: '登入', href: '/login',   icon: 'user',   matchPrefixes: ['/login'] },
+  { key: 'chat',      label: '聊天',     href: '/chat',                       icon: 'chat',   matchPrefixes: ['/chat'] },
+  { key: 'trips',     label: '行程',     href: '/manage',                     icon: 'home',   matchPrefixes: ['/manage', '/trip'] },
+  { key: 'map',       label: '地圖',     href: '/map',                        icon: 'map',    matchPrefixes: ['/map'], exactOnly: true },
+  { key: 'explore',   label: '探索',     href: '/explore',                    icon: 'search', matchPrefixes: ['/explore'] },
+  { key: 'settings',  label: '已連結應用', href: '/settings/connected-apps',   icon: 'gear',   matchPrefixes: ['/settings'] },
+  { key: 'developer', label: '開發者',   href: '/developer/apps',             icon: 'code',   matchPrefixes: ['/developer'] },
+  { key: 'login',     label: '登入',     href: '/login',                      icon: 'user',   matchPrefixes: ['/login'] },
 ];
+
+// Auth-required nav items — hidden for anonymous users
+const AUTH_REQUIRED_NAV_KEYS = new Set(['settings', 'developer']);
 
 function isItemActive(pathname: string, item: NavItemConfig): boolean {
   for (const prefix of item.matchPrefixes) {
@@ -168,10 +173,11 @@ export default function DesktopSidebar({ user, onNewTrip, brand }: DesktopSideba
   const { pathname } = useLocation();
   const initial = user?.name?.charAt(0)?.toUpperCase() ?? '?';
 
-  // Logged in 時 hide「登入」 nav item — user chip + 登出 link 已在 sidebar bottom
+  // Logged in: hide '登入' (use chip + 登出 link 在底部); show settings/developer
+  // Logged out: hide auth-required items; show '登入'
   const visibleNavItems = user
     ? NAV_ITEMS.filter((item) => item.key !== 'login')
-    : NAV_ITEMS;
+    : NAV_ITEMS.filter((item) => !AUTH_REQUIRED_NAV_KEYS.has(item.key));
 
   return (
     <>


### PR DESCRIPTION
## Summary

接通先前 PR 落地的 user-facing 入口到 DesktopSidebar 主導航。

| Nav item | Href | Visibility |
|----------|------|-----------|
| 已連結應用 (gear) | `/settings/connected-apps` | logged-in only |
| 開發者 (code) | `/developer/apps` | logged-in only |

### 邏輯

- 加 `AUTH_REQUIRED_NAV_KEYS` set 標 settings/developer
- 已登入：show all incl. settings/developer，hide「登入」
- 未登入：hide settings/developer，show「登入」（避免 click 進去拿 401）

### 依賴

無 backend 依賴 — 純前端 nav 加入。實際頁面由 PR #299 (ConnectedAppsPage) + PR #300 (DeveloperAppsPage) 提供。在那兩 PR merge 前，nav 連到 nonexistent route → SPA fall through to LegacyRedirect。建議按 #299 → #300 → 本 PR 順序 merge。

## Test plan

- [x] tsc strict 全過
- [x] 894/894 vitest 全綠（既有 sidebar tests 仍 pass — 新 nav items 不影響邏輯）

🤖 Generated with [Claude Code](https://claude.com/claude-code)