### PR TITLE
feat(v2-design): bundle audit follow-ups — settings AppShell + /trips landing + close-out

### DIFF
--- a/docs/v2-design-audit-2026-04-25.md
+++ b/docs/v2-design-audit-2026-04-25.md
@@ -135,14 +135,18 @@ mobile has the same card grid layout in single-column.
 | Page | Desktop | Mobile | Notes |
 |------|---------|--------|-------|
 | /oauth/consent | ✅ form-based POST, terracotta CTA | ✅ same | recently rewritten in /review pass |
-| /settings/connected-apps | 🟡 functional, plain layout | 🟡 | needs AppShell wrap |
-| /developer/apps | 🟡 functional, plain | 🟡 | needs AppShell wrap |
-| /settings/sessions | 🟡 functional, plain | 🟡 | needs AppShell wrap |
+| /settings/connected-apps | ✅ AppShell wrap | ✅ AppShell wrap (sidebar hidden by media query) | this PR |
+| /developer/apps | ✅ AppShell wrap | ✅ AppShell wrap | this PR |
+| /settings/sessions | ✅ AppShell wrap | ✅ AppShell wrap | this PR |
 
 **Settings follow-ups:**
 
-1. ⏭ Wrap all settings pages in `AppShell` so sidebar nav + brand are visible.
-2. ⏭ Add page-level header with breadcrumb / "← 帳號設定" back link pattern.
+1. ✅ **DONE this PR.** ConnectedAppsPage / DeveloperAppsPage / SessionsPage
+   wrapped in `AppShell` with `<DesktopSidebarConnected />` so logged-in user
+   sees sidebar nav + account chip on every settings route.
+2. ⏭ Add page-level breadcrumb / "← 帳號設定" back link pattern. Sidebar
+   highlighting on `/settings/sessions` falls back to nearest match
+   (「已連結應用」) since there's no sessions-specific nav item — minor polish.
 
 ---
 
@@ -221,12 +225,12 @@ mobile has the same card grid layout in single-column.
 
 | Priority | Item | Estimated CC time | Status |
 |----------|------|------|--------|
-| P1 | Wrap auth pages in AppShell so sidebar visible to anonymous users | ~30min | ⏭ pending |
+| P1 | Wrap auth pages in AppShell so sidebar visible to anonymous users | ~30min | ⏭ deferred — anonymous click on sidebar nav causes redirect-bounce; not worth UX cost without disabling-while-anon polish |
 | P1 | Add `<aside>` desktop right-pane brand hero to login/signup/forgot | ~45min | ✅ #318 + #319 (5 pages, shared `AuthBrandHero` component) |
-| P2 | `/trips` landing page with peach-gradient trip cards | ~60min | ⏭ pending |
-| P2 | Right pane on `/trip/:id` shows selected day's stop summary | ~30min | ⏭ pending |
-| P2 | Wrap `/settings/*` and `/developer/*` in AppShell | ~20min | ⏭ pending |
-| P3 | `/explore` POI card grid with category-keyed gradients | ~90min | ⏭ pending |
+| P2 | `/trips` landing page with peach-gradient trip cards | ~60min | ✅ this PR — `TripsListPage` wired at `/trips`, JP/KR/TW/other gradient covers |
+| P2 | Right pane on `/trip/:id` shows selected day's stop summary | ~30min | ✅ already shipped — `TripSheet` (itinerary/ideas/map/chat tabs) replaced placeholder before this audit was written; audit claim was stale |
+| P2 | Wrap `/settings/*` and `/developer/*` in AppShell | ~20min | ✅ this PR — connected-apps + developer/apps + settings/sessions wrapped |
+| P3 | `/explore` POI card grid with category-keyed gradients | ~90min | ⏭ deferred to dedicated explore-redesign sprint (also needs right-pane POI detail + improved empty state) |
 | P3 | Implement `/chat` (LLM concierge) — mockup-chat-v2 design exists | several days | ⏭ pending |
 | P3 | Implement `/map` (cross-trip global map) | ~2 days | ⏭ pending |
 

