### PR TITLE
refactor(auth): strip CF Access dead code + add SPA /login redirect

### DIFF
--- a/functions/api/_middleware.ts
+++ b/functions/api/_middleware.ts
@@ -56,19 +56,6 @@ export function detectSource(
   return 'anonymous';
 }
 
-/** Decodes a JWT payload without signature verification. Cloudflare Access validates the JWT at the edge. */
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-    const payload = parts[1]!.replace(/-/g, '+').replace(/_/g, '/');
-    const decoded = atob(payload);
-    return JSON.parse(decoded) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
 export const onRequest: PagesFunction<Env> = async (context) => {
   const start = Date.now();
   const { request, env } = context;
@@ -368,94 +355,15 @@ async function handleAuth(
     }
   }
 
-  // 公開讀取：GET /api/trips/** 不需認證
+  // 公開讀取：GET /api/trips/** 不需認證 — anonymous 直接 next() 不附 auth。
+  // V2 logged-in users were already auth-decorated by the V2 session block
+  // above, so they reach this branch only when V2 fell through (anonymous).
   if (request.method === 'GET' && url.pathname.startsWith('/api/trips')) {
-    // Service Token（CLI / scheduler）→ admin
-    // Security assumption: Cloudflare Access validates CF-Access-Client-Id and
-    // CF-Access-Client-Secret at the edge. We require both headers as
-    // defense-in-depth so that a leaked Client-Id alone is not sufficient.
-    const stClientId = request.headers.get('CF-Access-Client-Id');
-    const stClientSecret = request.headers.get('CF-Access-Client-Secret');
-    if (stClientId && stClientSecret) {
-      (context.data as Record<string, unknown>).auth = {
-        email: env.ADMIN_EMAIL,
-        isAdmin: true,
-        isServiceToken: true,
-      };
-      return context.next();
-    }
-    // 嘗試解析 JWT auth（給 admin 功能用，如 ?all=1），但不強制
-    const token = getCookie(request, 'CF_Authorization');
-    if (token) {
-      const payload = decodeJwtPayload(token);
-      if (payload?.email) {
-        const email = String(payload.email).toLowerCase();
-        (context.data as Record<string, unknown>).auth = {
-          email,
-          isAdmin: env.ADMIN_EMAIL
-            ? email === env.ADMIN_EMAIL.toLowerCase()
-            : false,
-          isServiceToken: false,
-        };
-      } else if (payload?.common_name) {
-        (context.data as Record<string, unknown>).auth = {
-          email: env.ADMIN_EMAIL,
-          isAdmin: true,
-          isServiceToken: true,
-        };
-      }
-    }
     return context.next();
   }
 
-  // Service Token 辨識（header 未被 Access 消化時）
-  // Security assumption: Cloudflare Access validates both headers at the edge.
-  // We require both CF-Access-Client-Id AND CF-Access-Client-Secret as
-  // defense-in-depth so a leaked Client-Id alone does not grant admin access.
-  const clientId = request.headers.get('CF-Access-Client-Id');
-  const clientSecret = request.headers.get('CF-Access-Client-Secret');
-  if (clientId && clientSecret) {
-    (context.data as Record<string, unknown>).auth = {
-      email: env.ADMIN_EMAIL,
-      isAdmin: true,
-      isServiceToken: true,
-    };
-    return context.next();
-  }
-
-  // JWT 認證（Cloudflare Access 設定的 cookie）
-  const token = getCookie(request, 'CF_Authorization');
-  if (!token) {
-    return errorResponse(new AppError('AUTH_REQUIRED'));
-  }
-
-  const payload = decodeJwtPayload(token);
-  if (!payload) {
-    return errorResponse(new AppError('AUTH_INVALID'));
-  }
-
-  // Service Token JWT：Access 消化 header 後發 JWT，有 common_name 但無 email
-  if (!payload.email && payload.common_name) {
-    (context.data as Record<string, unknown>).auth = {
-      email: env.ADMIN_EMAIL,
-      isAdmin: true,
-      isServiceToken: true,
-    };
-    return context.next();
-  }
-
-  if (!payload.email) {
-    return errorResponse(new AppError('AUTH_INVALID'));
-  }
-
-  const email = String(payload.email).toLowerCase();
-  const isAdmin = email === env.ADMIN_EMAIL.toLowerCase();
-
-  (context.data as Record<string, unknown>).auth = {
-    email,
-    isAdmin,
-    isServiceToken: false,
-  };
-
-  return context.next();
+  // 進到這裡代表既無 V2 session 也無 V2 Bearer,且 path 不是 public-read。
+  // Cloudflare Access 已拆,不再有 CF_Authorization cookie 或 CF-Access-Client-* header,
+  // 直接拒絕。
+  return errorResponse(new AppError('AUTH_REQUIRED'));
 }

