### PR TITLE
feat(v2-p3): wire email service into verify / forgot / reset endpoints

### DIFF
--- a/functions/api/_types.ts
+++ b/functions/api/_types.ts
@@ -20,4 +20,7 @@ export interface Env {
   SESSION_SECRET?: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
+  // V2-P3 email service (Resend)
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string; // e.g. 'Tripline <no-reply@trip-planner-dby.pages.dev>'
 }

--- a/functions/api/oauth/forgot-password.ts
+++ b/functions/api/oauth/forgot-password.ts
@@ -24,6 +24,8 @@
  */
 import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
 import { parseJsonBody } from '../_utils';
+import { sendEmail, EmailError } from '../../../src/server/email';
+import { passwordReset } from '../../../src/server/email-templates';
 import type { Env } from '../_types';
 
 interface ForgotBody {
@@ -55,12 +57,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   // Check if user exists with local provider
   const user = await context.env.DB
     .prepare(
-      `SELECT u.id AS user_id FROM users u
+      `SELECT u.id AS user_id, u.display_name FROM users u
        JOIN auth_identities ai ON ai.user_id = u.id
        WHERE u.email = ? AND ai.provider = 'local' LIMIT 1`,
     )
     .bind(email)
-    .first<{ user_id: string }>();
+    .first<{ user_id: string; display_name: string | null }>();
 
   if (!user) {
     // Don't generate token, but return same generic response
@@ -76,8 +78,25 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     TTL_SEC,
   );
 
-  // V2-P3 next slice: send email with reset link {origin}/reset-password?token={token}
-  // 目前 token 只 in D1, dev 用 wrangler d1 exec 看；prod 等 email send 接通。
+  // Send reset email — best-effort (token stays in D1 even if email fails)
+  if (context.env.RESEND_API_KEY && context.env.EMAIL_FROM) {
+    const origin = new URL(context.request.url).origin;
+    const resetUrl = `${origin}/auth/password/reset?token=${encodeURIComponent(token)}`;
+    const tpl = passwordReset(resetUrl, user.display_name);
+    try {
+      await sendEmail(context.env, {
+        to: email,
+        subject: tpl.subject,
+        html: tpl.html,
+        text: tpl.text,
+      });
+    } catch (err) {
+      // best-effort — anti-enum response unchanged
+      // eslint-disable-next-line no-console
+      console.error('[forgot-password] email send failed:',
+        err instanceof EmailError ? `${err.status} ${err.message}` : (err as Error).message);
+    }
+  }
 
   return genericResponse;
 };

--- a/functions/api/oauth/reset-password.ts
+++ b/functions/api/oauth/reset-password.ts
@@ -20,6 +20,8 @@
 import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
 import { hashPassword } from '../../../src/server/password';
 import { parseJsonBody } from '../_utils';
+import { sendEmail, EmailError } from '../../../src/server/email';
+import { passwordChangedConfirm } from '../../../src/server/email-templates';
 import type { Env } from '../_types';
 
 interface ResetBody {
@@ -87,6 +89,28 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
   // Destroy token (one-time use guard)
   await adapter.destroy(token);
+
+  // Send confirmation email — best-effort，不擋成功 response
+  if (context.env.RESEND_API_KEY && context.env.EMAIL_FROM) {
+    try {
+      const userRow = await context.env.DB
+        .prepare('SELECT display_name FROM users WHERE id = ?')
+        .bind(tokenRow.userId)
+        .first<{ display_name: string | null }>();
+      const tpl = passwordChangedConfirm(userRow?.display_name ?? null);
+      await sendEmail(context.env, {
+        to: tokenRow.email,
+        subject: tpl.subject,
+        html: tpl.html,
+        text: tpl.text,
+      });
+    } catch (err) {
+      // best-effort
+      // eslint-disable-next-line no-console
+      console.error('[reset-password] confirmation email failed:',
+        err instanceof EmailError ? `${err.status} ${err.message}` : (err as Error).message);
+    }
+  }
 
   return new Response(
     JSON.stringify({ ok: true, message: '密碼已更新，請用新密碼登入' }),

--- a/functions/api/oauth/send-verification.ts
+++ b/functions/api/oauth/send-verification.ts
@@ -19,6 +19,8 @@
  */
 import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
 import { parseJsonBody } from '../_utils';
+import { sendEmail, EmailError } from '../../../src/server/email';
+import { emailVerification } from '../../../src/server/email-templates';
 import type { Env } from '../_types';
 
 interface SendVerificationBody {
@@ -46,13 +48,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
   if (!email) return genericResponse;
 
-  // Look up unverified user
+  // Look up unverified user (joined to display_name for email greeting)
   const user = await context.env.DB
     .prepare(
-      `SELECT id FROM users WHERE email = ? AND email_verified_at IS NULL LIMIT 1`,
+      `SELECT id, display_name
+       FROM users
+       WHERE email = ? AND email_verified_at IS NULL LIMIT 1`,
     )
     .bind(email)
-    .first<{ id: string }>();
+    .first<{ id: string; display_name: string | null }>();
 
   if (!user) {
     // Either email doesn't exist or already verified — silent no-op
@@ -68,8 +72,25 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     TTL_SEC,
   );
 
-  // V2-P3 next slice: send email with verify link {origin}/api/oauth/verify?token={token}
-  // 目前 token 只 in D1, dev 用 wrangler d1 exec 看；prod 等 email send 接通。
+  // Send verification email — best-effort (token stays in D1 even if email fails)
+  if (context.env.RESEND_API_KEY && context.env.EMAIL_FROM) {
+    const origin = new URL(context.request.url).origin;
+    const verifyUrl = `${origin}/api/oauth/verify?token=${encodeURIComponent(token)}`;
+    const tpl = emailVerification(verifyUrl, user.display_name);
+    try {
+      await sendEmail(context.env, {
+        to: email,
+        subject: tpl.subject,
+        html: tpl.html,
+        text: tpl.text,
+      });
+    } catch (err) {
+      // best-effort: log but still return generic 200 (anti-enum + token in D1 valid)
+      // eslint-disable-next-line no-console
+      console.error('[send-verification] email send failed:',
+        err instanceof EmailError ? `${err.status} ${err.message}` : (err as Error).message);
+    }
+  }
 
   return genericResponse;
 };

--- a/functions/api/oauth/send-verification.ts
+++ b/functions/api/oauth/send-verification.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/oauth/send-verification
+ * Body: { email: string }
+ *
+ * V2-P2 — Generate email verification token + (V2-P3 email service 接通) send link。
+ *
+ * Anti-enumeration：response 永遠 generic 200。Email 不存在或已驗證的 case 都
+ * 不洩漏給 caller — 只有真正 unverified user 才產 token。
+ *
+ * Flow:
+ *   1. lowercase email
+ *   2. SELECT users WHERE email = ? AND email_verified_at IS NULL
+ *   3. 若 found：產 token + D1Adapter upsert (24h TTL per V2-P2 spec)
+ *   4. 若 not found / already verified：silently no-op
+ *   5. Always return 200 generic
+ *
+ * V2-P3 next slice：integrate email service to actually send link
+ *   {origin}/api/oauth/verify?token={token}
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import { parseJsonBody } from '../_utils';
+import type { Env } from '../_types';
+
+interface SendVerificationBody {
+  email?: string;
+}
+
+const TTL_SEC = 24 * 60 * 60; // 24h per V2-P2 spec
+
+function generateVerifyToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let str = '';
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]!);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const body = (await parseJsonBody<SendVerificationBody>(context.request)) ?? {};
+  const email = (body.email ?? '').trim().toLowerCase();
+
+  const genericResponse = new Response(
+    JSON.stringify({ ok: true, message: '若帳號需要驗證，驗證信會寄至信箱' }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+
+  if (!email) return genericResponse;
+
+  // Look up unverified user
+  const user = await context.env.DB
+    .prepare(
+      `SELECT id FROM users WHERE email = ? AND email_verified_at IS NULL LIMIT 1`,
+    )
+    .bind(email)
+    .first<{ id: string }>();
+
+  if (!user) {
+    // Either email doesn't exist or already verified — silent no-op
+    return genericResponse;
+  }
+
+  // Generate + store token
+  const token = generateVerifyToken();
+  const adapter = new D1Adapter(context.env.DB, 'EmailVerification');
+  await adapter.upsert(
+    token,
+    { userId: user.id, email, createdAt: Date.now(), used: false },
+    TTL_SEC,
+  );
+
+  // V2-P3 next slice: send email with verify link {origin}/api/oauth/verify?token={token}
+  // 目前 token 只 in D1, dev 用 wrangler d1 exec 看；prod 等 email send 接通。
+
+  return genericResponse;
+};

--- a/functions/api/oauth/verify.ts
+++ b/functions/api/oauth/verify.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/oauth/verify?token=<token>
+ *
+ * V2-P2 — Email verification endpoint。User 點 email 連結 → 驗 token →
+ * UPDATE users.email_verified_at → 302 redirect /login?verified=1。
+ *
+ * Flow:
+ *   1. Extract token from query
+ *   2. D1Adapter find token (oauth_models name='EmailVerification')
+ *   3. If not found / expired / used → 302 /login?verify_error=expired
+ *   4. UPDATE users SET email_verified_at = ISO_NOW WHERE id = userId
+ *   5. destroy token (one-time use)
+ *   6. 302 /login?verified=1
+ *
+ * 為什麼 GET 而不 POST：使用者點 email 連結觸發。標準 email-link 模式都用 GET。
+ * Token 在 URL（不在 body）的安全考量：
+ *   - referrer leak：依靠 V2-P5 callback page 加 Referrer-Policy: no-referrer
+ *   - browser history：token 確實會留 history。短 TTL (24h) + one-time-use 限制 risk
+ */
+import { D1Adapter } from '../../../src/server/oauth-d1-adapter';
+import type { Env } from '../_types';
+
+interface VerifyTokenPayload {
+  userId: string;
+  email: string;
+  createdAt: number;
+  used?: boolean;
+  [key: string]: unknown;
+}
+
+function redirect(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const token = (url.searchParams.get('token') ?? '').trim();
+
+  if (!token) {
+    return redirect('/login?verify_error=missing_token');
+  }
+
+  const adapter = new D1Adapter(context.env.DB, 'EmailVerification');
+  const tokenRow = (await adapter.find(token)) as VerifyTokenPayload | undefined;
+
+  if (!tokenRow) {
+    return redirect('/login?verify_error=expired');
+  }
+  if (tokenRow.used) {
+    return redirect('/login?verify_error=used');
+  }
+
+  // Mark user verified
+  try {
+    await context.env.DB
+      .prepare('UPDATE users SET email_verified_at = ? WHERE id = ?')
+      .bind(new Date().toISOString(), tokenRow.userId)
+      .run();
+  } catch {
+    // DB failure — token still valid, user can retry. Don't burn token.
+    return redirect('/login?verify_error=server_error');
+  }
+
+  // Destroy token (one-time use)
+  await adapter.destroy(token);
+
+  return redirect('/login?verified=1');
+};

--- a/src/server/email-templates.ts
+++ b/src/server/email-templates.ts
@@ -1,0 +1,131 @@
+/**
+ * Email HTML templates — V2-P3 transactional emails (繁體中文)
+ *
+ * 設計原則 (per V2 design doc Email section)：
+ *   - Inline CSS（外部 CSS 在 email client 不可靠）
+ *   - Table-based layout（max compatibility）
+ *   - Terracotta brand color（#D97848）
+ *   - 簡單 HTML，不用 image / external font
+ *   - 同時提供 plain text fallback（spam filter 友好）
+ *
+ * Templates:
+ *   - emailVerification(verifyUrl, displayName?) — 註冊後驗 email
+ *   - passwordReset(resetUrl, displayName?) — 忘記密碼重設
+ *   - passwordChangedConfirm(displayName?) — 密碼已更改通知
+ *
+ * 不放 user-controlled HTML 進 template — 全部 user input (displayName) 過
+ * `escapeHtml` 防 XSS。連結 URL 由 caller 組好（已 encodeURIComponent token）。
+ */
+
+export interface EmailTemplate {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const BRAND_COLOR = '#D97848';
+const BRAND_DEEP = '#B85C2E';
+const BG_COLOR = '#FFFBF5';
+const TEXT_COLOR = '#2A1F18';
+const MUTED_COLOR = '#6F5A47';
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function shellHtml(innerHtml: string): string {
+  return `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0; padding:24px; font-family: 'Helvetica Neue', Arial, 'Noto Sans TC', sans-serif; background:${BG_COLOR}; color:${TEXT_COLOR}; line-height:1.5;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px; margin:0 auto;">
+<tr><td>
+<div style="text-align:center; padding:24px 0; font-size:18px; font-weight:800; letter-spacing:-0.02em;">
+  <span style="color:${BRAND_COLOR};">●</span> Tripline
+</div>
+${innerHtml}
+<div style="text-align:center; padding:24px 0 0; font-size:12px; color:${MUTED_COLOR};">
+  本信件自動發出，請勿直接回覆。<br>
+  Tripline · 行程共享網站
+</div>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function ctaButton(url: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px auto;">
+<tr><td style="border-radius:10px; background:${BRAND_COLOR};">
+<a href="${escapeHtml(url)}" style="display:inline-block; padding:14px 32px; color:#fff; text-decoration:none; font-size:15px; font-weight:600; border-radius:10px;">${escapeHtml(label)}</a>
+</td></tr>
+</table>`;
+}
+
+export function emailVerification(verifyUrl: string, displayName?: string | null): EmailTemplate {
+  const greetName = displayName ? `${escapeHtml(displayName)}，` : '';
+  return {
+    subject: '驗證您的 Tripline 帳號',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">歡迎加入 Tripline${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">${greetName}請點擊下方按鈕驗證您的 email，完成註冊。</p>
+  ${ctaButton(verifyUrl, '驗證 Email')}
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">或複製以下連結到瀏覽器：</p>
+  <p style="margin:0 0 16px; font-size:12px; color:${MUTED_COLOR}; word-break:break-all;"><a href="${escapeHtml(verifyUrl)}" style="color:${BRAND_DEEP}; text-decoration:none;">${escapeHtml(verifyUrl)}</a></p>
+  <p style="margin:0; font-size:12px; color:${MUTED_COLOR};">此連結 24 小時內有效。如果不是您本人申請，請忽略此信件。</p>
+</div>
+`),
+    text: `歡迎加入 Tripline${displayName ? `，${displayName}` : ''}\n\n請點擊以下連結驗證您的 email：\n${verifyUrl}\n\n連結 24 小時內有效。如果不是您本人申請，請忽略此信件。\n\n— Tripline`,
+  };
+}
+
+export function passwordReset(resetUrl: string, displayName?: string | null): EmailTemplate {
+  return {
+    subject: '重設您的 Tripline 密碼',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">重設密碼${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">我們收到您重設密碼的請求。點擊下方按鈕設定新密碼：</p>
+  ${ctaButton(resetUrl, '重設密碼')}
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">或複製以下連結到瀏覽器：</p>
+  <p style="margin:0 0 16px; font-size:12px; color:${MUTED_COLOR}; word-break:break-all;"><a href="${escapeHtml(resetUrl)}" style="color:${BRAND_DEEP}; text-decoration:none;">${escapeHtml(resetUrl)}</a></p>
+  <p style="margin:0 0 8px; font-size:13px; color:${MUTED_COLOR};">為了您的帳號安全：</p>
+  <ul style="margin:0; padding-left:20px; font-size:12px; color:${MUTED_COLOR};">
+    <li>此連結 1 小時內有效</li>
+    <li>連結只能使用一次</li>
+    <li>重設後您所有裝置將被登出，需重新登入</li>
+  </ul>
+  <p style="margin:16px 0 0; font-size:12px; color:${MUTED_COLOR};">如果不是您本人申請，可忽略此信件。您的密碼不會變更。</p>
+</div>
+`),
+    text: `重設密碼${displayName ? `，${displayName}` : ''}\n\n我們收到您重設密碼的請求。請點擊以下連結設定新密碼：\n${resetUrl}\n\n· 此連結 1 小時內有效\n· 連結只能使用一次\n· 重設後您所有裝置將被登出\n\n如果不是您本人申請，可忽略此信件。\n\n— Tripline`,
+  };
+}
+
+export function passwordChangedConfirm(displayName?: string | null): EmailTemplate {
+  return {
+    subject: 'Tripline 密碼已更改',
+    html: shellHtml(`
+<div style="background:#fff; border:1px solid #EADFCF; border-radius:14px; padding:32px;">
+  <h2 style="margin:0 0 16px; font-size:22px; font-weight:800;">密碼已更改${displayName ? `，${escapeHtml(displayName)}` : ''}</h2>
+  <p style="margin:0 0 16px; font-size:15px;">您的 Tripline 帳號密碼已成功更改。為了安全，您所有裝置上的登入已自動登出。</p>
+  <p style="margin:0 0 8px; font-size:14px; color:${MUTED_COLOR};">如果不是您本人操作：</p>
+  <ul style="margin:0; padding-left:20px; font-size:13px; color:${MUTED_COLOR};">
+    <li>立即重設密碼防止帳號被盜用</li>
+    <li>檢查最近的登入裝置（設定 → 登入裝置）</li>
+    <li>有疑問請聯絡我們</li>
+  </ul>
+</div>
+`),
+    text: `密碼已更改${displayName ? `，${displayName}` : ''}\n\n您的 Tripline 帳號密碼已成功更改。為了安全，您所有裝置已自動登出。\n\n如果不是您本人操作：\n· 立即重設密碼\n· 檢查最近的登入裝置\n· 有疑問請聯絡我們\n\n— Tripline`,
+  };
+}

--- a/src/server/email.ts
+++ b/src/server/email.ts
@@ -1,0 +1,100 @@
+/**
+ * Email service — V2-P3 transactional email send via Resend API
+ *
+ * 為何 Resend：Workers fetch-friendly、3k/月免費、developer-first docs（per
+ * V2-OAuth design doc Open Question #1 + autoplan finding）。
+ *
+ * 為何不 Cloudflare Email Routing：forward-only (inbound)，outbound 仍 beta，
+ * 不適合 production 主流程。
+ *
+ * Usage:
+ *   import { sendEmail, type EmailEnv } from 'src/server/email';
+ *   await sendEmail(env, {
+ *     to: 'user@example.com',
+ *     subject: '驗證您的 Tripline 帳號',
+ *     html: ...,
+ *     text: ...,
+ *   });
+ *
+ * Best-effort：Resend API 失敗 → 拋 EmailError，caller 決定是否阻擋業務流程。
+ *   - signup verify email failure → user 看 fallback 訊息「無法寄信，請使用重寄」
+ *   - password reset failure → 同樣 fallback
+ *   - 視為「不影響 user 帳號狀態」的 best-effort，但 audit log 仍記錄 failure
+ */
+
+export interface EmailEnv {
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string; // e.g. 'Tripline <no-reply@trip-planner-dby.pages.dev>'
+}
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface SendEmailResult {
+  ok: true;
+  /** Resend message id (for tracking) */
+  id: string;
+}
+
+export class EmailError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+
+export async function sendEmail(
+  env: EmailEnv,
+  params: SendEmailParams,
+): Promise<SendEmailResult> {
+  if (!env.RESEND_API_KEY) {
+    throw new EmailError('RESEND_API_KEY not configured', 500, null);
+  }
+  if (!env.EMAIL_FROM) {
+    throw new EmailError('EMAIL_FROM not configured', 500, null);
+  }
+
+  const body = {
+    from: env.EMAIL_FROM,
+    to: [params.to],
+    subject: params.subject,
+    html: params.html,
+    ...(params.text ? { text: params.text } : {}),
+  };
+
+  const res = await fetch(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  let respBody: unknown = null;
+  try {
+    respBody = await res.json();
+  } catch {
+    /* non-json response — keep null */
+  }
+
+  if (!res.ok) {
+    throw new EmailError(`Resend API ${res.status}`, res.status, respBody);
+  }
+
+  const idVal = (respBody as Record<string, unknown> | null)?.id;
+  if (typeof idVal !== 'string') {
+    throw new EmailError('Resend response missing id', res.status, respBody);
+  }
+  return { ok: true, id: idVal };
+}

--- a/tests/api/email-module.test.ts
+++ b/tests/api/email-module.test.ts
@@ -1,0 +1,171 @@
+/**
+ * src/server/email.ts + email-templates.ts unit test — V2-P3
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendEmail, EmailError } from '../../src/server/email';
+import {
+  emailVerification,
+  passwordReset,
+  passwordChangedConfirm,
+} from '../../src/server/email-templates';
+
+const ENV_OK = {
+  RESEND_API_KEY: 're_test_key_123',
+  EMAIL_FROM: 'Tripline <no-reply@example.com>',
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sendEmail', () => {
+  it('throws EmailError when RESEND_API_KEY missing', async () => {
+    await expect(sendEmail({ EMAIL_FROM: 'a@b.com' }, {
+      to: 'u@x.com', subject: 's', html: '<p>x</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+
+  it('throws EmailError when EMAIL_FROM missing', async () => {
+    await expect(sendEmail({ RESEND_API_KEY: 'k' }, {
+      to: 'u@x.com', subject: 's', html: '<p>x</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+
+  it('POSTs to Resend API with Bearer auth + JSON body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg-123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await sendEmail(ENV_OK, {
+      to: 'user@example.com',
+      subject: 'Test',
+      html: '<p>hello</p>',
+      text: 'hello',
+    });
+
+    expect(result.id).toBe('msg-123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(opts.method).toBe('POST');
+    expect((opts.headers as Record<string, string>).Authorization).toBe(
+      'Bearer re_test_key_123',
+    );
+    expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body.from).toBe('Tripline <no-reply@example.com>');
+    expect(body.to).toEqual(['user@example.com']);
+    expect(body.subject).toBe('Test');
+    expect(body.html).toBe('<p>hello</p>');
+    expect(body.text).toBe('hello');
+  });
+
+  it('omits text field when not provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'm' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await sendEmail(ENV_OK, { to: 'u@x.com', subject: 's', html: '<p>h</p>' });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+    ) as Record<string, unknown>;
+    expect(body.text).toBeUndefined();
+  });
+
+  it('throws EmailError on Resend API error (4xx/5xx)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_api_key' }), { status: 401 }),
+    ));
+    await expect(sendEmail(ENV_OK, {
+      to: 'u@x.com', subject: 's', html: '<p>h</p>',
+    })).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('throws EmailError when response missing id', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    ));
+    await expect(sendEmail(ENV_OK, {
+      to: 'u@x.com', subject: 's', html: '<p>h</p>',
+    })).rejects.toBeInstanceOf(EmailError);
+  });
+});
+
+describe('email-templates', () => {
+  describe('emailVerification', () => {
+    it('subject + URL embedded in html + text', () => {
+      const tpl = emailVerification('https://x.com/verify?token=abc', 'Ray');
+      expect(tpl.subject).toContain('驗證');
+      expect(tpl.html).toContain('https://x.com/verify?token=abc');
+      expect(tpl.html).toContain('Ray');
+      expect(tpl.text).toContain('https://x.com/verify?token=abc');
+    });
+
+    it('no displayName works (anonymous greeting)', () => {
+      const tpl = emailVerification('https://x.com/v?t=t');
+      expect(tpl.html).toContain('歡迎加入 Tripline');
+    });
+
+    it('escapes HTML in displayName (XSS defence)', () => {
+      const tpl = emailVerification('https://x.com/v?t=t', '<script>alert(1)</script>');
+      expect(tpl.html).not.toContain('<script>alert(1)</script>');
+      expect(tpl.html).toContain('&lt;script&gt;');
+    });
+
+    it('escapes HTML in URL (anti-injection)', () => {
+      const tpl = emailVerification('https://x.com/v?t=" onclick=alert(1)');
+      expect(tpl.html).not.toContain('" onclick=alert(1)');
+      expect(tpl.html).toContain('&quot;');
+    });
+  });
+
+  describe('passwordReset', () => {
+    it('embeds reset URL + mentions 1h validity', () => {
+      const tpl = passwordReset('https://x.com/reset?token=xyz');
+      expect(tpl.html).toContain('https://x.com/reset?token=xyz');
+      expect(tpl.html).toContain('1 小時');
+      expect(tpl.html).toContain('一次');
+    });
+
+    it('mentions all-device logout', () => {
+      const tpl = passwordReset('https://x.com/r');
+      expect(tpl.html).toContain('登出');
+    });
+
+    it('escapes HTML in displayName', () => {
+      const tpl = passwordReset('https://x.com/r', '"><img src=x>');
+      expect(tpl.html).not.toContain('"><img src=x>');
+      expect(tpl.html).toContain('&quot;');
+    });
+  });
+
+  describe('passwordChangedConfirm', () => {
+    it('subject + recovery instructions if not user', () => {
+      const tpl = passwordChangedConfirm('Ray');
+      expect(tpl.subject).toContain('密碼');
+      expect(tpl.html).toContain('Ray');
+      expect(tpl.html).toContain('立即');
+      expect(tpl.text).toContain('登入');
+    });
+  });
+
+  describe('all templates produce non-empty plain-text fallback', () => {
+    it.each([
+      emailVerification('https://x.com/v?t=a'),
+      passwordReset('https://x.com/r?t=b'),
+      passwordChangedConfirm('user'),
+    ])('template has both html and text', (tpl) => {
+      expect(tpl.html.length).toBeGreaterThan(50);
+      expect(tpl.text.length).toBeGreaterThan(20);
+    });
+  });
+});

--- a/tests/api/oauth-forgot-password.test.ts
+++ b/tests/api/oauth-forgot-password.test.ts
@@ -121,4 +121,47 @@ describe('POST /api/oauth/forgot-password', () => {
     const sql = dbPrepare.mock.calls[0][0] as string;
     expect(sql).toContain("provider = 'local'");
   });
+
+  it('sends reset email via Resend when env keys set (V2-P3 wire)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg-1' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT u.id')) return makeStmt({ user_id: 'u-1', display_name: 'Ray' });
+      return makeStmt();
+    });
+    const env = {
+      DB: { prepare: dbPrepare },
+      RESEND_API_KEY: 're_test',
+      EMAIL_FROM: 'Tripline <no-reply@example.com>',
+    };
+    await onRequestPost(makeContext({ email: 'u@x.com' }, env as never));
+
+    const resendCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('resend.com'),
+    );
+    expect(resendCall).toBeTruthy();
+    const body = JSON.parse((resendCall![1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.to).toEqual(['u@x.com']);
+    expect(body.subject).toContain('重設');
+    expect(body.html).toContain('https://x.com/auth/password/reset?token=');
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT send email when env keys unset (graceful)', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT u.id')) return makeStmt({ user_id: 'u', display_name: null });
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onRequestPost(makeContext({ email: 'u@x.com' }, env));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
 });

--- a/tests/api/oauth-reset-password.test.ts
+++ b/tests/api/oauth-reset-password.test.ts
@@ -125,4 +125,59 @@ describe('POST /api/oauth/reset-password', () => {
     )?.[0] as string;
     expect(updateSql).toContain("provider = 'local'");
   }, 30_000);
+
+  it('sends confirmation email when env keys set (V2-P3 wire)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg-1' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u-1', email: 'u@x.com', createdAt: 0, used: false }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      if (sql.includes('SELECT display_name FROM users')) {
+        return makeStmt({ display_name: 'Ray' });
+      }
+      return makeStmt();
+    });
+    const env = {
+      DB: { prepare: dbPrepare },
+      RESEND_API_KEY: 're_test',
+      EMAIL_FROM: 'Tripline <no-reply@example.com>',
+    };
+    await onRequestPost(makeContext({ token: 't', password: 'newpass1234' }, env as never));
+
+    const resendCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('resend.com'),
+    );
+    expect(resendCall).toBeTruthy();
+    const body = JSON.parse((resendCall![1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.to).toEqual(['u@x.com']);
+    expect(body.subject).toContain('密碼');
+    vi.unstubAllGlobals();
+  }, 30_000);
+
+  it('does NOT send confirmation email when env keys unset', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u-1', email: 'u@x.com', createdAt: 0, used: false }),
+          expires_at: Date.now() + 60000,
+        });
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onRequestPost(makeContext({ token: 't', password: 'newpass1234' }, env));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  }, 30_000);
 });

--- a/tests/api/oauth-verify.test.ts
+++ b/tests/api/oauth-verify.test.ts
@@ -1,0 +1,221 @@
+/**
+ * /api/oauth/verify + /api/oauth/send-verification — V2-P2 email verification
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet } from '../../functions/api/oauth/verify';
+import { onRequestPost as onSendVerification } from '../../functions/api/oauth/send-verification';
+
+interface MockEnv {
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+  };
+}
+
+function makeVerifyContext(query: string, env: MockEnv): Parameters<typeof onRequestGet>[0] {
+  return {
+    request: new Request(`https://x.com/api/oauth/verify?${query}`, { method: 'GET' }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+function makeSendContext(body: unknown, env: MockEnv): Parameters<typeof onSendVerification>[0] {
+  return {
+    request: new Request('https://x.com/api/oauth/send-verification', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    env: env as unknown as never,
+    params: {} as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onSendVerification>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/oauth/verify', () => {
+  it('302 → /login?verify_error=missing_token when token query absent', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onRequestGet(makeVerifyContext('', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=missing_token');
+  });
+
+  it('302 → /login?verify_error=expired when token not found', async () => {
+    const stmt = makeStmt(null); // adapter.find returns nothing
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onRequestGet(makeVerifyContext('token=fake-token', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=expired');
+  });
+
+  it('302 → /login?verified=1 happy path + UPDATE email_verified_at', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({
+            userId: 'u-1',
+            email: 'u@x.com',
+            createdAt: Date.now() - 1000,
+            used: false,
+          }),
+          expires_at: Date.now() + 60_000,
+        });
+      }
+      if (sql.includes('UPDATE users SET email_verified_at')) return makeStmt();
+      if (sql.includes('DELETE FROM oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=valid-token', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verified=1');
+
+    // Assert UPDATE called
+    const updateCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE users SET email_verified_at'),
+    );
+    expect(updateCall).toBeTruthy();
+    // Assert DELETE called (one-time use)
+    const deleteCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCall).toBeTruthy();
+  });
+
+  it('302 → /login?verify_error=expired when token expired (D1Adapter.find returns null)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        // Adapter find filters expired internally — null returned
+        return makeStmt(null);
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=expired-token', env));
+    expect(res.headers.get('Location')).toBe('/login?verify_error=expired');
+  });
+
+  it('does NOT destroy token if UPDATE fails (so user can retry)', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT payload, expires_at FROM oauth_models')) {
+        return makeStmt({
+          payload: JSON.stringify({ userId: 'u', email: 'u@x.com', createdAt: 0, used: false }),
+          expires_at: Date.now() + 60_000,
+        });
+      }
+      if (sql.includes('UPDATE users SET email_verified_at')) {
+        const stmt = makeStmt();
+        stmt.run = vi.fn().mockRejectedValue(new Error('DB unavailable'));
+        return stmt;
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onRequestGet(makeVerifyContext('token=t', env));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login?verify_error=server_error');
+
+    // DELETE was NOT called (token preserved for retry)
+    const deleteCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('DELETE FROM oauth_models'),
+    );
+    expect(deleteCall).toBeFalsy();
+  });
+});
+
+describe('POST /api/oauth/send-verification', () => {
+  it('200 generic response when email empty (no enum leak)', async () => {
+    const env: MockEnv = { DB: { prepare: vi.fn() } };
+    const res = await onSendVerification(makeSendContext({}, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; message: string };
+    expect(json.ok).toBe(true);
+    expect(json.message).toContain('若帳號');
+  });
+
+  it('200 generic when email not found (no enum leak)', async () => {
+    const stmt = makeStmt(null); // user not found
+    const env: MockEnv = { DB: { prepare: vi.fn().mockReturnValue(stmt) } };
+    const res = await onSendVerification(makeSendContext({ email: 'nobody@x.com' }, env));
+    expect(res.status).toBe(200);
+    // No INSERT — user not found means no token generated
+  });
+
+  it('200 generic when email already verified (silent no-op)', async () => {
+    // Filter SQL excludes verified users → SELECT returns null
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id FROM users')) {
+        // emulate WHERE email_verified_at IS NULL filter excluding verified user
+        return makeStmt(null);
+      }
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onSendVerification(makeSendContext({ email: 'verified@x.com' }, env));
+    expect(res.status).toBe(200);
+    const insertCall = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertCall).toBeFalsy();
+  });
+
+  it('200 + INSERT EmailVerification token when email is unverified user', async () => {
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id FROM users')) {
+        return makeStmt({ id: 'u-1' });
+      }
+      if (sql.includes('INSERT OR REPLACE INTO oauth_models')) return makeStmt();
+      return makeStmt();
+    });
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    const res = await onSendVerification(makeSendContext({ email: 'unverified@x.com' }, env));
+    expect(res.status).toBe(200);
+
+    // Verify INSERT called with name='EmailVerification'
+    const insertIdx = dbPrepare.mock.calls.findIndex(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT OR REPLACE INTO oauth_models'),
+    );
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+    const insertStmt = dbPrepare.mock.results[insertIdx].value as { bind: { mock: { calls: unknown[][] } } };
+    const bindArgs = insertStmt.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe('EmailVerification'); // name
+    // bindArgs[1] = id (token), bindArgs[2] = payload JSON, bindArgs[3] = expires_at
+    expect(bindArgs[3]).toBe(Date.now() + 24 * 60 * 60 * 1000); // 24h TTL
+  });
+
+  it('Filters by email_verified_at IS NULL (only unverified users get tokens)', async () => {
+    const stmt = makeStmt(null);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onSendVerification(makeSendContext({ email: 'u@x.com' }, env));
+
+    const sql = dbPrepare.mock.calls[0][0] as string;
+    expect(sql).toContain('email_verified_at IS NULL');
+  });
+
+  it('email lowercase + trim before lookup', async () => {
+    const stmt = makeStmt(null);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = { DB: { prepare: dbPrepare } };
+    await onSendVerification(makeSendContext({ email: '  Mixed@EXAMPLE.com  ' }, env));
+    expect(stmt.bind).toHaveBeenCalledWith('mixed@example.com');
+  });
+});

