### PR TITLE
feat(v2-p6): multi-device session management (full stack)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -9,6 +9,34 @@
 - **P3** — 想做再做（nice-to-have）
 - **P4** — 可能不做（長期觀察）
 
+## OIDC discovery routing 錯亂（V2-P5 critical bug）
+
+**Priority:** P0
+**Discovered:** 2026-04-25 by /qa on `feat/v2-p6-multi-device-sessions`
+**Affects:** master（V2-P1 #256 起就有）
+
+OIDC discovery doc (`/.well-known/openid-configuration`) 公告的 4 個 endpoint 中 2 個指錯：
+
+| Discovery 公告 | 實際 handler | 結果 |
+|---------------|------------|------|
+| `authorization_endpoint: /api/oauth/authorize` | OAuth Client to Google | 回 `PROVIDER_UNSUPPORTED` ✗ |
+| `token_endpoint: /api/oauth/token` | 不存在 | 405 ✗ |
+| `userinfo_endpoint: /api/oauth/userinfo` | userinfo.ts | OK ✓ |
+| `revocation_endpoint: /api/oauth/revoke` | 不存在 | 405 ✗ |
+| `jwks_uri: .../jwks.json` | jwks.json.ts | OK ✓ |
+
+實際 OAuth Server endpoint 在 `/api/oauth/server-authorize` + `/api/oauth/server-token`，discovery doc 沒指過去。
+
+**衝擊：** 任何 OIDC-compliant external client 跟 discovery 走，會打到 `/api/oauth/authorize` 拿 Google client redirect bug，或打 `/api/oauth/token` 拿 405 — OAuth Server 對外完全 broken。
+
+**修法選項：**
+1. **改 routing**（推薦）：`/api/oauth/authorize` 改成 OAuth Server，現有 Google client 改 mount 到 `/api/oauth/google/redirect` — 符合 autoplan「`/oauth/*` 為 public」設計。需改 server-authorize.ts → authorize.ts、新建 token.ts + revoke.ts wrapper。
+2. **改 discovery doc**（妥協）：讓 doc 直接指 `/server-authorize` / `/server-token` — leak internal naming，違反 autoplan 設計但 atomic 修。
+
+要 V2-P7 上線前修。本 PR (V2-P6 sessions) scope 不含 OAuth Server routing，已 flag。
+
+---
+
 ## Lighthouse — Blocking gate（2 週 baseline 後）
 
 **Current**: Lighthouse CI 已建立（PR #8），所有 assertion 為 warn 模式。

--- a/functions/api/_session.ts
+++ b/functions/api/_session.ts
@@ -7,7 +7,14 @@
  *
  * 用 SESSION_SECRET env 簽 token；env 缺少時 throw（fail loud avoid silent
  * security degrade）。
+ *
+ * V2-P6 multi-device support：
+ *   - issueSession 多生 sid (uuid) 嵌進 payload + 寫 session_devices row
+ *   - getSessionUser 額外檢查 session_devices.revoked_at（best-effort，DB
+ *     失敗不擋 verify — degrade gracefully）
+ *   - Legacy session（V2-P1 簽出，無 sid）→ 跳過 revocation check，仍 valid
  */
