### PR TITLE
chore: bump signup rate limit 3→10/hr/IP

### DIFF
--- a/functions/api/_rate_limit.ts
+++ b/functions/api/_rate_limit.ts
@@ -144,8 +144,9 @@ export function clientIp(request: Request): string {
 export const RATE_LIMITS = {
   // Anti brute-force login: 5 attempts / 15min window, 30min lockout
   LOGIN: { maxAttempts: 5, windowMs: 15 * 60 * 1000, lockoutMs: 30 * 60 * 1000 },
-  // Signup spam protection: 3 attempts / 1h window, 1h lockout
-  SIGNUP: { maxAttempts: 3, windowMs: 60 * 60 * 1000, lockoutMs: 60 * 60 * 1000 },
+  // Signup spam protection: 10 attempts / 1h window, 1h lockout.
+  // (Was 3/h per autoplan; bumped — too tight for dev self-testing + shared NAT IP)
+  SIGNUP: { maxAttempts: 10, windowMs: 60 * 60 * 1000, lockoutMs: 60 * 60 * 1000 },
   // Password reset abuse: 3 attempts / 1h window, 1h lockout
   FORGOT_PASSWORD: { maxAttempts: 3, windowMs: 60 * 60 * 1000, lockoutMs: 60 * 60 * 1000 },
   // OAuth token endpoint per-client: 100 attempts / minute, 5min lockout

--- a/tests/api/rate-limit-module.test.ts
+++ b/tests/api/rate-limit-module.test.ts
@@ -173,8 +173,8 @@ describe('RATE_LIMITS presets', () => {
     expect(RATE_LIMITS.LOGIN.lockoutMs).toBe(30 * 60 * 1000);
   });
 
-  it('SIGNUP: more conservative (3 attempts / 1h)', () => {
-    expect(RATE_LIMITS.SIGNUP.maxAttempts).toBe(3);
+  it('SIGNUP: 10 attempts / 1h (bumped from autoplan original 3 — too tight for dev + NAT)', () => {
+    expect(RATE_LIMITS.SIGNUP.maxAttempts).toBe(10);
   });
 
   it('OAUTH_TOKEN: high frequency (100 / min) for active client', () => {


### PR DESCRIPTION
Original 3/h was too tight for dev self-testing + shared NAT. 10/h still blocks spam but unblocks legitimate use.