### PR TITLE
feat(v2-design): brand hero pane on Signup/Forgot/Reset/VerifyPending

### DIFF
--- a/src/components/auth/AuthBrandHero.tsx
+++ b/src/components/auth/AuthBrandHero.tsx
@@ -1,0 +1,177 @@
+/**
+ * AuthBrandHero — desktop right-pane brand hero for auth pages
+ *
+ * Shows on ≥1024px only (display:none below). Mirrors mockup-{login|signup|
+ * forgot}-v2.html aside-* pattern. Used by SignupPage / ForgotPasswordPage /
+ * ResetPasswordPage / EmailVerifyPendingPage. (LoginPage uses an inline copy
+ * of this pattern — folded into shared component in a future cleanup PR.)
+ *
+ * Layout responsibility split:
+ *   - This component: brand hero <aside> + its scoped styles
+ *   - Caller page: shell-level grid (1fr/1fr ≥1024px) and form-side wrapper.
+ *     See `AUTH_LAYOUT_STYLES` for the snippet pages embed in their SCOPED_STYLES.
+ */
+import type { ReactNode } from 'react';
+
+/**
+ * Styles a page must include in its SCOPED_STYLES so the brand hero sits
+ * correctly next to the form card. Pages already define `.tp-{ns}-shell` and
+ * a `tp-{ns}-form-side` wrapper — `ns` is `auth` or `verify` depending on the
+ * page's existing class prefix.
+ */
+export const AUTH_LAYOUT_STYLES = `
+.tp-auth-form-side, .tp-verify-form-side {
+  width: 100%;
+  display: flex; align-items: center; justify-content: center;
+}
+@media (min-width: 1024px) {
+  .tp-auth-shell, .tp-verify-shell {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: stretch;
+    padding: 0;
+  }
+  .tp-auth-form-side, .tp-verify-form-side {
+    padding: 48px;
+  }
+}
+`;
+
+const HERO_STYLES = `
+.tp-auth-brand-hero {
+  display: none;
+  background: linear-gradient(135deg, var(--color-foreground) 0%, var(--color-accent-deep, #B85C2E) 100%);
+  color: var(--color-background);
+  padding: 56px 48px;
+  position: relative;
+  overflow: hidden;
+  flex-direction: column;
+  justify-content: space-between;
+}
+@media (min-width: 1024px) {
+  .tp-auth-brand-hero { display: flex; }
+}
+.tp-auth-brand-hero::before {
+  content: '';
+  position: absolute;
+  top: -100px; right: -100px;
+  width: 400px; height: 400px;
+  border-radius: 50%;
+  background: rgba(247, 223, 203, 0.1);
+  pointer-events: none;
+}
+.tp-auth-brand-hero::after {
+  content: '';
+  position: absolute;
+  bottom: -80px; left: -80px;
+  width: 300px; height: 300px;
+  border-radius: 50%;
+  background: rgba(217, 120, 72, 0.18);
+  pointer-events: none;
+}
+.tp-bs-eyebrow {
+  font-size: var(--font-size-eyebrow);
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  position: relative; z-index: 2;
+}
+.tp-bs-display {
+  font-size: 38px; font-weight: 900;
+  letter-spacing: -0.03em; line-height: 1.1;
+  margin: 16px 0 24px;
+  position: relative; z-index: 2;
+  max-width: 400px;
+}
+.tp-bs-sub {
+  font-size: 15px; line-height: 1.6;
+  opacity: 0.85;
+  max-width: 380px;
+  margin-bottom: 24px;
+  position: relative; z-index: 2;
+}
+.tp-bs-features {
+  display: flex; flex-direction: column;
+  gap: 18px;
+  position: relative; z-index: 2;
+}
+.tp-bs-feature {
+  display: flex; gap: 14px;
+  align-items: flex-start;
+}
+.tp-bs-feature .tp-feat-icon {
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  background: rgba(255, 251, 245, 0.12);
+  display: grid; place-items: center;
+  flex-shrink: 0;
+  color: var(--color-background);
+}
+.tp-bs-feature .tp-feat-icon svg {
+  width: 18px; height: 18px;
+  stroke: currentColor; fill: none;
+  stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+}
+.tp-bs-feature .tp-feat-body { padding-top: 4px; }
+.tp-bs-feature .tp-feat-title {
+  font-size: 15px; font-weight: 700;
+  letter-spacing: -0.005em;
+}
+.tp-bs-feature .tp-feat-desc {
+  font-size: 13px; opacity: 0.78;
+  margin-top: 2px; line-height: 1.5;
+}
+.tp-bs-footnote {
+  font-size: 11px;
+  opacity: 0.6;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  position: relative; z-index: 2;
+}
+`;
+
+export interface HeroItem {
+  /** Inner SVG content (paths/circles) — the wrapper svg + viewBox is provided */
+  icon: ReactNode;
+  title: string;
+  desc: string;
+}
+
+export interface AuthBrandHeroProps {
+  eyebrow: string;
+  headline: ReactNode;
+  sub?: string;
+  items: HeroItem[];
+  footnote?: string;
+}
+
+export default function AuthBrandHero({ eyebrow, headline, sub, items, footnote }: AuthBrandHeroProps) {
+  return (
+    <>
+      <style>{HERO_STYLES}</style>
+      <aside className="tp-auth-brand-hero" data-testid="auth-brand-hero" aria-hidden="true">
+        <div className="tp-bs-eyebrow">{eyebrow}</div>
+        <div>
+          <h2 className="tp-bs-display">{headline}</h2>
+          {sub && <p className="tp-bs-sub">{sub}</p>}
+          <div className="tp-bs-features">
+            {items.map((item, i) => (
+              <div className="tp-bs-feature" key={i}>
+                <div className="tp-feat-icon">
+                  <svg viewBox="0 0 24 24">{item.icon}</svg>
+                </div>
+                <div className="tp-feat-body">
+                  <div className="tp-feat-title">{item.title}</div>
+                  <div className="tp-feat-desc">{item.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        {footnote && <div className="tp-bs-footnote">{footnote}</div>}
+      </aside>
+    </>
+  );
+}

--- a/src/pages/EmailVerifyPendingPage.tsx
+++ b/src/pages/EmailVerifyPendingPage.tsx
@@ -13,6 +13,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import AuthBrandHero, { AUTH_LAYOUT_STYLES } from '../components/auth/AuthBrandHero';
 
 const SCOPED_STYLES = `
 .tp-verify-shell {
@@ -22,6 +23,7 @@ const SCOPED_STYLES = `
     radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
+${AUTH_LAYOUT_STYLES}
 .tp-verify-card {
   width: 100%; max-width: 440px;
   background: var(--color-background);
@@ -142,7 +144,8 @@ export default function EmailVerifyPendingPage() {
   return (
     <main className="tp-verify-shell" data-testid="verify-pending-page">
       <style>{SCOPED_STYLES}</style>
-      <div className="tp-verify-card">
+      <div className="tp-verify-form-side">
+        <div className="tp-verify-card">
         <div className="tp-verify-icon-circle">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
             <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
@@ -195,7 +198,32 @@ export default function EmailVerifyPendingPage() {
         <p className="tp-verify-footer">
           打錯 email？<a href="/signup">改用其他信箱</a>
         </p>
+        </div>
       </div>
+
+      <AuthBrandHero
+        eyebrow="Almost there"
+        headline={<>差最後一步<br />就能開始。</>}
+        sub="驗證 email 是為了確保你能收到旅伴邀請、行程更新通知，以及哪天忘記密碼時的重設連結。"
+        items={[
+          {
+            icon: <polyline points="20,6 9,17 4,12" />,
+            title: '驗證後立即可用',
+            desc: '點完連結會自動回到這個頁面，可以直接開始規劃 trip。',
+          },
+          {
+            icon: (
+              <>
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </>
+            ),
+            title: '未驗證不算啟用',
+            desc: '沒驗證的帳號 7 天後自動清除，避免假帳號占空間。',
+          },
+        ]}
+        footnote="© 2026 Tripline"
+      />
     </main>
   );
 }

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -10,6 +10,7 @@
  * Rate limit (V2-P6): 429 FORGOT_PASSWORD_RATE_LIMITED → 顯示 retry-after。
  */
 import { useState } from 'react';
+import AuthBrandHero, { AUTH_LAYOUT_STYLES } from '../components/auth/AuthBrandHero';
 
 const SCOPED_STYLES = `
 .tp-auth-shell {
@@ -19,6 +20,7 @@ const SCOPED_STYLES = `
     radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
+${AUTH_LAYOUT_STYLES}
 .tp-auth-card {
   width: 100%; max-width: 440px;
   background: var(--color-background);
@@ -147,7 +149,8 @@ export default function ForgotPasswordPage() {
   return (
     <main className="tp-auth-shell" data-testid="forgot-password-page">
       <style>{SCOPED_STYLES}</style>
-      <div className="tp-auth-card">
+      <div className="tp-auth-form-side">
+        <div className="tp-auth-card">
         <div className="tp-auth-brand">
           <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
           <span>Tripline</span>
@@ -209,7 +212,42 @@ export default function ForgotPasswordPage() {
             </div>
           </>
         )}
+        </div>
       </div>
+
+      <AuthBrandHero
+        eyebrow="Account Recovery"
+        headline={<>忘了沒關係<br />5 分鐘搞定。</>}
+        sub="我們不會請你回答秘密問題、不收手機號、不要身分證。Email 是唯一管道，最簡單也最不容易被釣魚。"
+        items={[
+          {
+            icon: (
+              <>
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </>
+            ),
+            title: '連結 1 小時失效',
+            desc: '即使被攔截，過期後就無法用，舊密碼也不洩漏。',
+          },
+          {
+            icon: (
+              <>
+                <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                <polyline points="22,6 12,13 2,6" />
+              </>
+            ),
+            title: '只透過 email',
+            desc: '不會 SMS、不會打電話、不會私訊。只看 email 收件匣即可。',
+          },
+          {
+            icon: <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />,
+            title: '舊登入裝置自動登出',
+            desc: '重設後，所有手機/平板的 session 都失效，避免別人用你舊密碼。',
+          },
+        ]}
+        footnote="© 2026 Tripline · 帳號安全最低承諾"
+      />
     </main>
   );
 }

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -14,6 +14,7 @@
  */
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import AuthBrandHero, { AUTH_LAYOUT_STYLES } from '../components/auth/AuthBrandHero';
 
 const SCOPED_STYLES = `
 .tp-auth-shell {
@@ -23,6 +24,7 @@ const SCOPED_STYLES = `
     radial-gradient(circle at 20% 0%, rgba(217, 120, 72, 0.06), transparent 50%),
     var(--color-secondary);
 }
+${AUTH_LAYOUT_STYLES}
 .tp-auth-card {
   width: 100%; max-width: 440px;
   background: var(--color-background);
@@ -235,7 +237,11 @@ export default function ResetPasswordPage() {
   // Token missing in URL → render error directly
   if (!token || tokenInvalid) {
     return (
-      <main className="tp-auth-shell" data-testid="reset-password-page">
+      <main
+        className="tp-auth-shell"
+        style={{ display: 'flex', gridTemplateColumns: 'unset', padding: '48px 24px' }}
+        data-testid="reset-password-page"
+      >
         <style>{SCOPED_STYLES}</style>
         <div className="tp-auth-card">
           <div className="tp-auth-brand">
@@ -264,7 +270,11 @@ export default function ResetPasswordPage() {
 
   if (success) {
     return (
-      <main className="tp-auth-shell" data-testid="reset-password-page">
+      <main
+        className="tp-auth-shell"
+        style={{ display: 'flex', gridTemplateColumns: 'unset', padding: '48px 24px' }}
+        data-testid="reset-password-page"
+      >
         <style>{SCOPED_STYLES}</style>
         <div className="tp-auth-card">
           <div className="tp-auth-brand">
@@ -289,7 +299,8 @@ export default function ResetPasswordPage() {
   return (
     <main className="tp-auth-shell" data-testid="reset-password-page">
       <style>{SCOPED_STYLES}</style>
-      <div className="tp-auth-card">
+      <div className="tp-auth-form-side">
+        <div className="tp-auth-card">
         <div className="tp-auth-brand">
           <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
           <span>Tripline</span>
@@ -388,7 +399,32 @@ export default function ResetPasswordPage() {
         <div className="tp-auth-footer">
           想起密碼了？<a href="/login">回登入</a>
         </div>
+        </div>
       </div>
+
+      <AuthBrandHero
+        eyebrow="Final Step"
+        headline={<>最後一步<br />就完成了。</>}
+        sub="設好新密碼，你會自動登入並進入「行程」頁。記得密碼存到密碼管理器（1Password / Apple Keychain / Google Password）。"
+        items={[
+          {
+            icon: <polyline points="20,6 9,17 4,12" />,
+            title: '即時生效',
+            desc: '設好密碼後立即可登入，不需等 email 或重新驗證。',
+          },
+          {
+            icon: (
+              <>
+                <path d="M12 1l3 3-3 3M12 17l3 3-3 3M5 12H1l3-3M19 12h4l-3 3" />
+                <path d="M9 12a3 3 0 0 1 6 0v0a3 3 0 0 1-6 0z" />
+              </>
+            ),
+            title: '舊裝置全登出',
+            desc: '手機、平板、其他電腦的 session 全部清掉，重新登入才能用。',
+          },
+        ]}
+        footnote="© 2026 Tripline"
+      />
     </main>
   );
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -14,6 +14,7 @@
  */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import AuthBrandHero, { AUTH_LAYOUT_STYLES } from '../components/auth/AuthBrandHero';
 
 const SCOPED_STYLES = `
 .tp-auth-shell {
@@ -24,6 +25,7 @@ const SCOPED_STYLES = `
     radial-gradient(circle at 80% 100%, rgba(217, 120, 72, 0.04), transparent 50%),
     var(--color-secondary);
 }
+${AUTH_LAYOUT_STYLES}
 .tp-auth-card {
   width: 100%; max-width: 440px;
   background: var(--color-background);
@@ -205,7 +207,8 @@ export default function SignupPage() {
   return (
     <main className="tp-auth-shell" data-testid="signup-page">
       <style>{SCOPED_STYLES}</style>
-      <div className="tp-auth-card">
+      <div className="tp-auth-form-side">
+        <div className="tp-auth-card">
         <div className="tp-auth-brand">
           <span className="tp-auth-brand-dot" aria-hidden="true">●</span>
           <span>Tripline</span>
@@ -289,7 +292,43 @@ export default function SignupPage() {
         <div className="tp-auth-footer">
           已有帳號？<a href="/login">直接登入</a>
         </div>
+        </div>
       </div>
+
+      <AuthBrandHero
+        eyebrow="Why Tripline"
+        headline={<>把每次旅程<br />留在身邊。</>}
+        sub="註冊後可同步行程到所有裝置、邀請旅伴共編、儲存喜歡的 POI 一鍵加入下次 trip。"
+        items={[
+          {
+            icon: (
+              <>
+                <path d="M21 12a9 9 0 0 1-9 9M3 12a9 9 0 0 1 9-9M21 12h-4M7 12H3M12 21v-4M12 7V3" />
+                <circle cx="12" cy="12" r="4" />
+              </>
+            ),
+            title: '跨裝置同步',
+            desc: '手機看到的就是平板看到的，離線也能用。',
+          },
+          {
+            icon: (
+              <>
+                <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                <circle cx="8.5" cy="7" r="4" />
+                <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+              </>
+            ),
+            title: '邀請旅伴共編',
+            desc: '用一個 link 把家人朋友拉進行程，不用 LINE 截圖。',
+          },
+          {
+            icon: <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />,
+            title: '儲存池跟著你',
+            desc: '看到喜歡的餐廳/景點按 ♡ 儲存，下次規劃直接拉進 trip。',
+          },
+        ]}
+        footnote="© 2026 Tripline · 由旅人為旅人打造"
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Rolls out the right-pane brand hero pattern (shipped on LoginPage in #318) to the remaining 4 V2 auth pages, via a new shared `<AuthBrandHero>` component.

| Page | Eyebrow | Headline | Items |
|------|---------|----------|-------|
| `/signup` | Why Tripline | 把每次旅程留在身邊。 | 3 features (sync / collab / save) |
| `/login/forgot` | Account Recovery | 忘了沒關係 5 分鐘搞定。 | 3 reassures (1h ttl / email-only / device logout) |
| `/auth/password/reset` (form) | Final Step | 最後一步就完成了。 | 2 reassures (instant / device logout) |
| `/signup/check-email` | Almost there | 差最後一步就能開始。 | 2 features (instant / 7d-cleanup) |

**ResetPasswordPage invalid-token + success views keep single-column** — alarming/celebratory UX, no brand pitch.

## Architecture
- New: `src/components/auth/AuthBrandHero.tsx` — exports both:
  - `<AuthBrandHero eyebrow={...} headline={...} sub={...} items={...} footnote={...} />` React component (hero JSX + scoped styles)
  - `AUTH_LAYOUT_STYLES` string each page embeds in its existing `SCOPED_STYLES` so `.tp-{auth|verify}-shell` switches to `grid 1fr/1fr` ≥1024px and stays single-column flex centered on mobile
- LoginPage's inline copy of the same pattern (#318) is intentionally left as-is — folding it into the shared component is a future cleanup PR. The pattern itself is identical.

## Visual QA on localhost (chromium 1280×800)
| URL | Hero | Card |
|-----|------|------|
| /signup | x=640 w=640 h=800 ✓ | left half |
| /login/forgot | x=640 w=640 h=800 ✓ | left half |
| /auth/password/reset?token=… | x=640 w=640 h=800 ✓ | left half |
| /auth/password/reset (no token) | hidden ✓ | centered x=420 w=440 |
| /signup/check-email | x=640 w=640 h=800 ✓ | left half |
| mobile /signup | hidden ✓ | full-width single column |

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx vitest run tests/unit/{signup,forgot-password,reset-password,email-verify-pending,login}-page.test.tsx` → 41/41 pass
- [ ] Cloudflare Pages preview deploy
- [ ] Canary check each page on preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)