--- a/src/hooks/useRequireAuth.ts
+++ b/src/hooks/useRequireAuth.ts
@@ -1,0 +1,39 @@
+/**
+ * useRequireAuth — page-level auth guard for V2 self-served pages.
+ *
+ * Pre-V2 / pre-cutover: Cloudflare Access redirected unauthenticated users at
+ * the edge before any SPA code ran. With CF Access removed, anonymous users can
+ * land directly on /manage / /admin / settings pages — the SPA must redirect
+ * them itself.
+ *
+ * Usage in a protected page:
+ *
+ *   export default function ManagePage() {
+ *     useRequireAuth(); // redirects to /login?redirect_after=/manage if no session
+ *     ...
+ *   }
+ *
+ * The redirect preserves the intended destination via `?redirect_after=` so
+ * `LoginPage` can navigate back after successful login.
+ *
+ * Returns the same shape as useCurrentUser for convenience — the protected
+ * page can read `user` directly without a second hook call.
+ */
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useCurrentUser, type UseCurrentUserResult } from './useCurrentUser';
+
+export function useRequireAuth(): UseCurrentUserResult {
+  const result = useCurrentUser();
+  const navigate = useNavigate();
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    // Wait for the userinfo probe to settle (undefined = still loading)
+    if (result.user !== null) return;
+    const redirectAfter = `${pathname}${search}`;
+    navigate(`/login?redirect_after=${encodeURIComponent(redirectAfter)}`, { replace: true });
+  }, [result.user, pathname, search, navigate]);
+
+  return result;
+}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -5,13 +5,14 @@ import { useDarkMode } from '../hooks/useDarkMode';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
 import { useOfflineToast } from '../hooks/useOfflineToast';
 import { usePermissions } from '../hooks/usePermissions';
+import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useTripSelector } from '../hooks/useTripSelector';
 import { lsGet, lsSet, LS_KEY_TRIP_PREF } from '../lib/localStorage';
 import { apiFetchRaw } from '../lib/apiClient';
 import PageNav from '../components/shared/PageNav';
 import ToastContainer, { showToast } from '../components/shared/Toast';
 
