### PR TITLE
feat(design): V2 Terracotta pivot — tokens + sidebar Phase 3 cleanup

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-# Design System — Tripline（Ocean）
+# Design System — Tripline（V2 Terracotta）
 
 ## Product Context
 - **What this is:** 行程共享網站 — 旅伴可以瀏覽精美行程表（時間軸、餐廳推薦、飯店、地圖導航）
@@ -7,11 +7,27 @@
 - **Project type:** Mobile-first PWA（React SPA + Cloudflare Pages）
 
 ## Aesthetic Direction
-- **Direction:** Clean editorial — 明信片／雜誌式版面，clean Airbnb-inspired
-- **Decoration level:** Restrained — 靠排版、留白、hairline、單一 accent 支撐畫面，不靠裝飾 SVG
-- **Mood:** 清爽、專業、旅行前的期待感。純白底 + Ocean 海洋藍 accent 讓行程資訊保持主角
-- **Differentiation:** 單一色調 Ocean（非六主題切換、非暖色沙土）、Airbnb 式三層陰影、Inter + Noto Sans TC 排版
-- **Reference sites:** Airbnb（card + shadow）、Apple HIG（tap target、subheadline）、Anthropic Claude Design 稿（Okinawa Trip Redesign/Mobile）
+- **Direction:** Warm editorial — 明信片／旅遊雜誌的暖色排版，cream-paper + 焦糖陶土
+- **Decoration level:** Restrained — 靠排版、留白、hairline、單一 terracotta accent 支撐畫面，不靠裝飾 SVG
+- **Mood:** 旅途上的溫度、紙本旅遊書的安心感。奶油底（`#FFFBF5`）+ terracotta 焦糖（`#D97848`）accent 把行程資訊保持主角，避免 SaaS 冷藍感
+- **Differentiation:** 單一色調 V2 Terracotta（非六主題切換、非冷色 Ocean）、Airbnb 式三層陰影但 rgba 用暖棕（`rgba(42, 31, 24, …)`）、Inter + Noto Sans TC 排版
+- **Reference sites:** Airbnb（card + shadow）、Apple HIG（tap target、subheadline）、Anthropic Claude Design 稿（Okinawa Trip Redesign/Mobile）、`docs/design-sessions/mockup-trip-v2.html`（V2 canonical mockup）
+
+## Palette — V2 Terracotta（canonical source: tokens.css `@theme`）
+| Token | Hex | 用途 |
+|-------|-----|------|
+| `--color-accent` | `#D97848` | UI chrome 唯一主色（active state、CTA、link） |
+| `--color-accent-deep` | `#B85C2E` | hover / pressed |
+| `--color-accent-subtle` | `#FBEEE4` | badge bg、selected row |
+| `--color-accent-bg` | `#F7DFCB` | accent panel |
+| `--color-background` | `#FFFBF5` | page bg |
+| `--color-secondary` | `#FAF4EA` | card bg |
+| `--color-foreground` | `#2A1F18` | body text |
+| `--color-muted` | `#6F5A47` | secondary text |
+| `--color-border` | `#EADFCF` | hairline |
+| `--color-line-strong` | `#C8B89F` | divider strong |
+
+> **Day palette exception**: 10 色 Tailwind -500（sky/teal/amber/rose/violet/lime/orange/cyan/fuchsia/emerald）只用於地圖 polyline + day chip — 對應 Data Visualization 例外，UI chrome 仍嚴守 terracotta 單色。
 
 ## Typography
 

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,4 +1,4 @@
-/* ===== tokens.css — Ocean Design System (single-theme, Inter + Noto Sans TC) ===== */
+/* ===== tokens.css — V2 Terracotta Design System (single-theme, Inter + Noto Sans TC) ===== */
 
 /* F004: 讓瀏覽器原生 UI（scrollbar、form element、selection）在 dark mode 下自動跟隨 */
 html { color-scheme: light dark; }
@@ -6,34 +6,41 @@ html { color-scheme: light dark; }
 @import "tailwindcss/theme" layer(theme);
 @import "tailwindcss/utilities" layer(utilities);
 
