### PR TITLE
fix(cli): token helper auto-loads .env.local + provision iter matches prod (100k)

### DIFF
--- a/scripts/lib/get-tripline-token.js
+++ b/scripts/lib/get-tripline-token.js
@@ -31,6 +31,20 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+// Auto-load .env.local so scripts invoked from launchd (which doesn't auto-source
+// the user's shell rc) can find TRIPLINE_API_CLIENT_ID / SECRET. Shell-invoked
+// callers that already exported these env vars take precedence (we never overwrite).
+try {
+  const envPath = path.join(__dirname, '..', '..', '.env.local');
+  const content = fs.readFileSync(envPath, 'utf8');
+  content.split('\n').forEach((line) => {
+    const m = line.match(/^(\w+)=(.+)/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].trim();
+  });
+} catch {
+  /* no .env.local — caller must export env vars manually */
+}
+
 const DEFAULT_BASE = 'https://trip-planner-dby.pages.dev';
 const REFRESH_LEADTIME_SEC = 60; // refresh 1min before actual expiry to avoid edge races
 

--- a/scripts/provision-admin-cli-client.js
+++ b/scripts/provision-admin-cli-client.js
@@ -98,10 +98,18 @@ function generateClientSecret() {
   return `tps_${result}`;
 }
 
-/** PBKDF2-SHA256 600k iter — matches src/server/password.ts hashPassword format */
+/**
+ * PBKDF2-SHA256 — matches src/server/password.ts ITERATIONS (currently 100,000;
+ * sized for CF Workers Free 10ms CPU budget — see password.ts comment for the
+ * "bump back to 600k after Workers Paid plan" upgrade path).
+ *
+ * MUST stay in sync with `ITERATIONS` in src/server/password.ts. If they
+ * diverge, verifyPassword on prod will read iter from the stored hash and
+ * run that many iterations — exceeding CPU budget when iter > current ceiling.
+ */
 async function hashPassword(plain) {
   const salt = crypto.randomBytes(16);
-  const iter = 600_000;
+  const iter = 100_000;
   const hash = crypto.pbkdf2Sync(plain, salt, iter, 32, 'sha256');
   const b64u = (buf) =>
     buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');


### PR DESCRIPTION
Two issues found during the live cutover:
1. `get-tripline-token.js` couldn't find creds when run from launchd (no shell rc) → auto-load `.env.local` on import.
2. `provision-admin-cli-client.js` hashed secret with 600k iter but prod runs 100k → verifyPassword exceeded CF Workers CPU budget → 500.

Real-world canary: token fetch ~250ms, Bearer auth 200, scheduler launchd reload clean, CF Access apps both deleted.