### PR TITLE
feat(v2-design): public-config + Google graceful + V2 design audit

### DIFF
--- a/docs/v2-design-audit-2026-04-25.md
+++ b/docs/v2-design-audit-2026-04-25.md
@@ -1,0 +1,239 @@
+# V2 Design Audit — 2026-04-25
+
+Side-by-side comparison of every V2 page on prod against the canonical mockups
+in `docs/design-sessions/`. Desktop (1280×800) AND mobile (375×812).
+
+**Status legend:**
+- ✅ Aligned — matches mockup
+- 🟡 Partial — visual aesthetic correct, structure differs
+- 🔴 Gap — needs follow-up work
+- ⏭ Deferred — Phase 3 / out of V2 scope
+
+**Theme baseline (verified on prod after V2 Terracotta pivot):**
+- accent: `#D97848` ✓
+- bg: `#FFFBF5` ✓
+- fg: `#2A1F18` ✓
+- meta theme-color: `#D97848` ✓
+
+---
+
+## Auth pages — prod uses standalone scoped layout, mockups use AppShell-wrapped layout with right hero pane
+
+| Page | Desktop | Mobile | Mockup target |
+|------|---------|--------|---------------|
+| /login | 🟡 standalone card | 🟡 standalone card | mockup-login-v2.html |
+| /signup | 🟡 standalone card | ✅ aesthetic clean & email-first | mockup-signup-v2.html |
+| /login/forgot | 🟡 standalone card | 🟡 | mockup-forgot-v2.html |
+| /auth/password/reset | 🟡 standalone card (no mockup) | 🟡 | (V2 design language) |
+| /signup/check-email | 🟡 standalone card (no mockup) | 🟡 | (V2 design language) |
+
+**Common gaps across all auth pages:**
+
+1. 🟡 **No AppShell wrapping.** Mockups (login/signup/forgot) all show auth pages
+   inside the AppShell with sidebar visible (`聊天 / 行程 / 地圖 / 探索 / 登入`)
+   and right-side terracotta brand hero pane. Prod renders auth as standalone
+   centered cards. Aesthetic (cream + terracotta CTA + warm dark text) is
+   already aligned via tokens.css; only the structural shell is missing.
+2. 🔴 **No right-side brand hero on desktop.** Mockup desktop has a 40vw
+   right pane with terracotta gradient + tagline "把每次旅程留在身邊" /
+   "ACCOUNT RECOVERY 5 分鐘搞定" / per-page brand reinforcement.
+3. 🟡 **Top step indicator missing** on multi-step flows (forgot→check-email,
+   signup→check-email). Mockup shows `STEP 1 / 2` chip in card header.
+
+**Auth-specific fixes applied this PR:**
+
+1. ✅ **Google login graceful fallback** (`LoginPage.tsx`): button is now hidden
+   until `/api/public-config` confirms `GOOGLE_CLIENT_ID` env is set. New
+   `functions/api/public-config.ts` endpoint exposes `{ providers: { google },
+   features: { passwordSignup, emailVerification } }`. Per user direction
+   "沒有 google 沒關係 先開放自建帳號".
+2. ✅ **Self-registration flow promoted.** The "沒有帳號? 建立帳號" link is now
+   above the CF Access fallback so the primary path is unmistakable.
+3. ✅ **CF Access transition link demoted** — moved below the signup link so the
+   V2 self-signup is the obvious primary action.
+
+**Auth-specific follow-ups (P2):**
+
+1. ⏭ Wrap `/login`, `/signup`, `/login/forgot`, `/auth/password/reset`,
+   `/signup/check-email` in `AppShell` so unauthenticated users see the same
+   sidebar + chrome as logged-in. Sidebar already supports `user: null`.
+2. ⏭ Add a desktop-only `<aside>` right-pane brand hero to each auth page
+   (one per page, content matches mockup's per-page narrative).
+3. ⏭ Add `STEP 1/2` indicator chips on the forgot→check-email flow.
+
+---
+
+## Trip page (`/trip/:id`) — biggest IA mismatch
+
+**Desktop:** 🔴 mockup-trip-v2.html shows a `/trips` LANDING page with a card
+grid of all user trips (沖繩之旅 / 首爾美食行 / 台中週末小旅), each rendered as
+a peach-gradient card. Right pane shows the selected trip's day chips + stop
+list. Header is just `我的行程` with sort/filter chips.
+
+Prod `/trip/:id` is the trip-DETAIL view — a 3-pane shell with day-grouped
+timeline in the center column and a placeholder right pane saying
+`行程已顯示在左側`. There's no parent `/trips` index page at all; the user
+arrives via deep link (`/trip/okinawa-trip-2026-Ray`).
+
+**Mobile:** 🟡 prod renders the timeline cleanly with day chips at the top,
+similar in spirit to the mobile mockup, but lacks the gradient day pills and
+the floating bottom action bar from the mockup.
+
+**Trip-specific gaps:**
+
+1. 🔴 **No `/trips` landing page.** Mockup desktop is a "my trips" overview
+   that doesn't exist in prod. Click into a trip → see the detail view.
+   Currently we go straight to detail, no grid step.
+2. 🔴 **No gradient trip cards.** Mockup shows each trip as a peach/amber/teal
+   warm-gradient card with title + days. Prod has no card surface for trips.
+3. 🟡 **Right pane is placeholder text.** Mockup shows trip days breakdown +
+   stop list in the right pane; prod shows static "行程已顯示在左側" copy.
+4. 🟡 **Mobile bottom action bar.** Mockup shows a floating `+` CTA + day pill
+   filter row pinned to bottom. Prod has the BottomNavBar (route nav) instead.
+
+**Trip-specific follow-ups (P2/P3):**
+
+1. ⏭ Build `/trips` landing page (`TripsListPage`) with peach-gradient card
+   grid. Re-route default landing from `/trip/:default` to `/trips`.
+2. ⏭ Right pane: render selected day's stop summary instead of placeholder.
+3. ⏭ Mobile: add the bottom action sheet pattern from mockup-trip-v2 mobile.
+
+---
+
+## Explore page (`/explore`)
+
+**Desktop:** 🔴 mockup-explore-v2.html shows a 2×3 grid of POI cards with
+full-color gradient backgrounds (teal / peach / blue / orange / green / brown
+— POI category palette). Right pane shows the selected POI detail.
+
+Prod `/explore` is functional but plain: title + description + search bar +
+empty `儲存池 0 個已儲存 POI`. No card grid. No right pane.
+
+**Mobile:** 🟡 prod mobile is essentially the desktop content stacked. Mockup
+mobile has the same card grid layout in single-column.
+
+**Explore-specific gaps:**
+
+1. 🔴 **No POI card grid** with gradient surfaces.
+2. 🔴 **No POI category palette.** Mockup uses 6 distinct hues for category
+   badges; prod has none.
+3. 🟡 **Empty-state UX.** Prod's empty state ("還沒有儲存任何 POI…") is bland;
+   mockup uses an empty state with category cards prompting exploration.
+
+**Explore follow-ups (P3):**
+
+1. ⏭ Add POI card grid component with gradient backgrounds keyed to category.
+2. ⏭ Right-pane POI detail view.
+3. ⏭ Improved empty state with category prompts.
+
+---
+
+## Settings pages (`/settings/*`, `/developer/apps`) — no mockup; align to V2 shell
+
+| Page | Desktop | Mobile | Notes |
+|------|---------|--------|-------|
+| /oauth/consent | ✅ form-based POST, terracotta CTA | ✅ same | recently rewritten in /review pass |
+| /settings/connected-apps | 🟡 functional, plain layout | 🟡 | needs AppShell wrap |
+| /developer/apps | 🟡 functional, plain | 🟡 | needs AppShell wrap |
+| /settings/sessions | 🟡 functional, plain | 🟡 | needs AppShell wrap |
+
+**Settings follow-ups:**
+
+1. ⏭ Wrap all settings pages in `AppShell` so sidebar nav + brand are visible.
+2. ⏭ Add page-level header with breadcrumb / "← 帳號設定" back link pattern.
+
+---
+
+## Shell components — sidebar visible, header/sheet structure differs
+
+### DesktopSidebar (`src/components/shell/DesktopSidebar.tsx`)
+
+✅ Cream background (matches mockup `--sidebar-bg: #FFFBF5`)
+✅ Brand "Tripline" + terracotta accent dot
+✅ Active state: dark cocoa bg + cream text
+✅ "新增行程" CTA in terracotta
+🟡 Mockup spacing is slightly tighter — prod uses 12px sidebar padding, mockup
+   uses 14px. Minor.
+✅ `comingSoon` flag hides 聊天/地圖 from nav until Phase 3 implements them
+   (per `mockup-chat-v2` / `mockup-map-v2` design exists but build deferred).
+   **Login is NOT hidden** — it stays visible per user direction.
+
+### BottomNavBar (mobile, `src/components/shell/BottomNavBar.tsx`)
+
+✅ 4-tab IA (`行程 / 地圖 / 訊息 / 更多`) per CLAUDE.md
+🟡 Mockup shows a wider rounded action bar with floating `+` button; prod is
+   flatter sticky bar. Functional parity but visual treatment differs.
+
+### Header (page-level, varies per page)
+
+🔴 Mockup shows a uniform top header bar with breadcrumb / page title +
+   secondary actions chip row. Prod has page-specific headers (TripPage shows
+   day chip nav, ExplorePage shows just title + description).
+🔴 No persistent top "tabs" pattern (mockup signup shows `新增 / 登入 / 已登錄帳號`
+   tabs). Prod treats /login and /signup as separate routes without that
+   shared header.
+
+---
+
+## Per-page polish items (small CSS-only fixes feasible later)
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `src/pages/LoginPage.tsx` | CF Access link styled as muted text — could be smaller | reduce font-size to caption, lower contrast |
+| `src/pages/SignupPage.tsx` | "至少 8 字元" hint right-aligned — mockup has it inline-after | minor copy reflow |
+| `src/pages/ExplorePage.tsx` | Empty state container has 360px min-height — feels weighty | tighten to fit content |
+| `src/components/shell/DesktopSidebar.tsx` | Sidebar padding `20px 12px` — mockup uses `20px 14px` | bump 12 → 14 |
+
+---
+
+## Scoring
+
+| Category | Grade | Notes |
+|----------|-------|-------|
+| Color & Theme | A | Terracotta token migration complete, warm shadows, semantic colors aligned. |
+| Typography | B+ | Inter + Noto Sans TC, headings warm dark brown. Mockup uses slightly heavier display weights on hero pages. |
+| Spacing & Layout | B | Tokens consistent. AppShell on auth pages would lift this to A. |
+| Visual Hierarchy | B | Auth pages clean, but trip page right pane is placeholder + missing card grid hurts hierarchy. |
+| Interaction States | A- | Hover / focus / disabled all reasonable; locked-out countdown is a delight. |
+| Responsive | B+ | Mobile auth pages strong, trip page mobile works but doesn't match mockup's bottom action sheet. |
+| Content & Copy | A- | Friendly, specific, error states named. Empty states could be warmer. |
+| Motion | B | Sheet animations + toast slide tokens defined; auth pages don't use them. |
+| Performance Feel | A | TTFB ~96ms on prod /, no FOUT, font-display: swap. |
+| AI Slop | A | Zero generic SaaS patterns. Custom palette, branded shell, no purple gradient. |
+
+**Overall design score: B+ (was C before terracotta pivot, was D before V2 layout pivot).**
+
+**AI slop score: A (single-theme intentional terracotta system; no symmetrical 3-column generic SaaS layout; warm brown shadows are specific and rare).**
+
+---
+
+## Quick wins applied this PR
+
+1. ✅ `/api/public-config` endpoint added — backend signal for "is Google
+   configured" so frontend can hide buttons.
+2. ✅ `LoginPage` Google button gated on the public-config probe.
+3. ✅ Footer link `沒有帳號? 建立帳號` promoted above the CF Access fallback.
+4. ✅ Audit document (this file) lists every gap with status + follow-up tag.
+
+## Follow-ups in priority order (P1 → P3)
+
+| Priority | Item | Estimated CC time |
+|----------|------|------|
+| P1 | Wrap auth pages in AppShell so sidebar visible to anonymous users | ~30min |
+| P1 | Add `<aside>` desktop right-pane brand hero to login/signup/forgot | ~45min |
+| P2 | `/trips` landing page with peach-gradient trip cards | ~60min |
+| P2 | Right pane on `/trip/:id` shows selected day's stop summary | ~30min |
+| P2 | Wrap `/settings/*` and `/developer/*` in AppShell | ~20min |
+| P3 | `/explore` POI card grid with category-keyed gradients | ~90min |
+| P3 | Implement `/chat` (LLM concierge) — mockup-chat-v2 design exists | several days |
+| P3 | Implement `/map` (cross-trip global map) | ~2 days |
+
+---
+
+## Screenshots
+
+All comparison screenshots saved to `.gstack/design-shots/`:
+- `prod-d-{login,signup,forgot,reset,check-email,consent,explore,trip}.png` — desktop
+- `prod-m-{login,signup,forgot,reset,check-email,consent,explore,trip}.png` — mobile
+- `mock-d-{login,signup,forgot,trip,explore}.png` — mockup desktop
+- `mock-m-{login,signup,forgot,trip,explore}.png` — mockup mobile

--- a/functions/api/public-config.ts
+++ b/functions/api/public-config.ts
@@ -1,0 +1,36 @@
+/**
+ * GET /api/public-config
+ *
+ * Public capability probe — tells unauthenticated clients which optional providers
+ * are configured for this deployment so the UI can hide buttons that would lead
+ * to a 503. No secrets are exposed; we only signal "configured / not configured".
+ *
+ * Response: { providers: { google: boolean }, features: { passwordSignup: boolean } }
+ *
+ * NOTE: keep this endpoint side-effect-free (no D1 writes, no state tokens).
+ * It runs on every login/signup page load, so any work done here multiplies.
+ */
+import type { Env } from './_types';
+
+export const onRequestGet: PagesFunction<Env> = (context) => {
+  const env = context.env;
+  return new Response(
+    JSON.stringify({
+      providers: {
+        google: Boolean(env.GOOGLE_CLIENT_ID),
+      },
+      features: {
+        passwordSignup: true,
+        emailVerification: Boolean(env.RESEND_API_KEY && env.EMAIL_FROM),
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        // Short cache; values change only on env update which redeploys.
+        'cache-control': 'public, max-age=60',
+      },
+    },
+  );
+};

--- a/src/pages/EmailVerifyPendingPage.tsx
+++ b/src/pages/EmailVerifyPendingPage.tsx
@@ -19,7 +19,7 @@ const SCOPED_STYLES = `
   display: flex; align-items: center; justify-content: center;
   min-height: 100dvh; padding: 48px 24px;
   background:
-    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
 .tp-verify-card {

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -16,7 +16,7 @@ const SCOPED_STYLES = `
   display: flex; align-items: center; justify-content: center;
   min-height: 100dvh; padding: 48px 24px;
   background:
-    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
 .tp-auth-card {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -19,8 +19,8 @@ const SCOPED_STYLES = `
   display: flex; align-items: center; justify-content: center;
   min-height: 100dvh; padding: 48px 24px;
   background:
-    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
-    radial-gradient(circle at 80% 100%, rgba(0, 119, 182, 0.04), transparent 50%),
+    radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
+    radial-gradient(circle at 80% 100%, rgba(217, 120, 72, 0.04), transparent 50%),
     var(--color-secondary);
 }
 .tp-login-card {
@@ -179,6 +179,10 @@ export default function LoginPage() {
   const [bannerError, setBannerError] = useState<string | null>(null);
   const [lockedRetryAfter, setLockedRetryAfter] = useState<number | null>(null);
   const [failureCount, setFailureCount] = useState(0);
+  // Whether the deployment has Google OIDC env configured. We optimistically
+  // assume "no" so the button doesn't flash on slow networks; the probe flips
+  // it on if /api/public-config confirms.
+  const [googleAvailable, setGoogleAvailable] = useState(false);
 
   // Read failure count from sessionStorage to show defensive UX warning
   useEffect(() => {
@@ -188,6 +192,22 @@ export default function LoginPage() {
     } catch {
       /* ignore */
     }
+  }, []);
+
+  // Probe public-config to know which providers are enabled. Side-effect-free.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/public-config')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (cancelled || !cfg) return;
+        const providers = (cfg as { providers?: { google?: boolean } }).providers;
+        if (providers?.google) setGoogleAvailable(true);
+      })
+      .catch(() => {
+        // Network error — leave Google hidden. Email/password still works.
+      });
+    return () => { cancelled = true; };
   }, []);
 
   function bumpFailure() {
@@ -396,24 +416,27 @@ export default function LoginPage() {
           </button>
         </form>
 
-        <div className="tp-divider">或</div>
-
-        <a
-          className="tp-btn tp-btn-secondary"
-          href={`/api/oauth/login/google${redirectAfter ? `?redirect_after_login=${encodeURIComponent(redirectAfter)}` : ''}`}
-          data-testid="login-google"
-        >
-          <GoogleLogo />
-          <span>使用 Google 登入</span>
-        </a>
-
-        <a className="tp-cf-fallback" href="/manage" data-testid="login-cf-access">
-          Cloudflare Access 登入（過渡期）
-        </a>
+        {googleAvailable && (
+          <>
+            <div className="tp-divider">或</div>
+            <a
+              className="tp-btn tp-btn-secondary"
+              href={`/api/oauth/login/google${redirectAfter ? `?redirect_after_login=${encodeURIComponent(redirectAfter)}` : ''}`}
+              data-testid="login-google"
+            >
+              <GoogleLogo />
+              <span>使用 Google 登入</span>
+            </a>
+          </>
+        )}
 
         <div className="tp-login-footer">
           沒有帳號？<a href="/signup" data-testid="login-signup-link">建立帳號</a>
         </div>
+
+        <a className="tp-cf-fallback" href="/manage" data-testid="login-cf-access">
+          Cloudflare Access 登入（過渡期）
+        </a>
       </div>
     </main>
   );

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -20,7 +20,7 @@ const SCOPED_STYLES = `
   display: flex; align-items: center; justify-content: center;
   min-height: 100dvh; padding: 48px 24px;
   background:
-    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
+    radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
 .tp-auth-card {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -20,8 +20,8 @@ const SCOPED_STYLES = `
   display: flex; align-items: center; justify-content: center;
   min-height: 100dvh; padding: 48px 24px;
   background:
-    radial-gradient(circle at 20% 0%, rgba(0, 119, 182, 0.06), transparent 50%),
-    radial-gradient(circle at 80% 100%, rgba(0, 119, 182, 0.04), transparent 50%),
+    radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
+    radial-gradient(circle at 80% 100%, rgba(217, 120, 72, 0.04), transparent 50%),
     var(--color-secondary);
 }
 .tp-auth-card {

--- a/tests/unit/login-page.test.tsx
+++ b/tests/unit/login-page.test.tsx
@@ -38,14 +38,24 @@ afterEach(() => {
 });
 
 describe('LoginPage form', () => {
-  it('renders email + password + submit + Google + signup link', () => {
+  it('renders email + password + submit + signup link (Google hidden until probe confirms)', () => {
     renderAt();
     expect(screen.getByTestId('login-email')).toBeTruthy();
     expect(screen.getByTestId('login-password')).toBeTruthy();
     expect(screen.getByTestId('login-submit')).toBeTruthy();
-    expect(screen.getByTestId('login-google')).toBeTruthy();
     expect(screen.getByTestId('login-signup-link')).toBeTruthy();
     expect(screen.getByTestId('login-forgot-link')).toBeTruthy();
+    // Google button is gated on /api/public-config probe (not stubbed here, so absent)
+    expect(screen.queryByTestId('login-google')).toBeNull();
+  });
+
+  it('shows Google button when /api/public-config reports it enabled', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ providers: { google: true } }), { status: 200 }),
+    ));
+    vi.useRealTimers();
+    renderAt();
+    await waitFor(() => expect(screen.queryByTestId('login-google')).not.toBeNull());
   });
 
   it('successful login → navigate /manage by default', async () => {

--- a/tests/unit/placeholder-pages.test.tsx
+++ b/tests/unit/placeholder-pages.test.tsx
@@ -35,17 +35,18 @@ describe('GlobalMapPage placeholder（/map 全域，非 per-trip）', () => {
   });
 });
 
-describe('LoginPage (V2-P1 Google sign-in + CF Access 過渡期 fallback)', () => {
-  it('render 「登入您的帳號」heading + Google login button + CF Access fallback', () => {
-    const { getByTestId, getByRole } = renderWithRouter(<LoginPage />);
+describe('LoginPage (V2 password-first + optional Google + CF Access transitional fallback)', () => {
+  it('render 「登入」heading + signup link + CF Access fallback (Google gated on /api/public-config probe)', () => {
+    const { getByTestId, queryByTestId, getByRole } = renderWithRouter(<LoginPage />);
     expect(getByTestId('login-page')).toBeTruthy();
     const heading = getByRole('heading', { level: 1 }).textContent ?? '';
     expect(heading).toContain('登入');
-    // Google login button
-    const google = getByTestId('login-google') as HTMLAnchorElement;
-    expect(google.getAttribute('href')).toBe('/api/oauth/login/google');
-    expect(google.textContent).toContain('Google');
-    // CF Access fallback
+    // Self-signup link (primary V2 path per "先開放自建帳號")
+    const signup = getByTestId('login-signup-link') as HTMLAnchorElement;
+    expect(signup.getAttribute('href')).toBe('/signup');
+    // Google login button is hidden until the public-config probe confirms env
+    expect(queryByTestId('login-google')).toBeNull();
+    // CF Access fallback still present (transitional)
     const cf = getByTestId('login-cf-access') as HTMLAnchorElement;
     expect(cf.getAttribute('href')).toBe('/manage');
     expect(cf.textContent).toContain('Cloudflare Access');


### PR DESCRIPTION
## Summary

V2 Terracotta pivot 留下兩個小尾巴 + 全 V2 page 還沒做正式 mockup 比對。這 PR 修齊。

- **`/api/public-config` endpoint** — side-effect-free probe,告訴 client 哪些 provider 開了
- **`LoginPage` Google graceful** — 沒設 `GOOGLE_CLIENT_ID` env 時 Google button 不會渲染(probe 確認後才顯示)
- **「沒有帳號?建立帳號」link 提上去** — 在 CF Access 過渡 link 之上,符合 user 「先開放自建帳號」方向
- **5 個 auth page radial-gradient bg 換 terracotta rgba** — 之前 V2 token migration 沒抓到 SCOPED_STYLES 裡的硬碼 ocean blue
- **`docs/v2-design-audit-2026-04-25.md`** — 全 V2 page (login/signup/forgot/reset/check-email/consent/sessions/connected-apps/developer-apps/trip/explore) × desktop + mobile × mockup 對照,標 ✅ / 🟡 / 🔴 / ⏭ + P1-P3 follow-up table

## Audit headline 發現

| 項目 | 狀態 |
|------|------|
| Color & Theme | ✅ A — terracotta tokens 一致 |
| AI Slop | ✅ A — 沒有任何 generic SaaS pattern |
| Auth page 結構 | 🟡 mockup 是 AppShell-wrapped + 右 hero,prod 是 standalone card → P1 follow-up |
| `/trips` landing page | 🔴 mockup 有 trip card grid + 右 pane detail,prod 直接進 trip detail → P2 follow-up |
| Settings / Developer page | 🟡 沒包 AppShell → P2 follow-up |
| Explore POI card grid | 🔴 mockup 有 6 色 category palette,prod 是空 search bar → P3 follow-up |

整體 design score: **B+** (V2 sprint 開始前是 D)。

## Test plan

- [x] `npm test --run` — 969/969 pass
- [x] `npm run test:api` — 510/510 pass
- [x] `npx tsc --noEmit` + `tsconfig.functions.json` — clean
- [ ] CI green
- [ ] Prod canary: `/api/public-config` 回 `{providers: {google: false}}` (env 還沒設)
- [ ] Prod canary: login page 不再顯示 Google button

🤖 Generated with [Claude Code](https://claude.com/claude-code)