### PR TITLE
fix(api): /api/my-trips inner-joins trips so orphan permissions don't leak

### DIFF
--- a/functions/api/my-trips.ts
+++ b/functions/api/my-trips.ts
@@ -11,17 +11,27 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   const auth = getAuth(context);
   if (!auth) throw new AppError('AUTH_REQUIRED');
 
+  // INNER JOIN trips so orphan permission rows (trip deleted but permission left
+  // behind) never leak into /trips landing or ManagePage trip selector. Wildcard
+  // '*' admin grant is filtered out — it's a sentinel, not a real tripId.
   let results;
   if (auth.isAdmin) {
-    // admin 可看所有行程（從 permissions 中取 distinct trip_id）
     const { results: rows } = await env.DB
-      .prepare('SELECT DISTINCT trip_id AS tripId FROM trip_permissions WHERE trip_id != ? ORDER BY trip_id')
+      .prepare(`SELECT DISTINCT p.trip_id AS tripId
+                FROM trip_permissions p
+                INNER JOIN trips t ON t.id = p.trip_id
+                WHERE p.trip_id != ?
+                ORDER BY p.trip_id`)
       .bind('*')
       .all();
     results = rows;
   } else {
     const { results: rows } = await env.DB
-      .prepare('SELECT trip_id AS tripId FROM trip_permissions WHERE email = ? AND trip_id != ? ORDER BY trip_id')
+      .prepare(`SELECT p.trip_id AS tripId
+                FROM trip_permissions p
+                INNER JOIN trips t ON t.id = p.trip_id
+                WHERE p.email = ? AND p.trip_id != ?
+                ORDER BY p.trip_id`)
       .bind(auth.email.toLowerCase(), '*')
       .all();
     results = rows;


### PR DESCRIPTION
## Symptom
`/trips` landing showed 7 phantom trips for the admin user. Their `trip_permissions` rows referenced `tripId`s that no longer existed in the `trips` table — orphan permission records left behind when trips were deleted.

## Root cause
Both code paths in `functions/api/my-trips.ts` selected straight from `trip_permissions` without verifying the trip still exists:

```sql
-- admin path (was)
SELECT DISTINCT trip_id AS tripId FROM trip_permissions WHERE trip_id != '*'
-- member path (was)
SELECT trip_id AS tripId FROM trip_permissions WHERE email = ? AND trip_id != '*'
```

## Fix
INNER JOIN `trips` on every read so only live trips ever appear:

```sql
SELECT DISTINCT p.trip_id AS tripId
FROM trip_permissions p
INNER JOIN trips t ON t.id = p.trip_id
WHERE p.trip_id != '*'
```

Wildcard `'*'` admin sentinel filtered as before.

## Out-of-band prod cleanup
The 8 existing orphan rows were already deleted on prod via wrangler:
```sql
DELETE FROM trip_permissions
WHERE trip_id NOT IN (SELECT id FROM trips)
  AND trip_id != '*'
-- 8 rows deleted, verified 0 orphans remaining
```

## Test plan
- [x] `npx vitest run --config vitest.config.api.mts tests/api/my-trips.integration.test.ts` → 3/3 pass
- [x] `npx tsc -p tsconfig.functions.json --noEmit` clean
- [ ] Cloudflare Pages preview deploy + reload `/trips` to confirm only HuiYun's + Ray's 沖繩 trips show

🤖 Generated with [Claude Code](https://claude.com/claude-code)