### PR TITLE
fix(middleware): CSRF bypass /api/oauth/* + Bearer-token requests

### DIFF
--- a/functions/api/_middleware.ts
+++ b/functions/api/_middleware.ts
@@ -156,15 +156,26 @@ export function isAllowedOrigin(origin: string, env: Env): boolean {
  * CSRF protection for mutating requests.
  *
  * Validates the Origin header for POST/PUT/PATCH/DELETE requests.
- * Requests without an Origin header are only permitted when they carry a
- * CF-Access-Client-Id header (i.e. service-token CLI calls that don't set
- * Origin).
+ *
+ * Bypasses (these endpoints carry their own auth, not session-cookie-based):
+ *   - `/api/oauth/*` — OAuth wire endpoints authenticate via client_secret /
+ *     PKCE / Bearer token. Origin is irrelevant; spec-compliant clients
+ *     (curl, server-to-server) won't send it.
+ *   - `Authorization: Bearer` header present — V2 service token (client_credentials
+ *     grant). Bearer-auth requests come from CLI / cron, not browsers.
+ *   - `CF-Access-Client-Id` + `CF-Access-Client-Secret` — legacy service token.
  */
 /** @internal — exported for unit testing */
-export function checkCsrf(request: Request, env: Env): Response | null {
+export function checkCsrf(request: Request, env: Env, url: URL): Response | null {
   const method = request.method.toUpperCase();
   const mutating = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
   if (!mutating) return null;
+
+  // OAuth wire endpoints handle their own auth — skip session-cookie CSRF.
+  if (url.pathname.startsWith('/api/oauth/')) return null;
+
+  // V2 Bearer token = service-to-service, not browser. No Origin needed.
+  if (request.headers.get('Authorization')?.startsWith('Bearer ')) return null;
 
   const origin = request.headers.get('Origin');
   if (!origin) {
@@ -229,7 +240,7 @@ async function handleAuth(
   }
 
   // CSRF protection for all mutating requests
-  const csrfError = checkCsrf(request, env);
+  const csrfError = checkCsrf(request, env, url);
   if (csrfError) return csrfError;
 
   // Companion scope restriction — tp-request scheduler sends this header

--- a/tests/api/middleware-oauth-bypass.test.ts
+++ b/tests/api/middleware-oauth-bypass.test.ts
@@ -22,11 +22,17 @@ describe('_middleware.ts — OAuth bypass (V2-P1)', () => {
   });
 
   it('bypass 設 auth = null 並 context.next()', () => {
-    // 抓 OAuth pattern 後 5 行 window 找 auth = null + context.next()
+    // V2-P6 cutover 後檔案有兩個 /api/oauth/ 比對:CSRF bypass 跟 handleAuth
+    // bypass。lastIndexOf 抓 handleAuth 那個(它後面才有 auth = null + next())。
     const lines = MIDDLEWARE_SRC.split('\n');
-    const oauthLineIdx = lines.findIndex((l) => l.includes("'/api/oauth/'") || l.includes('"/api/oauth/"'));
-    expect(oauthLineIdx).toBeGreaterThan(0);
-    const window = lines.slice(oauthLineIdx, oauthLineIdx + 5).join('\n');
+    let lastOauthBypass = -1;
+    lines.forEach((l, i) => {
+      if (l.includes("startsWith('/api/oauth/')") || l.includes('startsWith("/api/oauth/")')) {
+        lastOauthBypass = i;
+      }
+    });
+    expect(lastOauthBypass).toBeGreaterThan(0);
+    const window = lines.slice(lastOauthBypass, lastOauthBypass + 5).join('\n');
     expect(window).toMatch(/auth\s*=\s*null/);
     expect(window).toMatch(/context\.next\(\)/);
   });

--- a/tests/api/middleware.test.ts
+++ b/tests/api/middleware.test.ts
@@ -45,7 +45,7 @@ describe('isAllowedOrigin', () => {
 describe('checkCsrf', () => {
   it('GET 請求直接放行', () => {
     const req = new Request('https://test.com/api/trips', { method: 'GET' });
-    expect(checkCsrf(req, baseEnv)).toBeNull();
+    expect(checkCsrf(req, baseEnv, new URL(req.url))).toBeNull();
   });
 
   it('POST 有合法 Origin → 放行', () => {
@@ -53,12 +53,12 @@ describe('checkCsrf', () => {
       method: 'POST',
       headers: { Origin: 'https://trip-planner-dby.pages.dev' },
     });
-    expect(checkCsrf(req, baseEnv)).toBeNull();
+    expect(checkCsrf(req, baseEnv, new URL(req.url))).toBeNull();
   });
 
   it('POST 無 Origin 無 Service Token → 403', () => {
     const req = new Request('https://test.com/api/trips', { method: 'POST' });
-    const resp = checkCsrf(req, baseEnv);
+    const resp = checkCsrf(req, baseEnv, new URL(req.url));
     expect(resp).not.toBeNull();
     expect(resp!.status).toBe(403);
   });
@@ -71,7 +71,7 @@ describe('checkCsrf', () => {
         'CF-Access-Client-Secret': 'some-secret',
       },
     });
-    expect(checkCsrf(req, baseEnv)).toBeNull();
+    expect(checkCsrf(req, baseEnv, new URL(req.url))).toBeNull();
   });
 
   it('POST 非法 Origin → 403', () => {
@@ -79,7 +79,7 @@ describe('checkCsrf', () => {
       method: 'POST',
       headers: { Origin: 'https://evil.com' },
     });
-    const resp = checkCsrf(req, baseEnv);
+    const resp = checkCsrf(req, baseEnv, new URL(req.url));
     expect(resp!.status).toBe(403);
   });
 
@@ -88,7 +88,7 @@ describe('checkCsrf', () => {
       method: 'DELETE',
       headers: { Origin: 'http://localhost:5173' },
     });
-    expect(checkCsrf(req, baseEnv)).toBeNull();
+    expect(checkCsrf(req, baseEnv, new URL(req.url))).toBeNull();
   });
 });
 


### PR DESCRIPTION
PR #311 wired client_credentials grant, but CSRF middleware blocks POST /api/oauth/token without Origin header — CLI 用 curl 沒 Origin → 403。Token endpoint 自己驗 client_secret,不需要 Origin。

- `checkCsrf` 在 path startsWith `/api/oauth/` 時 skip
- `checkCsrf` 看到 `Authorization: Bearer` header 時 skip(service-to-service,不是 browser)
- signature 改 `checkCsrf(request, env, url)` — path check 不用 re-parse

514 API tests pass。沒這個 CLI 完全 fetch 不到 token。