-/* Cloudflare Access 在 infrastructure 層處理認證，不需要 JS redirect */
+/* V2 OAuth 取代 CF Access — useRequireAuth 在頁面 mount 時 redirect 未登入 user 到 /login */
 
 /* ===== Chevron SVG as background-image for the select ===== */
 const SELECT_STYLE = { backgroundImage:
@@ -19,6 +20,7 @@ const SELECT_STYLE = { backgroundImage:
   backgroundPosition: 'right 16px center' } as const;
 
 export default function AdminPage() {
+  useRequireAuth(); // V2 sole-auth: redirect to /login if no tripline_session
   useDarkMode();
   const isOnline = useOnlineStatus();
 

--- a/src/pages/ConnectedAppsPage.tsx
+++ b/src/pages/ConnectedAppsPage.tsx
@@ -9,6 +9,7 @@
  * 安全 UX：撤銷必須二次確認（modal）— 破壞性操作。
  */
 import { useEffect, useState } from 'react';
+import { useRequireAuth } from '../hooks/useRequireAuth';
 
 const SCOPED_STYLES = `
 .tp-settings-shell {
@@ -203,6 +204,7 @@ function relativeTime(ms: number): string {
 }
 
 export default function ConnectedAppsPage() {
+  useRequireAuth(); // V2 sole-auth: redirect to /login if no tripline_session
   const [apps, setApps] = useState<ConnectedApp[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);

--- a/src/pages/DeveloperAppsPage.tsx
+++ b/src/pages/DeveloperAppsPage.tsx
@@ -17,6 +17,7 @@
  *   - redirect_uris textarea: HTTPS-only validation 由後端做
  */
 import { useEffect, useState } from 'react';
+import { useRequireAuth } from '../hooks/useRequireAuth';
 
 const SCOPED_STYLES = `
 .tp-dev-shell {
@@ -289,6 +290,7 @@ function statusPill(status: string): { className: string; label: string } {
 }
 
 export default function DeveloperAppsPage() {
+  useRequireAuth(); // V2 sole-auth: redirect to /login if no tripline_session
   const [apps, setApps] = useState<ClientApp[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/pages/ManagePage.tsx
+++ b/src/pages/ManagePage.tsx
@@ -4,6 +4,7 @@ import ToastContainer, { showToast } from '../components/shared/Toast';
 import Icon from '../components/shared/Icon';
 import { apiFetchRaw } from '../lib/apiClient';
 import { useDarkMode } from '../hooks/useDarkMode';
+import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
 import { useOfflineToast } from '../hooks/useOfflineToast';
 import { useRequests, RawRequest } from '../hooks/useRequests';
@@ -319,6 +320,7 @@ type PageState =
   | { kind: 'ready' };
 
 export default function ManagePage() {
+  useRequireAuth(); // V2 sole-auth: redirect to /login if no tripline_session
   useDarkMode();
   const isOnline = useOnlineStatus();
 

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -12,6 +12,7 @@
  *   - 異地裝置警示（不同 ip_hash_prefix → 警示樣式）— optional V2-P6 future
  */
 import { useEffect, useState } from 'react';
+import { useRequireAuth } from '../hooks/useRequireAuth';
 
 const SCOPED_STYLES = `
 .tp-sessions-shell {
@@ -153,6 +154,7 @@ function relativeTime(iso: string): string {
 }
 
 export default function SessionsPage() {
+  useRequireAuth(); // V2 sole-auth: redirect to /login if no tripline_session
   const [sessions, setSessions] = useState<SessionRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [revokingSid, setRevokingSid] = useState<string | null>(null);

--- a/tests/unit/admin-page.test.tsx
+++ b/tests/unit/admin-page.test.tsx
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import AdminPage from '../../src/pages/AdminPage';
 
 vi.mock('../../src/hooks/useDarkMode', () => ({ useDarkMode: () => {} }));
 vi.mock('../../src/hooks/useOnlineStatus', () => ({ useOnlineStatus: () => true, reportFetchResult: () => {} }));
 vi.mock('../../src/hooks/useOfflineToast', () => ({
   useOfflineToast: () => ({ showOffline: false, showReconnect: false }),
 }));
+// Bypass V2 auth gate — page is rendered as if user is logged in
+vi.mock('../../src/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({ user: { id: 'u1', email: 'admin@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
+}));
+
+import AdminPage from '../../src/pages/AdminPage';
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/tests/unit/connected-apps-page.test.tsx
+++ b/tests/unit/connected-apps-page.test.tsx
@@ -4,6 +4,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
+// Bypass V2 auth gate — page is rendered as if user is logged in
+vi.mock('../../src/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
+}));
+
 import ConnectedAppsPage from '../../src/pages/ConnectedAppsPage';
 
 const SAMPLE_APPS = [

--- a/tests/unit/developer-apps-page.test.tsx
+++ b/tests/unit/developer-apps-page.test.tsx
@@ -4,6 +4,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
+// Bypass V2 auth gate — page is rendered as if user is logged in
+vi.mock('../../src/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
+}));
+
 import DeveloperAppsPage from '../../src/pages/DeveloperAppsPage';
 
 const SAMPLE_APP = {


### PR DESCRIPTION
CF Access was deleted this morning. middleware 殘留 CF JWT 解析跟 service token 區塊全部變 dead code,清掉。同時加 `useRequireAuth` hook 讓未登入瀏覽器在 SPA 端被 redirect 到 /login(沒有它 user 看到 broken /manage)。

5 個 protected page 套用:ManagePage, AdminPage, ConnectedAppsPage, SessionsPage, DeveloperAppsPage。

969 unit + 514 API tests pass.