-/* ===== @theme: design token source of truth (Ocean light) ===== */
+/* ===== @theme: design token source of truth (V2 Terracotta light) =====
+ * Source: docs/design-sessions/mockup-trip-v2.html (V2 Terracotta Final).
+ * Values mirror the canonical mockup palette so design ↔ implementation stay
+ * in lock-step. UI chrome is single-accent terracotta (`#D97848`); the 10-color
+ * day palette (Tailwind -500) is the documented exception per DESIGN.md
+ * Data Visualization. */
 @theme {
     /* Colors — generate bg-*, text-*, border-* utilities */
-    --color-accent: #0077B6;
-    --color-accent-subtle: #E0F4FA;
-    --color-accent-bg: #CAF0F8;
-    --color-background: #FFFFFF;
-    --color-secondary: #F7FBFD;
-    --color-tertiary: #F2F2F2;
-    --color-hover: #F2F8FB;
-    --color-foreground: #222222;
-    --color-muted: #6A6A6A;
+    --color-accent: #D97848;
+    --color-accent-subtle: #FBEEE4;
+    --color-accent-bg: #F7DFCB;
+    --color-accent-deep: #B85C2E;
+    --color-background: #FFFBF5;
+    --color-secondary: #FAF4EA;
+    --color-tertiary: #F2EAD9;
+    --color-hover: #F9EDE0;
+    --color-foreground: #2A1F18;
+    --color-muted: #6F5A47;
     --color-accent-foreground: #FFFFFF;
-    --color-border: #EBEBEB;
+    --color-border: #EADFCF;
+    --color-line-strong: #C8B89F;
     --color-destructive: #C13515;
     --color-destructive-bg: #FDECEC;
     --color-success: #06A77D;
     --color-success-bg: rgba(6, 167, 125, 0.12);
     --color-warning: #F48C06;
     --color-warning-bg: rgba(244, 140, 6, 0.12);
-    --color-info: #0077B6;
-    --color-info-bg: rgba(0, 119, 182, 0.12);
-    --color-plan-bg: #E0F4FA;
-    --color-plan-text: #023E8A;
-    --color-plan-hover: #CAF0F8;
-    --color-disabled: #B0B8BE;
-    --color-disabled-foreground: #D0D6DA;
-    --color-overlay: rgba(13, 27, 42, 0.35);
+    --color-info: #D97848;
+    --color-info-bg: rgba(217, 120, 72, 0.12);
+    --color-plan-bg: #FBEEE4;
+    --color-plan-text: #B85C2E;
+    --color-plan-hover: #F7DFCB;
+    --color-disabled: #B8AC9B;
+    --color-disabled-foreground: #D8CDB8;
+    --color-overlay: rgba(42, 31, 24, 0.35);
     --color-priority-high-bg: rgba(193, 53, 21, 0.12);
     --color-priority-high-dot: #C13515;
     --color-priority-medium-bg: rgba(244, 140, 6, 0.12);
@@ -50,9 +57,10 @@ html { color-scheme: light dark; }
     --radius-full: 9999px;
 
     /* Shadow — Airbnb 三層陰影 */
-    --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
-    --shadow-md: 0 6px 16px rgba(0,0,0,0.08);
-    --shadow-lg: 0 10px 28px rgba(0,0,0,0.12);
+    /* Warm-tinted shadows (rgba sourced from foreground brown for V2 Terracotta) */
+    --shadow-sm: 0 1px 2px rgba(42, 31, 24, 0.05);
+    --shadow-md: 0 6px 16px rgba(42, 31, 24, 0.09);
+    --shadow-lg: 0 10px 28px rgba(42, 31, 24, 0.12);
 
     /* Spacing — 4pt grid */
     --spacing-half: 2px;
@@ -186,7 +194,7 @@ body {
     --color-glass-nav: color-mix(in srgb, var(--color-background) 92%, transparent);
     --color-glass-toast: color-mix(in srgb, var(--color-secondary) 92%, transparent);
     --shadow-toast: var(--shadow-lg), 0 0 0 1px color-mix(in srgb, var(--color-border) 60%, transparent);
-    --badge-open-bg: #E0F4FA;         --badge-open-text: #023E8A;
+    --badge-open-bg: #FBEEE4;          --badge-open-text: #B85C2E;
     --badge-processing-bg: #FFF3CD;    --badge-processing-text: #856404;
     --badge-completed-bg: #D4EDDA;     --badge-completed-text: #155724;
     --badge-failed-bg: #F8D7DA;        --badge-failed-text: #721C24;
@@ -208,19 +216,19 @@ body.dark {
 
 /* ===== Non-utility tokens ===== */
 :root {
-    --scrollbar-thumb: #C1C1C1;
-    --scrollbar-thumb-hover: #A8A8A8;
-    --cmp-light-bg: #E0F4FA;
-    --cmp-light-surface: #FFFFFF;
-    --cmp-light-input: #EBEBEB;
-    --cmp-dark-bg: #0D1B2A;
-    --cmp-dark-surface: #1B263B;
-    --cmp-dark-input: #2E3B4F;
-    --color-badge-open: #0077B6;
-    --color-badge-closed: #023E8A;
-    --color-plan-bg: #E0F4FA;
-    --color-plan-text: #023E8A;
-    --color-plan-hover: #CAF0F8;
+    --scrollbar-thumb: #C8B89F;
+    --scrollbar-thumb-hover: #A89978;
+    --cmp-light-bg: #FBEEE4;
+    --cmp-light-surface: #FFFBF5;
+    --cmp-light-input: #EADFCF;
+    --cmp-dark-bg: #1A140F;
+    --cmp-dark-surface: #2A1F18;
+    --cmp-dark-input: #3D2D22;
+    --color-badge-open: #D97848;
+    --color-badge-closed: #B85C2E;
+    --color-plan-bg: #FBEEE4;
+    --color-plan-text: #B85C2E;
+    --color-plan-hover: #F7DFCB;
     --color-google-maps: #4285F4;
     --color-naver-maps: #03C75A;
     --theme-header-gradient: none;
@@ -783,47 +791,49 @@ body.dark {
     100% { background: transparent; }
 }
 
-/* ===== Dark mode override (Ocean deep-navy) ===== */
+/* ===== Dark mode override (Terracotta deep-cocoa) ===== */
 @layer base {
     body.dark {
-        --color-accent: #48CAE4;
-        --color-accent-subtle: #13293D;
-        --color-accent-bg: #1E3A52;
-        --color-background: #0D1B2A;
-        --color-secondary: #1B263B;
-        --color-tertiary: #2E3B4F;
-        --color-hover: #253345;
-        --color-foreground: #E0F4FA;
-        --color-muted: #90A4B8;
-        --color-accent-foreground: #0D1B2A;
-        --color-border: #2E3B4F;
+        --color-accent: #E89968;
+        --color-accent-subtle: #3A2A20;
+        --color-accent-bg: #4D372A;
+        --color-accent-deep: #FFB890;
+        --color-background: #1A140F;
+        --color-secondary: #241B14;
+        --color-tertiary: #2E2418;
+        --color-hover: #2D2218;
+        --color-foreground: #F5EBDD;
+        --color-muted: #B89E84;
+        --color-accent-foreground: #1A140F;
+        --color-border: #3D2D22;
+        --color-line-strong: #5A4634;
         --color-destructive: #E8A0A0;
         --color-destructive-bg: rgba(232, 160, 160, 0.15);
         --color-success: #7EC89A;
         --color-success-bg: rgba(126, 200, 154, 0.15);
         --color-warning: #F0D060;
         --color-warning-bg: rgba(240, 208, 96, 0.15);
-        --color-info: #48CAE4;
-        --color-info-bg: rgba(72, 202, 228, 0.15);
-        --shadow-sm: 0 1px 2px rgba(0,0,0,0.20);
-        --shadow-md: 0 6px 16px rgba(0,0,0,0.30);
-        --shadow-lg: 0 10px 28px rgba(0,0,0,0.40);
+        --color-info: #E89968;
+        --color-info-bg: rgba(232, 153, 104, 0.15);
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.30);
+        --shadow-md: 0 6px 16px rgba(0,0,0,0.42);
+        --shadow-lg: 0 10px 28px rgba(0,0,0,0.55);
         --color-priority-high-bg: rgba(232, 160, 160, 0.18);
         --color-priority-high-dot: #E8A0A0;
         --color-priority-medium-bg: rgba(240, 208, 96, 0.18);
         --color-priority-medium-dot: #F0D060;
         --color-priority-low-bg: rgba(126, 200, 154, 0.12);
         --color-priority-low-dot: #7EC89A;
-        --scrollbar-thumb: #3A4758;
-        --scrollbar-thumb-hover: #4A5768;
-        --color-overlay: rgba(0,0,0,0.60);
-        --color-badge-open: #48CAE4;
-        --color-badge-closed: #8B5CF6;
-        --color-disabled: #4A5768;
-        --color-disabled-foreground: #2E3B4F;
-        --color-plan-bg: #13293D;
-        --color-plan-text: #90E0EF;
-        --color-plan-hover: #1E3A52;
+        --scrollbar-thumb: #5A4634;
+        --scrollbar-thumb-hover: #7A604A;
+        --color-overlay: rgba(0,0,0,0.65);
+        --color-badge-open: #E89968;
+        --color-badge-closed: #B85C2E;
+        --color-disabled: #5A4634;
+        --color-disabled-foreground: #3D2D22;
+        --color-plan-bg: #3A2A20;
+        --color-plan-text: #FFB890;
+        --color-plan-hover: #4D372A;
     }
 
     /* Print mode — flat white + hairline for printing */

--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -1,8 +1,12 @@
 /**
- * DesktopSidebar — 5-nav app-level sidebar (chat / trips / map / explore / login).
+ * DesktopSidebar — app-level sidebar.
  *
  * 「行程」nav matches /manage AND /trip/* so per-trip sub-routes (e.g. /trip/:id/map)
  * stay highlighted on the trips nav, not the cross-trip /map global view.
+ *
+ * `chat` (/chat) + `map` (/map) are kept in NAV_ITEMS but flagged `comingSoon`
+ * so they're hidden from sidebar until Phase 3 builds the real product. Routes
+ * still resolve (placeholder pages) for direct URL access.
  */
 import type { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -18,12 +22,14 @@ interface NavItemConfig {
   matchPrefixes: readonly string[];
   /** When true, match only the exact prefix — no nested sub-routes. */
   exactOnly?: boolean;
+  /** Phase 3 placeholder — hide from sidebar until implemented. Flip to `false` to re-enable. */
+  comingSoon?: boolean;
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItemConfig> = [
-  { key: 'chat',      label: '聊天',     href: '/chat',                       icon: 'chat',   matchPrefixes: ['/chat'] },
+  { key: 'chat',      label: '聊天',     href: '/chat',                       icon: 'chat',   matchPrefixes: ['/chat'], comingSoon: true },
   { key: 'trips',     label: '行程',     href: '/manage',                     icon: 'home',   matchPrefixes: ['/manage', '/trip'] },
-  { key: 'map',       label: '地圖',     href: '/map',                        icon: 'map',    matchPrefixes: ['/map'], exactOnly: true },
+  { key: 'map',       label: '地圖',     href: '/map',                        icon: 'map',    matchPrefixes: ['/map'], exactOnly: true, comingSoon: true },
   { key: 'explore',   label: '探索',     href: '/explore',                    icon: 'search', matchPrefixes: ['/explore'] },
   { key: 'settings',  label: '已連結應用', href: '/settings/connected-apps',   icon: 'gear',   matchPrefixes: ['/settings'] },
   { key: 'developer', label: '開發者',   href: '/developer/apps',             icon: 'code',   matchPrefixes: ['/developer'] },
@@ -173,11 +179,13 @@ export default function DesktopSidebar({ user, onNewTrip, brand }: DesktopSideba
   const { pathname } = useLocation();
   const initial = user?.name?.charAt(0)?.toUpperCase() ?? '?';
 
-  // Logged in: hide '登入' (use chip + 登出 link 在底部); show settings/developer
-  // Logged out: hide auth-required items; show '登入'
-  const visibleNavItems = user
-    ? NAV_ITEMS.filter((item) => item.key !== 'login')
-    : NAV_ITEMS.filter((item) => !AUTH_REQUIRED_NAV_KEYS.has(item.key));
+  // Filter chain:
+  //   1. comingSoon items hidden (Phase 3 placeholders)
+  //   2. Logged in: hide '登入' (use chip + 登出 link 在底部); show settings/developer
+  //   2. Logged out: hide auth-required items; show '登入'
+  const visibleNavItems = NAV_ITEMS.filter((item) => !item.comingSoon).filter((item) =>
+    user ? item.key !== 'login' : !AUTH_REQUIRED_NAV_KEYS.has(item.key),
+  );
 
   return (
     <>

--- a/src/components/trip/OceanMap.tsx
+++ b/src/components/trip/OceanMap.tsx
@@ -92,10 +92,10 @@ const SCOPED_STYLES = `
 }
 .ocean-map-pin[data-state="active"] {
   width: 36px; height: 36px; font-size: 13px;
-  background: var(--color-accent, #0077B6);
+  background: var(--color-accent, #D97848);
   border-color: #fff;
   color: #fff;
-  box-shadow: 0 4px 12px rgba(0, 119, 182, 0.30);
+  box-shadow: 0 4px 12px rgba(217, 120, 72, 0.30);
 }
 .ocean-map-pin[data-state="past"] {
   border-color: #E0E0E0;
@@ -106,8 +106,8 @@ const SCOPED_STYLES = `
   display: grid; place-items: center;
   width: 40px; height: 40px;
   border-radius: 50%;
-  background: var(--color-accent-bg, #CAF0F8);
-  border: 1.5px solid var(--color-accent, #0077B6);
+  background: var(--color-accent-bg, #F7DFCB);
+  border: 1.5px solid var(--color-accent, #D97848);
   color: var(--color-foreground, #222);
   font-weight: 700; font-size: 13px; font-variant-numeric: tabular-nums;
   font-family: var(--font-family-system, 'Inter', sans-serif);
@@ -163,7 +163,7 @@ function segmentStyle(isActive: boolean, approx: boolean, dayNum?: number): L.Po
   }
   // Default (no dayNum): accent for active, muted grey for idle.
   return {
-    color: isActive ? 'var(--color-accent, #0077B6)' : '#94A3B8',
+    color: isActive ? 'var(--color-accent, #D97848)' : '#94A3B8',
     weight: isActive ? 4 : 3,
     opacity: isActive ? 0.85 : 0.6,
     dashArray: approx ? '6,6' : undefined,

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -3,8 +3,8 @@ import { lsSet, lsGet } from '../lib/localStorage';
 
 export type ColorMode = 'light' | 'auto' | 'dark';
 
-/** Ocean theme color values (light / dark) — for <meta name="theme-color">. */
-const OCEAN_COLORS = { light: '#0077B6', dark: '#0D1B2A' } as const;
+/** Theme color values (light / dark) — for <meta name="theme-color">. Mirrors V2 Terracotta `--color-accent`. */
+const THEME_COLORS = { light: '#D97848', dark: '#1A140F' } as const;
 
 /** Resolve whether dark class should be applied for a given color mode. */
 function resolveDark(mode: ColorMode): boolean {
@@ -31,7 +31,7 @@ function readColorMode(): ColorMode {
 function updateMetaThemeColor(dark: boolean) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', dark ? OCEAN_COLORS.dark : OCEAN_COLORS.light);
+    meta.setAttribute('content', dark ? THEME_COLORS.dark : THEME_COLORS.light);
   }
 }
 

--- a/tests/unit/desktop-sidebar.test.tsx
+++ b/tests/unit/desktop-sidebar.test.tsx
@@ -1,7 +1,11 @@
 /**
- * DesktopSidebar — 
+ * DesktopSidebar —
  *
- * 5 nav items（聊天 / 行程 / 地圖 / 探索 / 登入）+ user chip + New Trip CTA。
+ * Visible nav items (3 anonymous, 4 logged-in): 行程 / 探索 / 登入 (anon) +
+ * 已連結應用 / 開發者 / 登出 chip (logged-in). 聊天 + 地圖 are flagged
+ * `comingSoon` and hidden from sidebar until Phase 3 builds the real product
+ * (per `mockup-chat-v2.html` + `mockup-map-v2.html`).
+ *
  * 視覺對應：docs/design-sessions/mockup-trip-v2.html sidebar 區塊。
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -24,26 +28,26 @@ function renderSidebar(opts: {
   );
 }
 
-describe('DesktopSidebar — 5 nav items', () => {
-  it('渲染 5 個 nav items 順序為 聊天 / 行程 / 地圖 / 探索 / 登入', () => {
+describe('DesktopSidebar — visible nav items (anonymous)', () => {
+  it('渲染 3 個 nav items: 行程 / 探索 / 登入（聊天 + 地圖 是 Phase 3 placeholder, 隱藏）', () => {
     const { getAllByRole } = renderSidebar();
     const links = getAllByRole('link');
-    expect(links.length).toBe(5);
-    expect(links[0].textContent).toContain('聊天');
-    expect(links[1].textContent).toContain('行程');
-    expect(links[2].textContent).toContain('地圖');
-    expect(links[3].textContent).toContain('探索');
-    expect(links[4].textContent).toContain('登入');
+    expect(links.length).toBe(3);
+    expect(links[0].textContent).toContain('行程');
+    expect(links[1].textContent).toContain('探索');
+    expect(links[2].textContent).toContain('登入');
+    // 確認 placeholder 沒進 nav
+    const allText = links.map((l) => l.textContent).join('|');
+    expect(allText).not.toContain('聊天');
+    expect(allText).not.toContain('地圖');
   });
 
-  it('nav items href 對應 /chat /manage /map /explore /login', () => {
+  it('nav items href 對應 /manage /explore /login', () => {
     const { getAllByRole } = renderSidebar();
     const links = getAllByRole('link') as HTMLAnchorElement[];
-    expect(links[0].getAttribute('href')).toBe('/chat');
-    expect(links[1].getAttribute('href')).toBe('/manage');
-    expect(links[2].getAttribute('href')).toBe('/map');
-    expect(links[3].getAttribute('href')).toBe('/explore');
-    expect(links[4].getAttribute('href')).toBe('/login');
+    expect(links[0].getAttribute('href')).toBe('/manage');
+    expect(links[1].getAttribute('href')).toBe('/explore');
+    expect(links[2].getAttribute('href')).toBe('/login');
   });
 });
 
@@ -51,50 +55,34 @@ describe('DesktopSidebar — active state', () => {
   it('路由 /manage 時「行程」item 有 is-active class', () => {
     const { getAllByRole } = renderSidebar({ path: '/manage' });
     const links = getAllByRole('link');
-    expect(links[1].className).toMatch(/is-active/);
-    // 其他 4 個不該 active
-    expect(links[0].className).not.toMatch(/is-active/);
+    expect(links[0].className).toMatch(/is-active/);
+    // 其他 nav 不 active
+    expect(links[1].className).not.toMatch(/is-active/);
     expect(links[2].className).not.toMatch(/is-active/);
-    expect(links[3].className).not.toMatch(/is-active/);
-    expect(links[4].className).not.toMatch(/is-active/);
   });
 
   it('路由 /trip/abc 時「行程」item 仍 active（trip 屬於行程 scope）', () => {
     const { getAllByRole } = renderSidebar({ path: '/trip/abc' });
     const links = getAllByRole('link');
-    expect(links[1].className).toMatch(/is-active/);
-  });
-
-  it('路由 /trip/abc/map 時「行程」item active（per-trip sub-route）', () => {
-    const { getAllByRole } = renderSidebar({ path: '/trip/abc/map' });
-    const links = getAllByRole('link');
-    expect(links[1].className).toMatch(/is-active/);
-    // /map nav item 是 cross-trip global，per-trip 的 sub-route 不該讓它 active
-    expect(links[2].className).not.toMatch(/is-active/);
-  });
-
-  it('路由 /chat 時「聊天」item active', () => {
-    const { getAllByRole } = renderSidebar({ path: '/chat' });
-    const links = getAllByRole('link');
     expect(links[0].className).toMatch(/is-active/);
   });
 
-  it('路由 /map 時「地圖」item active（cross-trip global）', () => {
-    const { getAllByRole } = renderSidebar({ path: '/map' });
+  it('路由 /trip/abc/map 時「行程」item active（per-trip sub-route，不轉到全域 /map）', () => {
+    const { getAllByRole } = renderSidebar({ path: '/trip/abc/map' });
     const links = getAllByRole('link');
-    expect(links[2].className).toMatch(/is-active/);
+    expect(links[0].className).toMatch(/is-active/);
   });
 
   it('路由 /explore 時「探索」item active', () => {
     const { getAllByRole } = renderSidebar({ path: '/explore' });
     const links = getAllByRole('link');
-    expect(links[3].className).toMatch(/is-active/);
+    expect(links[1].className).toMatch(/is-active/);
   });
 
   it('路由 /login 或 sub-route 時「登入」item active', () => {
     const { getAllByRole } = renderSidebar({ path: '/login/forgot' });
     const links = getAllByRole('link');
-    expect(links[4].className).toMatch(/is-active/);
+    expect(links[2].className).toMatch(/is-active/);
   });
 });
 
@@ -143,11 +131,13 @@ describe('DesktopSidebar — user chip', () => {
     });
     const nav = container.querySelector('[aria-label="主要功能"]');
     expect(nav?.textContent).not.toContain('登入');
-    // 其他 4 nav item 仍在
-    expect(nav?.textContent).toContain('聊天');
+    // 其他可見 nav item 仍在（聊天 + 地圖 是 Phase 3 placeholder，依然隱藏）
     expect(nav?.textContent).toContain('行程');
-    expect(nav?.textContent).toContain('地圖');
     expect(nav?.textContent).toContain('探索');
+    expect(nav?.textContent).toContain('已連結應用');
+    expect(nav?.textContent).toContain('開發者');
+    expect(nav?.textContent).not.toContain('聊天');
+    expect(nav?.textContent).not.toContain('地圖');
   });
 
   it('未登入時 nav 顯示「登入」item', () => {

--- a/tests/unit/tokens-css.test.ts
+++ b/tests/unit/tokens-css.test.ts
@@ -24,7 +24,7 @@ describe('tokens.css', () => {
     expect(tokens).toContain('--transition-duration-fast:');
   });
 
-  it('Ocean-only design system: dark + print, no legacy theme blocks', () => {
+  it('Single-theme design system: dark + print, no legacy multi-theme blocks', () => {
     expect(tokens).toContain('body.dark {');
     expect(tokens).toContain('body.theme-print');
     expect(tokens).not.toContain('body.theme-sun');
@@ -35,10 +35,10 @@ describe('tokens.css', () => {
     expect(tokens).not.toContain('body.theme-night');
   });
 
-  it('uses Ocean accent + white background as default @theme', () => {
-    expect(tokens).toMatch(/--color-accent:\s*#0077B6/);
-    expect(tokens).toMatch(/--color-background:\s*#FFFFFF/);
-    expect(tokens).toMatch(/--color-foreground:\s*#222222/);
+  it('uses V2 Terracotta accent + cream background as default @theme', () => {
+    expect(tokens).toMatch(/--color-accent:\s*#D97848/);
+    expect(tokens).toMatch(/--color-background:\s*#FFFBF5/);
+    expect(tokens).toMatch(/--color-foreground:\s*#2A1F18/);
   });
 
   it('loads Inter + Noto Sans TC primary font stack', () => {


### PR DESCRIPTION
## Summary

V2 layout pivot 套舊 Ocean tokens 不對齊 mockup,加上 sidebar 兩個 Phase 3 placeholder (聊天/地圖) 點下去顯示「Coming soon」破壞 UX。這 PR 補完。

- **tokens.css**: `@theme` + `body.dark` + 各 `:root` 區塊全換成 `mockup-trip-v2.html` 的 Terracotta 數值(accent `#D97848`、bg `#FFFBF5`、warm dark brown `#2A1F18`、暖棕 shadow `rgba(42,31,24,…)` 等)
- **DESIGN.md**: header 改 "V2 Terracotta",Aesthetic Direction 重寫,加 canonical palette table 對齊 tokens.css 防止再 drift
- **Sidebar**: 聊天 + 地圖 加 `comingSoon: true`,從 nav 隱藏(routes 仍可直連 placeholder page)。匿名 sidebar = 3 items,登入後 = 4 items + chip
- **Hardcoded fallback**: `OceanMap.tsx` 4 處 `var(--color-accent, #0077B6)` 改 `#D97848`、useDarkMode `OCEAN_COLORS` 改 `THEME_COLORS` 以更新 `<meta name="theme-color">`
- **Tests**: tokens-css.test 改驗 terracotta 值、desktop-sidebar.test 改驗新 visible-nav contract

968 unit / 510 API tests pass, tsc clean.

## Test plan

- [x] `npm test --run` — 968/968 pass
- [x] `npm run test:api` — 510/510 pass
- [x] `npx tsc --noEmit` — clean
- [ ] CI green
- [ ] CF Pages preview deploy 視覺對齊 `mockup-trip-v2.html`(等下手動確認)
- [ ] Land 後 prod canary 確認 accent + sidebar 都換好

🤖 Generated with [Claude Code](https://claude.com/claude-code)