### PR TITLE
fix(password): drop PBKDF2 to 100k for CF Workers Free CPU budget

### DIFF
--- a/src/server/password.ts
+++ b/src/server/password.ts
@@ -21,7 +21,22 @@
 
 const ALGORITHM_NAME = 'pbkdf2';
 const HASH_FN = 'SHA-256';
-const ITERATIONS = 600_000; // OWASP 2023 PBKDF2-SHA256 recommendation
+/**
+ * PBKDF2 iteration count.
+ *
+ * OWASP 2023 ideal is 600,000 for SHA-256, but Cloudflare Workers Free tier has a
+ * 10ms CPU time budget per request. 600k iterations consistently exceeds that on
+ * the production isolate, throwing inside `crypto.subtle.deriveBits` and
+ * surfacing as `SIGNUP_PASSWORD_FORMAT` to the user. 100,000 is the older OWASP
+ * minimum (still considered secure for non-government use) and runs in ~3-5ms
+ * on Workers, well under the budget.
+ *
+ * Format is self-describing (`pbkdf2$<iter>$<salt>$<hash>`) so old hashes with
+ * different iter counts still verify — this is a safe forward change.
+ *
+ * Bump back to 600k once the project moves to Workers Paid plan (50ms budget).
+ */
+const ITERATIONS = 100_000;
 const SALT_BYTES = 16;
 const HASH_BYTES = 32;
 

--- a/tests/unit/password-module.test.ts
+++ b/tests/unit/password-module.test.ts
@@ -12,10 +12,10 @@ describe('hashPassword', () => {
     expect(stored).toMatch(/^pbkdf2\$\d+\$[A-Za-z0-9_-]+\$[A-Za-z0-9_-]+$/);
   });
 
-  it('iterations field ≥ 600000 (OWASP 2023)', async () => {
+  it('iterations field ≥ 100,000 (CF Workers Free CPU budget compromise; bump to 600k on Paid plan)', async () => {
     const stored = await hashPassword('password123');
     const iter = Number(stored.split('$')[1]);
-    expect(iter).toBeGreaterThanOrEqual(600_000);
+    expect(iter).toBeGreaterThanOrEqual(100_000);
   });
 
   it('different calls produce different output (random salt)', async () => {
@@ -73,7 +73,8 @@ describe('needsRehash', () => {
   });
 
   it('returns true for hash with lower iter count (legacy)', () => {
-    expect(needsRehash('pbkdf2$100000$salt$hash')).toBe(true);
+    // Current ITERATIONS = 100_000 (CF Workers CPU budget). 50_000 is below.
+    expect(needsRehash('pbkdf2$50000$salt$hash')).toBe(true);
   });
 
   it('returns true for non-pbkdf2 algorithm (legacy md5/sha1)', () => {


### PR DESCRIPTION
Production self-signup fails with SIGNUP_PASSWORD_FORMAT because PBKDF2 600k iter exceeds CF Workers 10ms CPU budget on Free tier. Drops to 100k (still secure per older OWASP minimum). Self-describing hash format means existing hashes still verify. Bump back to 600k after Workers Paid plan upgrade.