--- a/tests/api/oauth-verify.test.ts
+++ b/tests/api/oauth-verify.test.ts
@@ -162,7 +162,7 @@ describe('POST /api/oauth/send-verification', () => {
   it('200 generic when email already verified (silent no-op)', async () => {
     // Filter SQL excludes verified users → SELECT returns null
     const dbPrepare = vi.fn().mockImplementation((sql: string) => {
-      if (sql.includes('SELECT id FROM users')) {
+      if (sql.includes('FROM users') && sql.includes('email_verified_at IS NULL')) {
         // emulate WHERE email_verified_at IS NULL filter excluding verified user
         return makeStmt(null);
       }
@@ -179,8 +179,8 @@ describe('POST /api/oauth/send-verification', () => {
 
   it('200 + INSERT EmailVerification token when email is unverified user', async () => {
     const dbPrepare = vi.fn().mockImplementation((sql: string) => {
-      if (sql.includes('SELECT id FROM users')) {
-        return makeStmt({ id: 'u-1' });
+      if (sql.includes('FROM users') && sql.includes('email_verified_at IS NULL')) {
+        return makeStmt({ id: 'u-1', display_name: null });
       }
       if (sql.includes('INSERT OR REPLACE INTO oauth_models')) return makeStmt();
       return makeStmt();
@@ -217,5 +217,74 @@ describe('POST /api/oauth/send-verification', () => {
     const env: MockEnv = { DB: { prepare: dbPrepare } };
     await onSendVerification(makeSendContext({ email: '  Mixed@EXAMPLE.com  ' }, env));
     expect(stmt.bind).toHaveBeenCalledWith('mixed@example.com');
+  });
+
+  it('sends Resend email when RESEND_API_KEY + EMAIL_FROM set (V2-P3 wire)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg-123' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM users') && sql.includes('email_verified_at IS NULL')) {
+        return makeStmt({ id: 'u-1', display_name: 'Ray' });
+      }
+      return makeStmt();
+    });
+    const env = {
+      DB: { prepare: dbPrepare },
+      RESEND_API_KEY: 're_test',
+      EMAIL_FROM: 'Tripline <no-reply@example.com>',
+    };
+    await onSendVerification(makeSendContext({ email: 'u@x.com' }, env as never));
+
+    // fetch hits Resend with verify URL in body
+    const resendCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('resend.com'),
+    );
+    expect(resendCall).toBeTruthy();
+    const body = JSON.parse((resendCall![1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.to).toEqual(['u@x.com']);
+    expect(body.subject).toContain('驗證');
+    expect(body.html).toContain('https://x.com/api/oauth/verify?token=');
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT send email when RESEND_API_KEY missing (graceful degrade)', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM users') && sql.includes('email_verified_at IS NULL')) {
+        return makeStmt({ id: 'u-1', display_name: null });
+      }
+      return makeStmt();
+    });
+    const env = { DB: { prepare: dbPrepare } }; // NO RESEND_API_KEY
+    await onSendVerification(makeSendContext({ email: 'u@x.com' }, env as never));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns generic 200 even when Resend API fails (best-effort)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_api_key' }), { status: 401 }),
+    ));
+
+    const dbPrepare = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM users') && sql.includes('email_verified_at IS NULL')) {
+        return makeStmt({ id: 'u-1', display_name: null });
+      }
+      return makeStmt();
+    });
+    const env = {
+      DB: { prepare: dbPrepare },
+      RESEND_API_KEY: 're_bad',
+      EMAIL_FROM: 'Tripline <no-reply@example.com>',
+    };
+    const res = await onSendVerification(makeSendContext({ email: 'u@x.com' }, env as never));
+    expect(res.status).toBe(200);
+    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Summary

V2-P3 email infrastructure 收尾：把 PR #296 的 `sendEmail()` 接通到實際 OAuth endpoints。

| Endpoint | Template | Behavior |
|----------|----------|----------|
| `/api/oauth/send-verification` | emailVerification | 寄驗證連結 `{origin}/api/oauth/verify?token=…` |
| `/api/oauth/forgot-password` | passwordReset | 寄重設連結 `{origin}/auth/password/reset?token=…` |
| `/api/oauth/reset-password` | passwordChangedConfirm | 重設成功後寄通知信 |

### Best-effort 策略

- **env 雙閘控**：`RESEND_API_KEY` + `EMAIL_FROM` 都設了才寄
- 任一未設 → graceful no-op（dev 環境照常運作）
- Resend API 失敗 → `console.error` 但不擋 user flow
- **Token 永遠寫進 D1**（即使 email 失敗）→ user 重試或聯絡支援仍能用
- 不破壞 anti-enumeration：response 不變

### Cherry-picked deps

- `5876ed1` (#296) email module + templates
- `a614242` (#292) verify + send-verification endpoints

⚠️ **Merge order**: 待 #292 + #296 都 merge 後本 PR 自動 rebase 乾淨（cherry-pick 重複的 commit 會被忽略）。

## Test plan

- [x] tsc strict 全過
- [x] 411/411 vitest API 全綠（+6 new wire tests）
- [x] CI pending

### Test 涵蓋

- `send-verification`: Resend 寄出 / no env graceful / Resend 401 仍回 generic 200
- `forgot-password`: Resend 寄出（驗 reset URL embed） / no env graceful
- `reset-password`: confirmation 寄出（驗 subject 含「密碼」） / no env graceful

## Deploy

```bash
# Resend signup → 拿 RESEND_API_KEY
wrangler pages secret put RESEND_API_KEY
# Domain DNS 設 SPF/DKIM (Resend dashboard 提供 records)
wrangler pages secret put EMAIL_FROM  # e.g. 'Tripline <no-reply@trip-planner-dby.pages.dev>'
```

## V2-P3 progress

- [x] #296 email module + templates
- [x] #292 verify + send-verification endpoints
- [x] **本 PR** wire email into all 4 endpoints
- [ ] V2-P3 final: signup auto-trigger send-verification（前端已做於 #297，後端可選）

🤖 Generated with [Claude Code](https://claude.com/claude-code)