--- a/src/components/auth/AuthBrandHero.tsx
+++ b/src/components/auth/AuthBrandHero.tsx
@@ -123,7 +123,7 @@ const HERO_STYLES = `
   margin-top: 2px; line-height: 1.5;
 }
 .tp-bs-footnote {
-  font-size: 11px;
+  font-size: var(--font-size-caption2);
   opacity: 0.6;
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -72,6 +72,7 @@ const ConnectedAppsPage = lazyWithRetry(() => import('../pages/ConnectedAppsPage
 const DeveloperAppsPage = lazyWithRetry(() => import('../pages/DeveloperAppsPage'));
 const SessionsPage = lazyWithRetry(() => import('../pages/SessionsPage'));
 const ConsentPage = lazyWithRetry(() => import('../pages/ConsentPage'));
+const TripsListPage = lazyWithRetry(() => import('../pages/TripsListPage'));
 
 const DEFAULT_TRIP = 'okinawa-trip-2026-Ray';
 const FALLBACK_STYLE = { padding: '2rem', textAlign: 'center' as const };
@@ -122,6 +123,7 @@ if (el) {
               <Route path="/developer/apps" element={<DeveloperAppsPage />} />
               <Route path="/settings/sessions" element={<SessionsPage />} />
               <Route path="/oauth/consent" element={<ConsentPage />} />
+              <Route path="/trips" element={<TripsListPage />} />
               <Route path="/trip/:tripId" element={<TripLayout />}>
                 <Route index element={<TripPage />} />
                 <Route path="map" element={<TripMapRedirect />} />

--- a/src/pages/ConnectedAppsPage.tsx
+++ b/src/pages/ConnectedAppsPage.tsx
@@ -10,6 +10,8 @@
  */
 import { useEffect, useState } from 'react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 
 const SCOPED_STYLES = `
 .tp-settings-shell {
@@ -252,8 +254,11 @@ export default function ConnectedAppsPage() {
   const target = apps?.find((a) => a.client_id === revokingId);
 
   return (
-    <main className="tp-settings-shell" data-testid="connected-apps-page">
+    <AppShell
+      sidebar={<DesktopSidebarConnected />}
+      main={<>
       <style>{SCOPED_STYLES}</style>
+      <div className="tp-settings-shell" data-testid="connected-apps-page">
       <div className="tp-settings-inner">
         <div className="tp-page-heading">
           <div className="tp-page-heading-crumb">設定</div>
@@ -322,6 +327,7 @@ export default function ConnectedAppsPage() {
           </div>
         )}
       </div>
+      </div>
 
       {revokingId && target && (
         <div className="tp-modal-backdrop" role="dialog" aria-modal="true" data-testid="connected-apps-confirm-modal">
@@ -362,6 +368,7 @@ export default function ConnectedAppsPage() {
           </div>
         </div>
       )}
-    </main>
+      </>}
+    />
   );
 }

--- a/src/pages/DeveloperAppsPage.tsx
+++ b/src/pages/DeveloperAppsPage.tsx
@@ -18,6 +18,8 @@
  */
 import { useEffect, useState } from 'react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 
 const SCOPED_STYLES = `
 .tp-dev-shell {
@@ -396,8 +398,11 @@ export default function DeveloperAppsPage() {
   }
 
   return (
-    <main className="tp-dev-shell" data-testid="developer-apps-page">
+    <AppShell
+      sidebar={<DesktopSidebarConnected />}
+      main={<>
       <style>{SCOPED_STYLES}</style>
+      <div className="tp-dev-shell" data-testid="developer-apps-page">
       <div className="tp-dev-inner">
         <div className="tp-page-heading">
           <div className="tp-page-heading-text">
@@ -464,6 +469,7 @@ export default function DeveloperAppsPage() {
             })}
           </div>
         )}
+      </div>
       </div>
 
       {creating && (
@@ -621,6 +627,7 @@ export default function DeveloperAppsPage() {
           </div>
         </div>
       )}
-    </main>
+      </>}
+    />
   );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -129,7 +129,7 @@ const SCOPED_STYLES = `
   margin-top: 2px; line-height: 1.5;
 }
 .tp-bs-footnote {
-  font-size: 11px;
+  font-size: var(--font-size-caption2);
   opacity: 0.6;
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -13,6 +13,8 @@
  */
 import { useEffect, useState } from 'react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 
 const SCOPED_STYLES = `
 .tp-sessions-shell {
@@ -223,8 +225,11 @@ export default function SessionsPage() {
   const otherSessions = sessions?.filter((s) => !s.is_current) ?? [];
 
   return (
-    <main className="tp-sessions-shell" data-testid="sessions-page">
+    <AppShell
+      sidebar={<DesktopSidebarConnected />}
+      main={<>
       <style>{SCOPED_STYLES}</style>
+      <div className="tp-sessions-shell" data-testid="sessions-page">
       <div className="tp-sessions-inner">
         <div className="tp-page-heading">
           <div className="tp-page-heading-text">
@@ -329,6 +334,8 @@ export default function SessionsPage() {
           </div>
         </div>
       </div>
-    </main>
+      </div>
+      </>}
+    />
   );
 }

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -1,0 +1,238 @@
+/**
+ * TripsListPage — V2 design audit landing page
+ *
+ * Route: /trips
+ * Shows the logged-in user's accessible trips as peach-gradient cards
+ * (mockup-trip-v2.html "/trips" landing). Click → /trip/:tripId detail.
+ *
+ * Data:
+ *   - GET /api/my-trips → tripIds the user has permission for
+ *   - GET /api/trips     → all published trips with name + countries
+ *   - Cross-ref so admins still see only what they can edit
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useRequireAuth } from '../hooks/useRequireAuth';
+import AppShell from '../components/shell/AppShell';
+import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
+
+const SCOPED_STYLES = `
+.tp-trips-shell {
+  min-height: 100%;
+  padding: 32px 24px 64px;
+  background: var(--color-secondary);
+}
+.tp-trips-inner { max-width: 960px; margin: 0 auto; }
+.tp-trips-heading {
+  margin-bottom: 24px;
+}
+.tp-trips-heading-crumb {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-muted); margin-bottom: 8px;
+}
+.tp-trips-heading h1 {
+  font-size: var(--font-size-title); font-weight: 800;
+  letter-spacing: -0.02em; margin: 0 0 6px;
+}
+.tp-trips-heading p {
+  color: var(--color-muted); font-size: var(--font-size-subheadline);
+  margin: 0;
+}
+
+.tp-trips-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+.tp-trip-card {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 120ms, box-shadow 120ms, transform 120ms;
+  display: block;
+}
+.tp-trip-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+.tp-trip-card-cover {
+  aspect-ratio: 16/9;
+  background: var(--color-tertiary);
+  border-radius: var(--radius-md);
+  margin-bottom: 12px;
+}
+.tp-trip-cover-jp {
+  background-image: linear-gradient(135deg, #D97848 0%, #F0935E 100%);
+}
+.tp-trip-cover-kr {
+  background-image: linear-gradient(135deg, #B85C2E 0%, #EADFCF 100%);
+}
+.tp-trip-cover-tw {
+  background-image: linear-gradient(135deg, #C88500 0%, #F7DFCB 100%);
+}
+.tp-trip-cover-other {
+  background-image: linear-gradient(135deg, #6F5A47 0%, #C8B89F 100%);
+}
+.tp-trip-card-eyebrow {
+  font-size: var(--font-size-caption2);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin-bottom: 6px;
+}
+.tp-trip-card-title {
+  font-size: var(--font-size-headline);
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  margin: 0 0 4px;
+}
+.tp-trip-card-meta {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+}
+
+.tp-trips-empty, .tp-trips-loading, .tp-trips-error {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--color-muted);
+  margin-top: 24px;
+}
+.tp-trips-error { color: var(--color-destructive); }
+`;
+
+interface MyTripRow {
+  tripId: string;
+}
+
+interface TripInfo {
+  tripId: string;
+  name: string;
+  owner?: string;
+  title?: string | null;
+  countries?: string | null;
+  published?: number | boolean;
+}
+
+function coverClass(countries: string | null | undefined): string {
+  const c = (countries ?? '').toUpperCase().trim();
+  if (c.includes('JP')) return 'tp-trip-cover-jp';
+  if (c.includes('KR')) return 'tp-trip-cover-kr';
+  if (c.includes('TW')) return 'tp-trip-cover-tw';
+  return 'tp-trip-cover-other';
+}
+
+function eyebrowText(countries: string | null | undefined): string {
+  const c = (countries ?? '').toUpperCase().trim();
+  if (c.includes('JP')) return 'JAPAN';
+  if (c.includes('KR')) return 'KOREA';
+  if (c.includes('TW')) return 'TAIWAN';
+  return c || 'TRIP';
+}
+
+export default function TripsListPage() {
+  useRequireAuth();
+  const [myIds, setMyIds] = useState<string[] | null>(null);
+  const [allTrips, setAllTrips] = useState<TripInfo[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      fetch('/api/my-trips', { credentials: 'same-origin' }),
+      fetch('/api/trips?all=1', { credentials: 'same-origin' }),
+    ])
+      .then(async ([myRes, allRes]) => {
+        if (cancelled) return;
+        if (!myRes.ok) {
+          if (myRes.status === 401 || myRes.status === 403) return; // useRequireAuth handles redirect
+          setError('無法載入你的行程清單。');
+          return;
+        }
+        const myJson = (await myRes.json()) as MyTripRow[];
+        const ids = myJson.map((r) => r.tripId);
+        setMyIds(ids);
+        if (allRes.ok) {
+          const allJson = (await allRes.json()) as TripInfo[];
+          setAllTrips(allJson);
+        } else {
+          setAllTrips([]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError('網路連線失敗，請稍後再試。');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const visibleTrips = useMemo<TripInfo[]>(() => {
+    if (myIds === null || allTrips === null) return [];
+    const idSet = new Set(myIds);
+    const map = new Map<string, TripInfo>();
+    for (const t of allTrips) map.set(t.tripId, t);
+    return myIds
+      .map((id) => map.get(id) ?? { tripId: id, name: id })
+      .filter((t) => idSet.has(t.tripId));
+  }, [myIds, allTrips]);
+
+  const loading = myIds === null && !error;
+
+  return (
+    <AppShell
+      sidebar={<DesktopSidebarConnected />}
+      main={<>
+        <style>{SCOPED_STYLES}</style>
+        <div className="tp-trips-shell" data-testid="trips-list-page">
+          <div className="tp-trips-inner">
+            <div className="tp-trips-heading">
+              <div className="tp-trips-heading-crumb">我的行程</div>
+              <h1>行程</h1>
+              <p>挑一個進去繼續編輯，或從上方建立新的旅程。</p>
+            </div>
+
+            {loading && (
+              <div className="tp-trips-loading" data-testid="trips-list-loading">載入中…</div>
+            )}
+
+            {error && (
+              <div className="tp-trips-error" role="alert" data-testid="trips-list-error">{error}</div>
+            )}
+
+            {!loading && !error && visibleTrips.length === 0 && (
+              <div className="tp-trips-empty" data-testid="trips-list-empty">
+                你目前沒有可編輯的行程。請聯繫管理者邀請你加入。
+              </div>
+            )}
+
+            {visibleTrips.length > 0 && (
+              <div className="tp-trips-grid">
+                {visibleTrips.map((t) => (
+                  <Link
+                    to={`/trip/${encodeURIComponent(t.tripId)}`}
+                    className="tp-trip-card"
+                    key={t.tripId}
+                    data-testid={`trips-list-card-${t.tripId}`}
+                  >
+                    <div className={`tp-trip-card-cover ${coverClass(t.countries)}`} aria-hidden="true" />
+                    <div className="tp-trip-card-eyebrow">{eyebrowText(t.countries)}</div>
+                    <h2 className="tp-trip-card-title">{t.title || t.name}</h2>
+                    <div className="tp-trip-card-meta">{t.tripId}</div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </>}
+    />
+  );
+}

--- a/tests/unit/connected-apps-page.test.tsx
+++ b/tests/unit/connected-apps-page.test.tsx
@@ -9,6 +9,9 @@ import { MemoryRouter } from 'react-router-dom';
 vi.mock('../../src/hooks/useRequireAuth', () => ({
   useRequireAuth: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
 }));
+vi.mock('../../src/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
+}));
 
 import ConnectedAppsPage from '../../src/pages/ConnectedAppsPage';
 

--- a/tests/unit/developer-apps-page.test.tsx
+++ b/tests/unit/developer-apps-page.test.tsx
@@ -9,6 +9,9 @@ import { MemoryRouter } from 'react-router-dom';
 vi.mock('../../src/hooks/useRequireAuth', () => ({
   useRequireAuth: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
 }));
+vi.mock('../../src/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' }, reload: () => {} }),
+}));
 
 import DeveloperAppsPage from '../../src/pages/DeveloperAppsPage';
 

--- a/tests/unit/sessions-page.test.tsx
+++ b/tests/unit/sessions-page.test.tsx
@@ -12,6 +12,15 @@ vi.mock('../../src/hooks/useRequireAuth', () => ({
     reload: () => {},
   }),
 }));
+// Mock useCurrentUser too — DesktopSidebarConnected (now wrapping the page in
+// AppShell) reads from it, and would otherwise consume the stubbed fetch
+// Response body before the page-level fetch could read it.
+vi.mock('../../src/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' },
+    reload: () => {},
+  }),
+}));
 
 import SessionsPage from '../../src/pages/SessionsPage';
 

--- a/tests/unit/trips-list-page.test.tsx
+++ b/tests/unit/trips-list-page.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * TripsListPage unit test — V2 design audit landing
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../src/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({
+    user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' },
+    reload: () => {},
+  }),
+}));
+vi.mock('../../src/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: { id: 'u1', email: 'u@x.com', emailVerified: true, displayName: null, avatarUrl: null, createdAt: '' },
+    reload: () => {},
+  }),
+}));
+
+import TripsListPage from '../../src/pages/TripsListPage';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockBoth(my: { tripId: string }[], all: Array<Record<string, unknown>>) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url === '/api/my-trips') {
+      return Promise.resolve(new Response(JSON.stringify(my), { status: 200 }));
+    }
+    if (url.startsWith('/api/trips')) {
+      return Promise.resolve(new Response(JSON.stringify(all), { status: 200 }));
+    }
+    return Promise.resolve(new Response('null', { status: 200 }));
+  });
+}
+
+describe('TripsListPage', () => {
+  it('shows loading state initially', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    expect(screen.getByTestId('trips-list-loading')).toBeTruthy();
+  });
+
+  it('renders empty state when user has no trips', async () => {
+    vi.stubGlobal('fetch', mockBoth([], []));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('trips-list-empty')).toBeTruthy());
+    expect(screen.getByText(/沒有可編輯的行程/)).toBeTruthy();
+  });
+
+  it('renders cards for accessible trips with country eyebrow + title', async () => {
+    const my = [{ tripId: 'okinawa-trip' }, { tripId: 'seoul-trip' }];
+    const all = [
+      { tripId: 'okinawa-trip', name: '沖繩之旅', title: '沖繩之旅', countries: 'JP', published: 1 },
+      { tripId: 'seoul-trip', name: '首爾美食行', title: '首爾美食行', countries: 'KR', published: 1 },
+      { tripId: 'unrelated', name: 'Other', countries: 'TW', published: 1 },
+    ];
+    vi.stubGlobal('fetch', mockBoth(my, all));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('trips-list-card-okinawa-trip')).toBeTruthy());
+    expect(screen.getByText('沖繩之旅')).toBeTruthy();
+    expect(screen.getByText('首爾美食行')).toBeTruthy();
+    expect(screen.getByText('JAPAN')).toBeTruthy();
+    expect(screen.getByText('KOREA')).toBeTruthy();
+    // Unrelated trip should NOT render — user has no permission
+    expect(screen.queryByText('Other')).toBeNull();
+  });
+
+  it('falls back to tripId when trip metadata missing', async () => {
+    const my = [{ tripId: 'orphan-trip' }];
+    vi.stubGlobal('fetch', mockBoth(my, []));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('trips-list-card-orphan-trip')).toBeTruthy());
+    // name falls back to tripId, eyebrow defaults to "TRIP"
+    expect(screen.getAllByText('orphan-trip').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('TRIP')).toBeTruthy();
+  });
+
+  it('shows error banner on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('trips-list-error')).toBeTruthy());
+  });
+
+  it('shows error banner on /api/my-trips 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url === '/api/my-trips') return Promise.resolve(new Response('boom', { status: 500 }));
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+    }));
+    render(<MemoryRouter><TripsListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.queryByTestId('trips-list-error')).toBeTruthy());
+  });
+});


### PR DESCRIPTION
## Summary
Bundles all remaining V2 design audit P1/P2 follow-ups per user direction「繼續 audit 不用分 PR 一次做完」.

### Settings AppShell wrap (audit #33)
ConnectedAppsPage / DeveloperAppsPage / SessionsPage now render inside `<AppShell sidebar={<DesktopSidebarConnected />} main={...} />`. Logged-in user sees sidebar nav + account chip on every settings route.

### /trips landing page (audit #35 partial)
New `TripsListPage` at `/trips` with peach-gradient trip cards keyed by country (JP / KR / TW / other → warm-tone gradient). Cross-refs `/api/my-trips` ∩ `/api/trips?all=1` so admins still see only their permitted trips.

### Token regression fix
`AuthBrandHero` + `LoginPage` `.tp-bs-footnote` font-size `11px` → `var(--font-size-caption2)`. Caught by `tests/unit/pr2-tokens.test.ts`.

### Audit doc close-out
| Item | Resolution |
|------|------------|
| Right pane on /trip/:id | ✅ already shipped via `TripSheet` (audit claim was stale) |
| Settings AppShell wrap | ✅ this PR |
| /trips landing | ✅ this PR |
| Auth-pages AppShell wrap | ⏭ deferred (anonymous click → redirect-bounce; needs disable-while-anon polish first) |
| /explore POI grid | ⏭ deferred to dedicated explore-redesign sprint |
| /chat + /map | ⏭ pending (multi-day implementations) |

## Visual QA (chromium 1280×800, mock session via routes)
- /trips: 2 cards with JP terracotta + KR cocoa gradients, sidebar visible ✅
- /settings/sessions: device list + sidebar ✅
- /settings/connected-apps: app list + sidebar ✅
- /developer/apps: empty CTA + sidebar ✅
- /login regression: split-screen + brand hero unchanged ✅

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx vitest run` → **988/988 pass**
- [x] Manual visual QA on localhost via playwright route mocks
- [ ] Cloudflare Pages preview deploy + canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)