+import type { D1Database } from '@cloudflare/workers-types';
 import { AppError } from './_errors';
 import {
   getSessionCookie,
@@ -28,6 +35,7 @@ import {
  */
 interface EnvWithSession {
   SESSION_SECRET?: string;
+  DB?: D1Database;
 }
 
 function requireSecret(env: EnvWithSession): string {
@@ -39,9 +47,42 @@ function requireSecret(env: EnvWithSession): string {
   return secret;
 }
 
+/** SHA-256(ip) base64 — same algorithm as auth_audit_log.ts for consistency */
+async function hashIp(ip: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(ip) as unknown as ArrayBuffer,
+  );
+  const arr = new Uint8Array(buf);
+  let str = '';
+  for (let i = 0; i < arr.length; i++) str += String.fromCharCode(arr[i]!);
+  return btoa(str);
+}
+
+/** Lightweight User-Agent → 'Browser · OS' summary（client display 用） */
+function summarizeUserAgent(ua: string): string {
+  if (!ua) return '';
+  let browser = 'Other';
+  if (/Edg\//.test(ua)) browser = 'Edge';
+  else if (/OPR\/|Opera/.test(ua)) browser = 'Opera';
+  else if (/Firefox/.test(ua)) browser = 'Firefox';
+  else if (/Chrome/.test(ua)) browser = 'Chrome';
+  else if (/Safari/.test(ua)) browser = 'Safari';
+  let os = 'Other';
+  if (/Windows NT/.test(ua)) os = 'Windows';
+  else if (/Mac OS X/.test(ua)) os = 'macOS';
+  else if (/iPhone|iPad/.test(ua)) os = 'iOS';
+  else if (/Android/.test(ua)) os = 'Android';
+  else if (/Linux/.test(ua)) os = 'Linux';
+  return `${browser} · ${os}`;
+}
+
 /**
  * Read session cookie + verify token → return payload or null。
  * 用於不強制 auth 的 endpoint（如 GET /api/trips）。
+ *
+ * V2-P6: 若 payload 含 sid 且 env.DB 存在 → 額外檢查 session_devices.revoked_at
+ * （已 revoke 視為無效）。DB 失敗 silent fallback（cookie 仍 valid）。
  */
 export async function getSessionUser(
   request: Request,
@@ -50,7 +91,32 @@ export async function getSessionUser(
   const token = getSessionCookie(request);
   if (!token) return null;
   const secret = requireSecret(env);
-  return verifySessionToken(token, secret);
+  const payload = await verifySessionToken(token, secret);
+  if (!payload) return null;
+
+  // V2-P6 revocation check
+  if (payload.sid && env.DB) {
+    try {
+      const row = await env.DB
+        .prepare('SELECT revoked_at FROM session_devices WHERE sid = ?')
+        .bind(payload.sid)
+        .first<{ revoked_at: string | null }>();
+      if (row && row.revoked_at) {
+        // Session manually revoked — refuse
+        return null;
+      }
+      // Best-effort touch last_seen_at（fire-and-forget — don't await）
+      void env.DB
+        .prepare('UPDATE session_devices SET last_seen_at = datetime(\'now\') WHERE sid = ?')
+        .bind(payload.sid)
+        .run()
+        .catch(() => undefined);
+    } catch {
+      // DB unavailable — cookie still valid (degrade gracefully)
+    }
+  }
+
+  return payload;
 }
 
 /**
@@ -69,6 +135,10 @@ export async function requireSessionUser(
 /**
  * Sign new session token + append Set-Cookie header to response。
  * 用於 OAuth callback / login success path。
+ *
+ * V2-P6: 若 env.DB 存在 → 產 sid 嵌進 payload + INSERT session_devices row
+ * （含 ua_summary + ip_hash 為 /settings/sessions 顯示用）。DB 失敗仍會
+ * 簽 token（only without sid），不擋 login。
  */
 export async function issueSession(
   request: Request,
@@ -78,15 +148,89 @@ export async function issueSession(
   ttlSeconds?: number,
 ): Promise<void> {
   const secret = requireSecret(env);
-  const token = await signSessionToken(uid, secret, ttlSeconds);
+  let sid: string | undefined;
+
+  if (env.DB) {
+    try {
+      sid = crypto.randomUUID();
+      const ua = (request.headers.get('User-Agent') ?? '').slice(0, 200);
+      const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      const ipHash = await hashIp(ip);
+      await env.DB
+        .prepare(
+          `INSERT INTO session_devices (sid, user_id, ua_summary, ip_hash)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .bind(sid, uid, summarizeUserAgent(ua) || null, ipHash)
+        .run();
+    } catch {
+      // DB failure → fall back to legacy (no sid) session — login still succeeds
+      sid = undefined;
+    }
+  }
+
+  const token = await signSessionToken(uid, secret, ttlSeconds, sid);
   const cookie = buildSessionSetCookie(token, { secure: shouldSetSecure(request), maxAge: ttlSeconds });
   response.headers.append('Set-Cookie', cookie);
 }
 
 /**
  * Append clear-session Set-Cookie header → logout。
+ *
+ * V2-P6: 若 env + sid 存在 → 額外 mark revoked_at 在 session_devices
+ * （讓 logout 立即生效在 multi-tab scenario）。
  */
-export function clearSession(request: Request, response: Response): void {
+export async function clearSession(
+  request: Request,
+  response: Response,
+  env?: EnvWithSession,
+): Promise<void> {
   const cookie = buildClearSessionSetCookie(shouldSetSecure(request));
   response.headers.append('Set-Cookie', cookie);
+
+  // V2-P6: revoke session_devices row if we can
+  if (env?.DB && env.SESSION_SECRET) {
+    try {
+      const token = getSessionCookie(request);
+      if (token) {
+        const payload = await verifySessionToken(token, env.SESSION_SECRET);
+        if (payload?.sid) {
+          await env.DB
+            .prepare(
+              `UPDATE session_devices SET revoked_at = datetime('now')
+               WHERE sid = ? AND revoked_at IS NULL`,
+            )
+            .bind(payload.sid)
+            .run();
+        }
+      }
+    } catch {
+      // best-effort — cookie cleared regardless
+    }
+  }
+}
+
+/** Helper for "log out all other devices" feature — used by /api/account/sessions DELETE all */
+export async function revokeAllOtherSessions(
+  db: D1Database,
+  userId: string,
+  currentSid: string | null,
+): Promise<{ revoked: number }> {
+  const result = currentSid
+    ? await db
+        .prepare(
+          `UPDATE session_devices SET revoked_at = datetime('now')
+           WHERE user_id = ? AND sid != ? AND revoked_at IS NULL`,
+        )
+        .bind(userId, currentSid)
+        .run()
+    : await db
+        .prepare(
+          `UPDATE session_devices SET revoked_at = datetime('now')
+           WHERE user_id = ? AND revoked_at IS NULL`,
+        )
+        .bind(userId)
+        .run();
+  const changes = (result.meta as { changes?: number } | undefined)?.changes ?? 0;
+  return { revoked: changes };
 }

--- a/functions/api/_session.ts
+++ b/functions/api/_session.ts
@@ -110,6 +110,10 @@ export async function getSessionUser(
       // Fire-and-forget without ctx.waitUntil — acceptable since miss is just
       // a stale last_seen_at not security-critical。SQL filter pushes the
       // throttle into D1 so most calls become 0-row no-op writes (still cheap)。
+      //
+      // TODO(V2-P7): thread context.executionCtx + ctx.waitUntil(promise) if
+      // last_seen_at accuracy becomes load-bearing for stale-session cleanup。
+      // 目前 cron cleanup 用 created_at + 30 天 cap 不依賴 last_seen_at 精度。
       void env.DB
         .prepare(
           `UPDATE session_devices SET last_seen_at = datetime('now')

--- a/functions/api/_session.ts
+++ b/functions/api/_session.ts
@@ -105,9 +105,16 @@ export async function getSessionUser(
         // Session manually revoked — refuse
         return null;
       }
-      // Best-effort touch last_seen_at（fire-and-forget — don't await）
+      // Best-effort touch last_seen_at, throttled to 5min so D1 write churn
+      // stays bounded（per-request UPDATE on hot path otherwise ~1 write/click）。
+      // Fire-and-forget without ctx.waitUntil — acceptable since miss is just
+      // a stale last_seen_at not security-critical。SQL filter pushes the
+      // throttle into D1 so most calls become 0-row no-op writes (still cheap)。
       void env.DB
-        .prepare('UPDATE session_devices SET last_seen_at = datetime(\'now\') WHERE sid = ?')
+        .prepare(
+          `UPDATE session_devices SET last_seen_at = datetime('now')
+           WHERE sid = ? AND last_seen_at < datetime('now', '-5 minutes')`,
+        )
         .bind(payload.sid)
         .run()
         .catch(() => undefined);
@@ -177,36 +184,33 @@ export async function issueSession(
 /**
  * Append clear-session Set-Cookie header → logout。
  *
- * V2-P6: 若 env + sid 存在 → 額外 mark revoked_at 在 session_devices
- * （讓 logout 立即生效在 multi-tab scenario）。
+ * V2-P6: mark revoked_at in session_devices（讓 logout 立即生效在 multi-tab
+ * scenario）。env 必傳 — caller 一律從 PagesFunction context 拿，沒有「無 env」
+ * 的情境。DB 缺或 token 無 sid（legacy）→ silent no-op，cookie 仍會被清。
  */
 export async function clearSession(
   request: Request,
   response: Response,
-  env?: EnvWithSession,
+  env: EnvWithSession,
 ): Promise<void> {
   const cookie = buildClearSessionSetCookie(shouldSetSecure(request));
   response.headers.append('Set-Cookie', cookie);
 
-  // V2-P6: revoke session_devices row if we can
-  if (env?.DB && env.SESSION_SECRET) {
-    try {
-      const token = getSessionCookie(request);
-      if (token) {
-        const payload = await verifySessionToken(token, env.SESSION_SECRET);
-        if (payload?.sid) {
-          await env.DB
-            .prepare(
-              `UPDATE session_devices SET revoked_at = datetime('now')
-               WHERE sid = ? AND revoked_at IS NULL`,
-            )
-            .bind(payload.sid)
-            .run();
-        }
-      }
-    } catch {
-      // best-effort — cookie cleared regardless
-    }
+  if (!env.DB || !env.SESSION_SECRET) return;
+  try {
+    const token = getSessionCookie(request);
+    if (!token) return;
+    const payload = await verifySessionToken(token, env.SESSION_SECRET);
+    if (!payload?.sid) return;
+    await env.DB
+      .prepare(
+        `UPDATE session_devices SET revoked_at = datetime('now')
+         WHERE sid = ? AND revoked_at IS NULL`,
+      )
+      .bind(payload.sid)
+      .run();
+  } catch {
+    // best-effort — cookie cleared regardless
   }
 }
 
@@ -216,21 +220,15 @@ export async function revokeAllOtherSessions(
   userId: string,
   currentSid: string | null,
 ): Promise<{ revoked: number }> {
-  const result = currentSid
-    ? await db
-        .prepare(
-          `UPDATE session_devices SET revoked_at = datetime('now')
-           WHERE user_id = ? AND sid != ? AND revoked_at IS NULL`,
-        )
-        .bind(userId, currentSid)
-        .run()
-    : await db
-        .prepare(
-          `UPDATE session_devices SET revoked_at = datetime('now')
-           WHERE user_id = ? AND revoked_at IS NULL`,
-        )
-        .bind(userId)
-        .run();
+  // 用 (? IS NULL OR sid != ?) 把「current 為 null 撤銷全部」+「current 有值
+  // 撤銷除自己外」合成單一 SQL，免 ternary 兩個 prepare branch
+  const result = await db
+    .prepare(
+      `UPDATE session_devices SET revoked_at = datetime('now')
+       WHERE user_id = ? AND revoked_at IS NULL AND (? IS NULL OR sid != ?)`,
+    )
+    .bind(userId, currentSid, currentSid)
+    .run();
   const changes = (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   return { revoked: changes };
 }

--- a/functions/api/_utils.ts
+++ b/functions/api/_utils.ts
@@ -28,6 +28,12 @@ export function json(data: unknown, status = 200) {
   return new Response(JSON.stringify(deepCamel(data)), { status, headers: { 'Content-Type': 'application/json' } });
 }
 
+/** JSON response WITHOUT key conversion — for OAuth wire format that requires
+ *  snake_case keys (RFC 6749 access_token / client_id etc.) */
+export function rawJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
 /** 型別安全的 auth 擷取 */
 export function getAuth(context: { data: unknown }): AuthData | null {
   return ((context.data as Record<string, unknown>)?.auth as AuthData) ?? null;

--- a/functions/api/account/sessions.ts
+++ b/functions/api/account/sessions.ts
@@ -30,6 +30,9 @@ interface SessionDeviceRow {
   last_seen_at: string;
 }
 
+// LIMIT 100 — UI display cap。Mass revoke (DELETE all-others) 是 unbounded
+// server-side，不受此影響。V2-P6 cron cleanup 30 天保留期使「>100 active sessions」
+// 在實務上幾乎不可能（除惡意/bug）— 真出現再加 pagination。
 const SESSIONS_LIST_LIMIT = 100;
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {

--- a/functions/api/account/sessions.ts
+++ b/functions/api/account/sessions.ts
@@ -19,6 +19,7 @@
  * Note: 不 leak 完整 ip_hash（避免 hash 反查）— 只回前 8 char 做 device 區分提示。
  */
 import { requireSessionUser, revokeAllOtherSessions } from '../_session';
+import { rawJson } from '../_utils';
 import type { Env } from '../_types';
 
 interface SessionDeviceRow {
@@ -29,12 +30,7 @@ interface SessionDeviceRow {
   last_seen_at: string;
 }
 
-function snakeJson(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
+const SESSIONS_LIST_LIMIT = 100;
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   const session = await requireSessionUser(context.request, context.env);
@@ -44,9 +40,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       `SELECT sid, ua_summary, ip_hash, created_at, last_seen_at
        FROM session_devices
        WHERE user_id = ? AND revoked_at IS NULL
-       ORDER BY last_seen_at DESC`,
+       ORDER BY last_seen_at DESC
+       LIMIT ?`,
     )
-    .bind(session.uid)
+    .bind(session.uid, SESSIONS_LIST_LIMIT)
     .all<SessionDeviceRow>();
 
   const currentSid = session.sid ?? null;
@@ -60,7 +57,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     is_current: row.sid === currentSid,
   }));
 
-  return snakeJson({ current_sid: currentSid, sessions });
+  return rawJson({ current_sid: currentSid, sessions });
 };
 
 export const onRequestDelete: PagesFunction<Env> = async (context) => {
@@ -70,5 +67,5 @@ export const onRequestDelete: PagesFunction<Env> = async (context) => {
     session.uid,
     session.sid ?? null,
   );
-  return snakeJson({ ok: true, revoked });
+  return rawJson({ ok: true, revoked });
 };

--- a/functions/api/account/sessions.ts
+++ b/functions/api/account/sessions.ts
@@ -1,0 +1,74 @@
+/**
+ * GET /api/account/sessions  — list current user's active sessions
+ * DELETE /api/account/sessions — log out all OTHER devices (not current)
+ *
+ * V2-P6 multi-device session management。Mockup section 6。
+ *
+ * Auth: requireSessionUser
+ *
+ * GET response: {
+ *   current_sid: string | null,        -- 當前 session 的 sid (frontend mark "current")
+ *   sessions: [
+ *     { sid, ua_summary, ip_hash_prefix?, created_at, last_seen_at, is_current },
+ *     ...
+ *   ]
+ * }
+ *
+ * DELETE response: { ok: true, revoked: <count> }
+ *
+ * Note: 不 leak 完整 ip_hash（避免 hash 反查）— 只回前 8 char 做 device 區分提示。
+ */
+import { requireSessionUser, revokeAllOtherSessions } from '../_session';
+import type { Env } from '../_types';
+
+interface SessionDeviceRow {
+  sid: string;
+  ua_summary: string | null;
+  ip_hash: string | null;
+  created_at: string;
+  last_seen_at: string;
+}
+
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+
+  const result = await context.env.DB
+    .prepare(
+      `SELECT sid, ua_summary, ip_hash, created_at, last_seen_at
+       FROM session_devices
+       WHERE user_id = ? AND revoked_at IS NULL
+       ORDER BY last_seen_at DESC`,
+    )
+    .bind(session.uid)
+    .all<SessionDeviceRow>();
+
+  const currentSid = session.sid ?? null;
+  const sessions = (result.results ?? []).map((row) => ({
+    sid: row.sid,
+    ua_summary: row.ua_summary,
+    // Only first 8 chars of ip_hash for "different device" hint, not full reverse-lookup-bait
+    ip_hash_prefix: row.ip_hash ? row.ip_hash.slice(0, 8) : null,
+    created_at: row.created_at,
+    last_seen_at: row.last_seen_at,
+    is_current: row.sid === currentSid,
+  }));
+
+  return snakeJson({ current_sid: currentSid, sessions });
+};
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const { revoked } = await revokeAllOtherSessions(
+    context.env.DB,
+    session.uid,
+    session.sid ?? null,
+  );
+  return snakeJson({ ok: true, revoked });
+};

--- a/functions/api/account/sessions.ts
+++ b/functions/api/account/sessions.ts
@@ -35,6 +35,16 @@ interface SessionDeviceRow {
 // 在實務上幾乎不可能（除惡意/bug）— 真出現再加 pagination。
 const SESSIONS_LIST_LIMIT = 100;
 
+/**
+ * SQLite `datetime('now')` 回 `'2026-04-25 07:48:12'` 沒 timezone 標記，
+ * frontend `new Date(iso)` 會 interpret 為 local TZ，造成 UTC+8 時區顯示
+ * 偏 8 小時。轉成 ISO 8601 with Z suffix（SQLite 已用 UTC 寫入）讓
+ * `new Date()` 正確解析為 UTC。
+ */
+function toIsoUtc(sqliteTs: string): string {
+  return sqliteTs.replace(' ', 'T') + 'Z';
+}
+
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   const session = await requireSessionUser(context.request, context.env);
 
@@ -55,8 +65,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     ua_summary: row.ua_summary,
     // Only first 8 chars of ip_hash for "different device" hint, not full reverse-lookup-bait
     ip_hash_prefix: row.ip_hash ? row.ip_hash.slice(0, 8) : null,
-    created_at: row.created_at,
-    last_seen_at: row.last_seen_at,
+    created_at: toIsoUtc(row.created_at),
+    last_seen_at: toIsoUtc(row.last_seen_at),
     is_current: row.sid === currentSid,
   }));
 

--- a/functions/api/account/sessions/[sid].ts
+++ b/functions/api/account/sessions/[sid].ts
@@ -1,0 +1,53 @@
+/**
+ * DELETE /api/account/sessions/:sid — revoke specific session by sid
+ *
+ * V2-P6 multi-device session management。允許 user 從 list 點某 device 「登出」。
+ *
+ * Auth: requireSessionUser
+ * Ownership: SQL 內 WHERE user_id 強制只能 revoke 自己的 session
+ *   （cross-user 攻擊 user A 試圖 DELETE user B 的 sid → SQL no-op，no rows changed）
+ *
+ * Response:
+ *   200 { ok: true } 若 revoke 成功
+ *   404 { error: 'SESSION_NOT_FOUND' } 若 sid 不屬於 current user 或已 revoked
+ *
+ * 撤銷自己當前 session：允許 — 等同 logout（cookie 仍在 client，但下次 request
+ * 會被 getSessionUser 的 revocation check 擋）。
+ */
+import { requireSessionUser } from '../../_session';
+import { AppError } from '../../_errors';
+import type { Env } from '../../_types';
+
+function snakeJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  const session = await requireSessionUser(context.request, context.env);
+  const sid = (context.params as { sid?: string }).sid;
+  if (!sid || typeof sid !== 'string') {
+    throw new AppError('DATA_VALIDATION', 'sid 必填');
+  }
+
+  const result = await context.env.DB
+    .prepare(
+      `UPDATE session_devices
+       SET revoked_at = datetime('now')
+       WHERE sid = ? AND user_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(sid, session.uid)
+    .run();
+
+  const changes = (result.meta as { changes?: number } | undefined)?.changes ?? 0;
+  if (changes === 0) {
+    return snakeJson(
+      { error: { code: 'SESSION_NOT_FOUND', message: '找不到此 session（可能已登出或不屬於你）' } },
+      404,
+    );
+  }
+
+  return snakeJson({ ok: true, revoked_sid: sid });
+};

--- a/functions/api/account/sessions/[sid].ts
+++ b/functions/api/account/sessions/[sid].ts
@@ -15,15 +15,9 @@
  * 會被 getSessionUser 的 revocation check 擋）。
  */
 import { requireSessionUser } from '../../_session';
+import { rawJson } from '../../_utils';
 import { AppError } from '../../_errors';
 import type { Env } from '../../_types';
-
-function snakeJson(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
 
 export const onRequestDelete: PagesFunction<Env> = async (context) => {
   const session = await requireSessionUser(context.request, context.env);
@@ -43,11 +37,11 @@ export const onRequestDelete: PagesFunction<Env> = async (context) => {
 
   const changes = (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   if (changes === 0) {
-    return snakeJson(
+    return rawJson(
       { error: { code: 'SESSION_NOT_FOUND', message: '找不到此 session（可能已登出或不屬於你）' } },
       404,
     );
   }
 
-  return snakeJson({ ok: true, revoked_sid: sid });
+  return rawJson({ ok: true, revoked_sid: sid });
 };

--- a/functions/api/oauth/logout.ts
+++ b/functions/api/oauth/logout.ts
@@ -30,21 +30,21 @@ function sanitizeRedirect(value: string | null): string {
   return value;
 }
 
-function buildLogoutResponse(request: Request): Response {
+async function buildLogoutResponse(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
   const redirectAfter = sanitizeRedirect(url.searchParams.get('redirect_after'));
   const response = new Response(null, {
     status: 302,
     headers: { Location: redirectAfter },
   });
-  clearSession(request, response);
+  await clearSession(request, response, env);
   return response;
 }
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
-  return buildLogoutResponse(context.request);
+  return buildLogoutResponse(context.request, context.env);
 };
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
-  return buildLogoutResponse(context.request);
+  return buildLogoutResponse(context.request, context.env);
 };

--- a/migrations/0037_session_devices.sql
+++ b/migrations/0037_session_devices.sql
@@ -14,9 +14,23 @@
 --
 -- ## Privacy
 --
--- ip_hash 是 SHA-256(ip)，跟 auth_audit_log 一致。**不存 plain IP**，但
+-- ip_hash 是 SHA-256(ip) **unsalted** — 跟 auth_audit_log 一致。**不存 plain IP**，
+-- 但 attacker with DB dump 可 rainbow-table 反查（IPv4 4B entries 秒級）。Threat
+-- model 接受：DB dump = 已 full compromise，IP 反查不是 incremental risk。
+-- API response 只 leak ip_hash 前 8 base64 char (~48 bits) 做「同 device 提示」，
+-- 不足以單獨反查單一 IP（48 bits prefix collide ~10s of IPv4）。
+-- 若未來需要 GDPR-grade de-identification，加 SESSION_IP_HASH_SECRET env 改 keyed
+-- hash (HMAC-SHA-256(secret, ip)) — V2-P7 task。
 -- city/country 留 NULL（V2-P6 future 加 GeoIP enrichment）。
 -- ua_summary 從 User-Agent parse 「Browser · OS」（client-side display 用）。
+--
+-- ## Revocation eventual consistency
+--
+-- 撤銷不立即生效。Logout / DELETE /sessions/:sid 寫 revoked_at 後，仍在 in-flight
+-- 的 getSessionUser 可能 race condition 撐過下一個 request（read-after-write lag
+-- ~tens of ms in D1）。Acceptable trade-off for "best-effort eventual" model。
+-- 真正立即撤銷需 storage-level fence（D1 不提供）— V2-P7 改 Durable Object
+-- 才能 strong consistency。
 --
 -- ## Cleanup
 --

--- a/migrations/0037_session_devices.sql
+++ b/migrations/0037_session_devices.sql
@@ -1,0 +1,41 @@
+-- Migration 0037: session_devices — V2-P6 multi-device session tracking
+--
+-- Each issueSession 寫一 row。支援 user 在 /settings/sessions 看見所有 active
+-- session + 遠端登出。
+--
+-- ## Why this design (vs storing whole session in DB)
+--
+-- 還是用 HMAC opaque cookie token + sid 嵌進 payload 而非 DB-only session。
+-- 理由：
+--   - HMAC verify 不需 DB 讀（constant time，無 latency）
+--   - DB 只在 revocation check 時讀（仍是 D1 ms-level）
+--   - 即使 D1 失敗（rare），cookie 仍能 verify → degrade gracefully
+--   - revocation 不立即生效（需 lookup）— acceptable since 1h scenario
+--
+-- ## Privacy
+--
+-- ip_hash 是 SHA-256(ip)，跟 auth_audit_log 一致。**不存 plain IP**，但
+-- city/country 留 NULL（V2-P6 future 加 GeoIP enrichment）。
+-- ua_summary 從 User-Agent parse 「Browser · OS」（client-side display 用）。
+--
+-- ## Cleanup
+--
+-- V2-P6 cron 30 天 cleanup：DELETE WHERE revoked_at IS NOT NULL OR
+-- (revoked_at IS NULL AND last_seen_at < datetime('now', '-30 days'))。
+-- 過期 cookie 已被 verifySessionToken 拒，但 row 留太久浪費空間。
+
+CREATE TABLE session_devices (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  sid             TEXT NOT NULL UNIQUE,                    -- session id 嵌 cookie payload
+  user_id         TEXT NOT NULL,                            -- 對應 users.id (no FK 防 cascade race)
+  ua_summary      TEXT,                                     -- 'Chrome · macOS 15'，client-friendly
+  ip_hash         TEXT,                                     -- SHA-256(ip) base64
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  last_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  revoked_at      TEXT
+);
+
+CREATE INDEX idx_session_devices_user_active
+  ON session_devices(user_id, revoked_at, last_seen_at);
+CREATE INDEX idx_session_devices_sid
+  ON session_devices(sid);

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -64,6 +64,7 @@ const ChatPage = lazyWithRetry(() => import('../pages/ChatPage'));
 const GlobalMapPage = lazyWithRetry(() => import('../pages/GlobalMapPage'));
 const ExplorePage = lazyWithRetry(() => import('../pages/ExplorePage'));
 const LoginPage = lazyWithRetry(() => import('../pages/LoginPage'));
+const SessionsPage = lazyWithRetry(() => import('../pages/SessionsPage'));
 const ConsentPage = lazyWithRetry(() => import('../pages/ConsentPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
@@ -107,6 +108,7 @@ if (el) {
               <Route path="/map" element={<GlobalMapPage />} />
               <Route path="/explore" element={<ExplorePage />} />
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/settings/sessions" element={<SessionsPage />} />
               <Route path="/oauth/consent" element={<ConsentPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -1,0 +1,331 @@
+/**
+ * SessionsPage — V2-P6 multi-device session management UI
+ *
+ * Route: /settings/sessions
+ * 配 mockup section 6「多裝置登入管理」。
+ *
+ * Features:
+ *   - List user's active sessions (current marked highlighted)
+ *   - Revoke specific session（破壞性，需 confirm modal — 但因不影響跨 user
+ *     資料而是只影響自己的 device list，UX 上可不二次確認）
+ *   - 「登出其他全部裝置」mass revoke（除當前外）
+ *   - 異地裝置警示（不同 ip_hash_prefix → 警示樣式）— optional V2-P6 future
+ */
+import { useEffect, useState } from 'react';
+
+const SCOPED_STYLES = `
+.tp-sessions-shell {
+  min-height: 100dvh; padding: 32px 16px 64px;
+  background: var(--color-secondary);
+}
+.tp-sessions-inner { max-width: 920px; margin: 0 auto; }
+
+.tp-page-heading {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 16px; margin-bottom: 24px; flex-wrap: wrap;
+}
+.tp-page-heading-text { flex: 1 1 auto; }
+.tp-page-heading-crumb {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-muted); margin-bottom: 8px;
+}
+.tp-page-heading h1 {
+  font-size: var(--font-size-title); font-weight: 800;
+  letter-spacing: -0.02em; margin: 0 0 6px;
+}
+.tp-page-heading p {
+  color: var(--color-muted); font-size: var(--font-size-subheadline);
+  margin: 0;
+}
+
+.tp-list {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.tp-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.tp-row:last-child { border-bottom: none; }
+.tp-row-header {
+  background: var(--color-secondary);
+  font-size: var(--font-size-caption2);
+  font-weight: 700; letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+.tp-row-current {
+  background: var(--color-accent-subtle);
+}
+
+.tp-device-info { display: flex; align-items: center; gap: 12px; }
+.tp-device-icon {
+  width: 36px; height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--color-tertiary);
+  color: var(--color-foreground);
+  display: grid; place-items: center;
+  flex-shrink: 0;
+}
+.tp-device-icon svg { width: 18px; height: 18px; }
+.tp-device-icon-current {
+  background: var(--color-accent);
+  color: #fff;
+}
+.tp-device-meta { font-size: var(--font-size-subheadline); }
+.tp-device-name { font-weight: 600; display: flex; align-items: center; gap: 8px; }
+.tp-pill {
+  display: inline-flex; padding: 2px 8px;
+  border-radius: var(--radius-xs);
+  font-size: var(--font-size-caption2);
+  font-weight: 700; letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.tp-pill-current { background: var(--color-success-bg); color: var(--color-success); }
+.tp-device-detail {
+  font-size: var(--font-size-caption); color: var(--color-muted);
+  margin-top: 2px;
+}
+
+.tp-time { font-size: var(--font-size-footnote); color: var(--color-muted); }
+
+.tp-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 6px;
+  padding: 8px 14px; border-radius: var(--radius-sm);
+  font-family: inherit; font-size: var(--font-size-footnote);
+  font-weight: 600; border: 1px solid var(--color-border);
+  background: var(--color-background); color: var(--color-foreground);
+  cursor: pointer; min-height: 36px;
+  transition: background 120ms;
+  text-decoration: none;
+}
+.tp-btn:hover:not(:disabled) { background: var(--color-hover); }
+.tp-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.tp-btn-destructive {
+  color: var(--color-destructive); border-color: var(--color-destructive);
+}
+.tp-btn-destructive:hover:not(:disabled) { background: var(--color-destructive-bg); }
+
+.tp-banner {
+  display: flex; gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-subheadline); line-height: 1.5;
+  margin-top: 16px;
+}
+.tp-banner-info { background: var(--color-accent-subtle); color: var(--color-accent); }
+.tp-banner-error { background: var(--color-destructive-bg); color: var(--color-destructive); }
+.tp-banner svg { flex-shrink: 0; width: 20px; height: 20px; margin-top: 1px; }
+
+.tp-loading, .tp-empty {
+  padding: 32px; text-align: center;
+  color: var(--color-muted);
+}
+`;
+
+interface SessionRow {
+  sid: string;
+  ua_summary: string | null;
+  ip_hash_prefix: string | null;
+  created_at: string;
+  last_seen_at: string;
+  is_current: boolean;
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return '剛才';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} 分鐘前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 小時前`;
+  const day = Math.floor(hr / 24);
+  return `${day} 天前`;
+}
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<SessionRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingSid, setRevokingSid] = useState<string | null>(null);
+  const [revokingAll, setRevokingAll] = useState(false);
+
+  async function load() {
+    setError(null);
+    try {
+      const res = await fetch('/api/account/sessions', { credentials: 'same-origin' });
+      if (!res.ok) {
+        setError('無法載入登入裝置，請重新整理頁面。');
+        return;
+      }
+      const json = (await res.json()) as { sessions: SessionRow[] };
+      setSessions(json.sessions);
+    } catch {
+      setError('網路連線失敗，請重新整理頁面。');
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function revokeOne(sid: string) {
+    setRevokingSid(sid);
+    try {
+      const res = await fetch(`/api/account/sessions/${encodeURIComponent(sid)}`, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      if (res.ok) {
+        setSessions((prev) => prev?.filter((s) => s.sid !== sid) ?? null);
+      } else {
+        setError('登出此裝置失敗，請稍後再試。');
+      }
+    } catch {
+      setError('網路連線失敗，請稍後再試。');
+    } finally {
+      setRevokingSid(null);
+    }
+  }
+
+  async function revokeAllOthers() {
+    if (!confirm('確定要登出其他所有裝置嗎？目前裝置不受影響。')) return;
+    setRevokingAll(true);
+    try {
+      const res = await fetch('/api/account/sessions', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      if (res.ok) {
+        // Reload to refresh list
+        void load();
+      } else {
+        setError('登出其他裝置失敗，請稍後再試。');
+      }
+    } catch {
+      setError('網路連線失敗，請稍後再試。');
+    } finally {
+      setRevokingAll(false);
+    }
+  }
+
+  const otherSessions = sessions?.filter((s) => !s.is_current) ?? [];
+
+  return (
+    <main className="tp-sessions-shell" data-testid="sessions-page">
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-sessions-inner">
+        <div className="tp-page-heading">
+          <div className="tp-page-heading-text">
+            <div className="tp-page-heading-crumb">設定</div>
+            <h1>登入裝置</h1>
+            <p>所有目前登入你帳號的裝置。發現可疑裝置請立即撤銷。</p>
+          </div>
+          {otherSessions.length > 0 && (
+            <button
+              className="tp-btn tp-btn-destructive"
+              onClick={revokeAllOthers}
+              disabled={revokingAll}
+              data-testid="sessions-revoke-all"
+            >
+              {revokingAll ? '登出中…' : '登出其他全部裝置'}
+            </button>
+          )}
+        </div>
+
+        {sessions === null && !error && (
+          <div className="tp-loading" data-testid="sessions-loading">載入中…</div>
+        )}
+
+        {sessions !== null && sessions.length === 0 && (
+          <div className="tp-list">
+            <div className="tp-empty" data-testid="sessions-empty">
+              目前沒有登入裝置紀錄。
+            </div>
+          </div>
+        )}
+
+        {sessions !== null && sessions.length > 0 && (
+          <div className="tp-list">
+            <div className="tp-row tp-row-header">
+              <div>裝置</div>
+              <div>上次活動</div>
+              <div></div>
+            </div>
+            {sessions.map((s) => (
+              <div
+                className={`tp-row ${s.is_current ? 'tp-row-current' : ''}`}
+                key={s.sid}
+                data-testid={`sessions-row-${s.sid}`}
+              >
+                <div className="tp-device-info">
+                  <div
+                    className={`tp-device-icon ${s.is_current ? 'tp-device-icon-current' : ''}`}
+                    aria-hidden="true"
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                      <rect x="2" y="3" width="20" height="14" rx="2" />
+                      <line x1="8" y1="21" x2="16" y2="21" />
+                      <line x1="12" y1="17" x2="12" y2="21" />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className="tp-device-name">
+                      {s.ua_summary ?? '未知裝置'}
+                      {s.is_current && (
+                        <span className="tp-pill tp-pill-current">目前</span>
+                      )}
+                    </div>
+                    <div className="tp-device-detail">
+                      建立 {relativeTime(s.created_at)}
+                      {s.ip_hash_prefix && ` · IP ${s.ip_hash_prefix}…`}
+                    </div>
+                  </div>
+                </div>
+                <div className="tp-time">{relativeTime(s.last_seen_at)}</div>
+                <div>
+                  {!s.is_current && (
+                    <button
+                      className="tp-btn tp-btn-destructive"
+                      onClick={() => revokeOne(s.sid)}
+                      disabled={revokingSid === s.sid}
+                      data-testid={`sessions-revoke-${s.sid}`}
+                    >
+                      {revokingSid === s.sid ? '登出中…' : '登出'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="tp-banner tp-banner-error" role="alert" data-testid="sessions-error">
+            {error}
+          </div>
+        )}
+
+        <div className="tp-banner tp-banner-info">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <div>
+            登出某裝置後，該裝置上的 Tripline 會立即跳回登入畫面。
+            OAuth 已連結 app 不受影響（請至「<a href="/settings/connected-apps">已連結的應用</a>」管理）。
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -205,8 +205,9 @@ export default function SessionsPage() {
         credentials: 'same-origin',
       });
       if (res.ok) {
-        // Reload to refresh list
-        void load();
+        // Optimistic: remove all non-current rows locally — match revokeOne() pattern,
+        // saves a round-trip vs reloading the list
+        setSessions((prev) => prev?.filter((s) => s.is_current) ?? null);
       } else {
         setError('登出其他裝置失敗，請稍後再試。');
       }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -35,6 +35,10 @@ export interface SessionPayload {
   csrf: string;
   /** Schema version 預留 — V2-P1 = 1 */
   v: number;
+  /** V2-P6 session id — for multi-device tracking + remote revocation。Legacy
+   * session（V2-P1）沒有此欄；revocation check 時遇 undefined 視為「無法 revoke」。
+   */
+  sid?: string;
   [key: string]: unknown;
 }
 
@@ -97,6 +101,7 @@ export async function signSessionToken(
   uid: string,
   secret: string,
   ttlSeconds = 30 * 24 * 60 * 60,
+  sid?: string,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const payload: SessionPayload = {
@@ -105,6 +110,7 @@ export async function signSessionToken(
     iat: now,
     exp: now + ttlSeconds,
     csrf: generateCsrfToken(),
+    ...(sid ? { sid } : {}),
   };
   const payloadStr = base64urlEncode(JSON.stringify(payload));
   const sig = await hmacSign(secret, payloadStr);

--- a/tests/api/account-sessions.test.ts
+++ b/tests/api/account-sessions.test.ts
@@ -1,0 +1,204 @@
+/**
+ * /api/account/sessions + /sessions/:sid — V2-P6 multi-device session API
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onRequestGet, onRequestDelete as onDeleteAll } from '../../functions/api/account/sessions';
+import { onRequestDelete as onDeleteOne } from '../../functions/api/account/sessions/[sid]';
+import { issueSession } from '../../functions/api/_session';
+
+interface MockEnv {
+  SESSION_SECRET?: string;
+  DB?: { prepare: ReturnType<typeof vi.fn> };
+}
+
+function makeStmt(firstResult: unknown = null, allResults: unknown[] = [], runMeta: { changes?: number } = { changes: 1 }) {
+  return {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(firstResult),
+    run: vi.fn().mockResolvedValue({ meta: runMeta }),
+    all: vi.fn().mockResolvedValue({ results: allResults }),
+  };
+}
+
+async function makeAuthedRequest(url: string, method: 'GET' | 'DELETE'): Promise<Request> {
+  // For these tests we use a stub fetch — issueSession needs SESSION_SECRET + DB
+  const r = new Response(null);
+  await issueSession(
+    new Request('https://x.com', { headers: { 'CF-Connecting-IP': '1.1.1.1' } }),
+    r,
+    'user-1',
+    { SESSION_SECRET: 'test-secret-32-chars-long-enough' } as never,
+  );
+  const setCookie = r.headers.get('Set-Cookie') ?? '';
+  const sessionCookie = setCookie.split(';')[0] ?? '';
+  return new Request(url, {
+    method,
+    headers: { Cookie: sessionCookie },
+  });
+}
+
+function makeContext(
+  request: Request,
+  env: MockEnv,
+  params: Record<string, string> = {},
+): Parameters<typeof onRequestGet>[0] {
+  return {
+    request,
+    env: env as unknown as never,
+    params: params as unknown as never,
+    data: {} as unknown as never,
+    next: () => Promise.resolve(new Response()),
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-25T00:00:00Z'));
+});
+
+describe('GET /api/account/sessions', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/account/sessions');
+    await expect(onRequestGet(makeContext(req, env)))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('200 returns sessions list with current marked', async () => {
+    const stmt = makeStmt(null, [
+      {
+        sid: 'sid-1',
+        ua_summary: 'Chrome · macOS',
+        ip_hash: 'abc123def456',
+        created_at: '2026-04-20T00:00:00Z',
+        last_seen_at: '2026-04-25T00:00:00Z',
+      },
+      {
+        sid: 'sid-2',
+        ua_summary: 'Safari · iOS',
+        ip_hash: 'xyz789abc',
+        created_at: '2026-04-22T00:00:00Z',
+        last_seen_at: '2026-04-24T00:00:00Z',
+      },
+    ]);
+    // For getSessionUser revocation check (not revoked → null result returned by first)
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions', 'GET');
+    const res = await onRequestGet(makeContext(req, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as {
+      current_sid: string | null;
+      sessions: Array<{ sid: string; ip_hash_prefix: string | null; is_current: boolean }>;
+    };
+    expect(json.sessions).toHaveLength(2);
+    // ip_hash truncated to 8 chars
+    expect(json.sessions[0]?.ip_hash_prefix).toBe('abc123de');
+    expect(json.sessions[0]?.ip_hash_prefix?.length).toBe(8);
+  });
+
+  it('SQL filters by user_id from session', async () => {
+    const stmt = makeStmt(null, []);
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions', 'GET');
+    await onRequestGet(makeContext(req, env));
+
+    const sessionSelect = dbPrepare.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('SELECT sid, ua_summary'),
+    );
+    expect(sessionSelect).toBeTruthy();
+    expect((sessionSelect![0] as string)).toContain('WHERE user_id = ?');
+    expect((sessionSelect![0] as string)).toContain('revoked_at IS NULL');
+  });
+});
+
+describe('DELETE /api/account/sessions (revoke all others)', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/account/sessions', { method: 'DELETE' });
+    await expect(onDeleteAll(makeContext(req, env)))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('200 + revokes all other sessions for current user', async () => {
+    const stmt = makeStmt(null, [], { changes: 3 });
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions', 'DELETE');
+    const res = await onDeleteAll(makeContext(req, env));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; revoked: number };
+    expect(json.ok).toBe(true);
+    expect(json.revoked).toBe(3);
+
+    const updateSql = dbPrepare.mock.calls
+      .map((c) => c[0] as string)
+      .find((s) => s.includes('UPDATE session_devices SET revoked_at'));
+    expect(updateSql).toBeTruthy();
+  });
+});
+
+describe('DELETE /api/account/sessions/:sid (revoke specific)', () => {
+  it('401 when no session', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn() } };
+    const req = new Request('https://x.com/api/account/sessions/sid-x', { method: 'DELETE' });
+    await expect(onDeleteOne(makeContext(req, env, { sid: 'sid-x' })))
+      .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+  });
+
+  it('400 when sid param missing', async () => {
+    const env: MockEnv = { SESSION_SECRET: 'test-secret-32-chars-long-enough', DB: { prepare: vi.fn().mockReturnValue(makeStmt()) } };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions/', 'DELETE');
+    await expect(onDeleteOne(makeContext(req, env, {})))
+      .rejects.toMatchObject({ code: 'DATA_VALIDATION' });
+  });
+
+  it('404 SESSION_NOT_FOUND when sid doesn\'t belong to user', async () => {
+    // SQL UPDATE with WHERE user_id = current → 0 changes if cross-user attempt
+    const stmt = makeStmt(null, [], { changes: 0 });
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions/other-user-sid', 'DELETE');
+    const res = await onDeleteOne(makeContext(req, env, { sid: 'other-user-sid' }));
+    expect(res.status).toBe(404);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('SESSION_NOT_FOUND');
+  });
+
+  it('200 + UPDATE revoked_at when sid belongs to user', async () => {
+    const stmt = makeStmt(null, [], { changes: 1 });
+    const dbPrepare = vi.fn().mockReturnValue(stmt);
+    const env: MockEnv = {
+      SESSION_SECRET: 'test-secret-32-chars-long-enough',
+      DB: { prepare: dbPrepare },
+    };
+    const req = await makeAuthedRequest('https://x.com/api/account/sessions/my-sid', 'DELETE');
+    const res = await onDeleteOne(makeContext(req, env, { sid: 'my-sid' }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; revoked_sid: string };
+    expect(json.ok).toBe(true);
+    expect(json.revoked_sid).toBe('my-sid');
+
+    // SQL filters by both sid AND user_id (cross-user defence)
+    const sql = dbPrepare.mock.calls
+      .map((c) => c[0] as string)
+      .find((s) => s.includes('UPDATE session_devices'));
+    expect(sql).toBeTruthy();
+    expect(sql).toContain('WHERE sid = ? AND user_id = ?');
+  });
+});

--- a/tests/unit/migration-0037-session-devices.test.ts
+++ b/tests/unit/migration-0037-session-devices.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Migration 0037 — session_devices schema 結構測試（V2-P6）
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION = fs.readFileSync(
+  path.resolve(__dirname, '../../migrations/0037_session_devices.sql'),
+  'utf8',
+);
+
+describe('Migration 0037 — session_devices', () => {
+  it('id INTEGER PRIMARY KEY AUTOINCREMENT', () => {
+    expect(MIGRATION).toMatch(/id\s+INTEGER PRIMARY KEY AUTOINCREMENT/);
+  });
+
+  it('sid TEXT NOT NULL UNIQUE', () => {
+    expect(MIGRATION).toMatch(/sid\s+TEXT NOT NULL UNIQUE/);
+  });
+
+  it('user_id TEXT NOT NULL', () => {
+    expect(MIGRATION).toMatch(/user_id\s+TEXT NOT NULL/);
+  });
+
+  it('ua_summary TEXT nullable', () => {
+    expect(MIGRATION).toMatch(/ua_summary\s+TEXT[\s,]/);
+    expect(MIGRATION).not.toMatch(/ua_summary[^,\n]+NOT NULL/);
+  });
+
+  it('ip_hash TEXT nullable', () => {
+    expect(MIGRATION).toMatch(/ip_hash\s+TEXT[\s,]/);
+    expect(MIGRATION).not.toMatch(/ip_hash[^,\n]+NOT NULL/);
+  });
+
+  it('created_at + last_seen_at default datetime now', () => {
+    expect(MIGRATION).toMatch(/created_at\s+TEXT NOT NULL DEFAULT/);
+    expect(MIGRATION).toMatch(/last_seen_at\s+TEXT NOT NULL DEFAULT/);
+  });
+
+  it('revoked_at TEXT nullable (column line, not the comments)', () => {
+    // Match the column definition line — leading whitespace + name + TEXT + no NOT NULL
+    const columnLine = MIGRATION
+      .split('\n')
+      .find((l) => /^\s+revoked_at\s+TEXT\b/.test(l));
+    expect(columnLine).toBeTruthy();
+    expect(columnLine).not.toMatch(/NOT NULL/);
+  });
+
+  it('indexes for user_active + sid lookup', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_session_devices_user_active/);
+    expect(MIGRATION).toMatch(/CREATE INDEX idx_session_devices_sid/);
+  });
+});


### PR DESCRIPTION
## Summary

V2 mockup §6「多裝置登入管理」完整落地：使用者在 `/settings/sessions` 看所有登入裝置 + 遠端登出。

| Layer | 內容 |
|-------|------|
| **Schema** | migration 0037 `session_devices` (sid / user_id / ua_summary / ip_hash / timestamps / revoked_at) |
| **Session module** | sid 嵌 cookie payload，issueSession 寫 session_devices row，getSessionUser revocation check |
| **API** | GET/DELETE `/api/account/sessions` + DELETE `/api/account/sessions/:sid` |
| **Frontend** | `SessionsPage` 配 mockup §6（列表 + 「目前」pill + 個別/批次登出） |

### Architecture: hybrid HMAC + DB tracking

不從 HMAC opaque cookie 改成 DB-stored session。Best of both:

- **HMAC verify 不需 DB read** — constant time，無 latency
- **DB 只在 revocation check 時讀** — D1 ms-level
- **DB 失敗 silent fallback** — cookie 仍 valid（degrade gracefully）
- **Legacy session（V2-P1 無 sid）跳過 revocation check** — backward compat

### Security

- `ip_hash` 是 SHA-256(ip)，不存 plain IP（跟 auth_audit_log 一致）
- API response 只 leak `ip_hash_prefix` 前 8 char（防反查 + 仍可 differentiate device）
- DELETE `/sessions/:sid` SQL WHERE user_id 強制只能撤銷自己的（cross-user 攻擊 → 0 rows changed → 404）
- `clearSession` 改 async 接 env → logout 立即 mark revoked_at（multi-tab）

## Test plan

- [x] tsc strict 全過
- [x] 902/902 vitest 全綠（+17 new — 8 migration + 9 API tests）

## V2 mockup 完成度

- [x] §1 重設密碼 (#298)
- [x] §2 Email 驗證 (#297)
- [x] §3 OAuth 同意 (existing)
- [x] §4 已連結應用 (#299)
- [x] §5 開發者後台 (#300)
- [x] **§6 多裝置登入管理（本 PR）**
- [x] §7 速率限制鎖定 (#304)

**V2 sprint 7/7 mockup surface 全部落地。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)