### PR TITLE
fix(v2-trips): 3-pane proportions + mobile day-strip pill + mobile bottom nav + drop AI 編輯

### DIFF
--- a/src/components/shell/GlobalBottomNav.tsx
+++ b/src/components/shell/GlobalBottomNav.tsx
@@ -1,0 +1,126 @@
+/**
+ * GlobalBottomNav — 5-tab mobile bottom nav for non-trip pages.
+ *
+ * Lifts mockup-trip-v2.html `.bottom-nav` pattern verbatim. Mirrors
+ * DesktopSidebar's 5-item primary nav (聊天 / 行程 / 地圖 / 探索 / 登入)
+ * so mobile and desktop share the same IA.
+ *
+ * Logged-in users have 登入 swapped for 帳號 (account chip with logout).
+ *
+ * Trip-scoped pages (/trip/:id) keep using BottomNavBar with 4-tab
+ * trip-context IA (行程/地圖/訊息/更多). This component is for /trips,
+ * /explore, /manage, /chat, /map and similar global routes.
+ */
+import { Link, useLocation } from 'react-router-dom';
+import clsx from 'clsx';
+import Icon from '../shared/Icon';
+
+interface NavItem {
+  key: 'chat' | 'trips' | 'map' | 'explore' | 'login' | 'account';
+  label: string;
+  href: string;
+  icon: string;
+  matchPrefixes: readonly string[];
+  exactOnly?: boolean;
+}
+
+const NAV_ITEMS_ANON: ReadonlyArray<NavItem> = [
+  { key: 'chat',    label: '聊天', href: '/chat',    icon: 'chat',   matchPrefixes: ['/chat'] },
+  { key: 'trips',   label: '行程', href: '/trips',   icon: 'home',   matchPrefixes: ['/trips', '/manage', '/trip'] },
+  { key: 'map',     label: '地圖', href: '/map',     icon: 'map',    matchPrefixes: ['/map'], exactOnly: true },
+  { key: 'explore', label: '探索', href: '/explore', icon: 'search', matchPrefixes: ['/explore'] },
+  { key: 'login',   label: '登入', href: '/login',   icon: 'user',   matchPrefixes: ['/login'] },
+];
+
+const NAV_ITEMS_AUTH: ReadonlyArray<NavItem> = [
+  { key: 'chat',    label: '聊天', href: '/chat',    icon: 'chat',   matchPrefixes: ['/chat'] },
+  { key: 'trips',   label: '行程', href: '/trips',   icon: 'home',   matchPrefixes: ['/trips', '/manage', '/trip'] },
+  { key: 'map',     label: '地圖', href: '/map',     icon: 'map',    matchPrefixes: ['/map'], exactOnly: true },
+  { key: 'explore', label: '探索', href: '/explore', icon: 'search', matchPrefixes: ['/explore'] },
+  { key: 'account', label: '帳號', href: '/settings/sessions', icon: 'user', matchPrefixes: ['/settings'] },
+];
+
+function isItemActive(pathname: string, item: NavItem): boolean {
+  for (const prefix of item.matchPrefixes) {
+    if (pathname === prefix) return true;
+    if (!item.exactOnly && pathname.startsWith(prefix + '/')) return true;
+  }
+  return false;
+}
+
+const SCOPED_STYLES = `
+.tp-global-bottom-nav {
+  position: sticky;
+  inset-block-end: 0;
+  left: 0; right: 0;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  height: var(--nav-height-mobile, 64px);
+  background: color-mix(in srgb, var(--color-background) 97%, transparent);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid var(--color-border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 10;
+}
+.tp-global-bottom-nav-btn {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  font: inherit;
+  min-height: var(--spacing-tap-min, 44px);
+  transition: color 150ms;
+}
+.tp-global-bottom-nav-btn .svg-icon {
+  width: 22px; height: 22px;
+}
+.tp-global-bottom-nav-btn span {
+  font-size: var(--font-size-caption2);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.tp-global-bottom-nav-btn:hover { color: var(--color-foreground); }
+.tp-global-bottom-nav-btn.is-active {
+  color: var(--color-accent);
+}
+.tp-global-bottom-nav-btn.is-active span {
+  font-weight: 700;
+}
+`;
+
+export interface GlobalBottomNavProps {
+  /** True when user is signed in. Swaps 登入 → 帳號 in last slot. */
+  authed: boolean;
+}
+
+export default function GlobalBottomNav({ authed }: GlobalBottomNavProps) {
+  const { pathname } = useLocation();
+  const items = authed ? NAV_ITEMS_AUTH : NAV_ITEMS_ANON;
+
+  return (
+    <>
+      <style>{SCOPED_STYLES}</style>
+      <div className="tp-global-bottom-nav" data-testid="global-bottom-nav">
+        {items.map((item) => {
+          const active = isItemActive(pathname, item);
+          return (
+            <Link
+              key={item.key}
+              to={item.href}
+              className={clsx('tp-global-bottom-nav-btn', active && 'is-active')}
+              aria-current={active ? 'page' : undefined}
+              data-testid={`global-bottom-nav-${item.key}`}
+            >
+              <Icon name={item.icon} />
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -99,19 +99,23 @@ body.print-mode .ocean-day-strip { display: none; }
 
 body.dark [data-dn]:not(.active) { background: transparent; color: var(--color-muted); }
 
-/* === MOBILE pill style (<761px): back to card-style snap-scroll === */
+/* === MOBILE pill style (<761px): mockup-trip-v2.html .mobile-day-strip-btn ===
+ * Vertical column layout (DAY 01 on top row, 7/26 on bottom row). Filled
+ * accent on active. 44px min tap target. Matches mockup exactly. */
 @media (max-width: 760px) {
   .ocean-day-strip {
     gap: 6px;
-    padding: 4px 16px 6px;
+    padding: 8px 16px;
     margin: -18px -16px 16px;
   }
   [data-dn] {
     padding: 7px 10px;
     border: 1px solid var(--color-border);
     border-radius: 10px;
-    gap: 6px;
-    min-height: 36px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    min-height: 44px;
     color: var(--color-foreground);
   }
   [data-dn]:hover:not(.active) {
@@ -125,11 +129,28 @@ body.dark [data-dn]:not(.active) { background: transparent; color: var(--color-m
     border-bottom-color: var(--color-accent);
   }
   [data-dn].active .dn-date { color: #fff; }
-  [data-dn].active .dn-eyebrow { color: rgba(255,255,255,0.85); }
-  [data-dn] .dn-date { font-size: 14px; color: var(--color-foreground); }
-  [data-dn] .dn-area { max-width: 56px; padding-left: 6px; font-size: var(--font-size-caption2); }
+  [data-dn].active .dn-eyebrow { color: rgba(255,255,255,0.85); opacity: 0.85; }
+  [data-dn] .dn-eyebrow {
+    font-size: var(--font-size-eyebrow);
+    letter-spacing: 0.14em;
+    opacity: 0.6;
+    line-height: 1;
+  }
+  [data-dn] .dn-date {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-foreground);
+  }
+  [data-dn] .dn-dow { margin-left: 4px; opacity: 0.55; }
+  [data-dn] .dn-area {
+    max-width: 80px;
+    padding-left: 0;
+    font-size: var(--font-size-caption2);
+    opacity: 0.6;
+    line-height: 1;
+  }
   [data-dn] .dn-area::before { display: none; }
-  [data-dn] .dn-eyebrow { font-size: var(--font-size-eyebrow); letter-spacing: 0.12em; }
   [data-dn] .dn-weather { background: rgba(0,0,0,0.06); color: var(--color-muted); }
   [data-dn].active .dn-weather { background: rgba(255,255,255,0.18); color: #fff; }
 }

--- a/src/components/trips/TripsPreviewSheet.tsx
+++ b/src/components/trips/TripsPreviewSheet.tsx
@@ -122,10 +122,12 @@ const SCOPED_STYLES = `
   font-weight: 600;
 }
 
+/* Day strip — mockup-trip-v2.html .mobile-day-strip pill pattern.
+ * Per user spec: desktop sheet AND mobile day-nav share THIS pattern. */
 .tp-day-strip {
-  display: flex; gap: 4px;
+  display: flex; gap: 6px;
   overflow-x: auto;
-  padding: 0 24px;
+  padding: 8px 16px;
   position: sticky; top: 0;
   background: color-mix(in srgb, var(--color-background) 92%, transparent);
   backdrop-filter: blur(14px);
@@ -136,19 +138,25 @@ const SCOPED_STYLES = `
 .tp-day-strip::-webkit-scrollbar { display: none; }
 .tp-day-strip-btn {
   flex: 0 0 auto;
-  padding: 10px 12px;
-  border: none; background: transparent;
-  border-bottom: 2px solid transparent;
+  padding: 7px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: transparent;
   cursor: pointer; font-family: inherit;
-  color: var(--color-muted);
-  display: inline-flex; flex-direction: column; gap: 2px;
+  color: var(--color-foreground);
+  display: inline-flex; flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   min-height: 44px;
-  transition: color 160ms, border-bottom-color 160ms;
+  transition: background 150ms, border-color 150ms, color 150ms;
 }
-.tp-day-strip-btn:hover:not(.is-active) { color: var(--color-foreground); }
+.tp-day-strip-btn:hover:not(.is-active) {
+  border-color: var(--color-accent);
+}
 .tp-day-strip-btn.is-active {
-  color: var(--color-accent-deep, #B85C2E);
-  border-bottom-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
 }
 .tp-day-strip-btn .tp-dn-head { display: inline-flex; align-items: center; gap: 4px; }
 .tp-day-strip-btn .tp-dn-eyebrow {
@@ -156,10 +164,11 @@ const SCOPED_STYLES = `
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  opacity: 0.7;
+  opacity: 0.6;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
 }
-.tp-day-strip-btn.is-active .tp-dn-eyebrow { opacity: 1; }
+.tp-day-strip-btn.is-active .tp-dn-eyebrow { opacity: 0.85; }
 .tp-day-strip-btn .tp-dn-today {
   font-size: 9px;
   font-weight: 700;
@@ -170,22 +179,25 @@ const SCOPED_STYLES = `
   background: var(--color-accent-subtle);
   color: var(--color-accent-deep, #B85C2E);
 }
+.tp-day-strip-btn.is-active .tp-dn-today {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
 .tp-day-strip-btn .tp-dn-date {
-  font-size: 14px; font-weight: 600;
+  font-size: 13px; font-weight: 600;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.005em;
   line-height: 1;
   color: var(--color-foreground);
 }
-.tp-day-strip-btn.is-active .tp-dn-date {
-  color: var(--color-accent-deep, #B85C2E);
-}
+.tp-day-strip-btn.is-active .tp-dn-date { color: #fff; }
 .tp-day-strip-btn .tp-dn-dow {
   font-size: var(--font-size-caption2);
   font-weight: 500;
   opacity: 0.55;
   margin-left: 4px;
 }
+.tp-day-strip-btn.is-active .tp-dn-dow { opacity: 0.85; }
 
 .tp-sheet-body { flex: 1; overflow-y: auto; }
 .tp-rail { padding: 16px 20px 20px; }

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -1,8 +1,7 @@
-import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
 import { useOfflineToast } from '../hooks/useOfflineToast';
-import clsx from 'clsx';
 import { apiFetch } from '../lib/apiClient';
 import { mapRow } from '../lib/mapRow';
 import { lsGet, lsSet, lsRemove, lsRenewAll, LS_KEY_TRIP_PREF } from '../lib/localStorage';
@@ -553,15 +552,6 @@ export default function TripPage() {
             onDownload={handleDownloadFormat}
             isOnline={isOnline}
           />
-          <a
-            className={clsx('ocean-tb-btn ocean-tb-ai', !isOnline && 'opacity-40 pointer-events-none')}
-            href="/manage/"
-            aria-disabled={!isOnline}
-            tabIndex={isOnline ? undefined : -1}
-            onClick={!isOnline ? (e: React.MouseEvent) => e.preventDefault() : undefined}
-          >
-            AI 編輯
-          </a>
         </div>
       </header>
 

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -22,12 +22,26 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useRequireAuth } from '../hooks/useRequireAuth';
+import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
+import GlobalBottomNav from '../components/shell/GlobalBottomNav';
 import TripsPreviewSheet from '../components/trips/TripsPreviewSheet';
 
 const SCOPED_STYLES = `
+/* /trips landing uses a narrower sheet than the trip-detail page so the card
+ * grid + browse area gets more room. Default 3-pane token is min(780px, 40vw)
+ * which gives ~50/50 main/sheet at 1440 (too cramped for a list). Override
+ * to min(420px, 32vw) — at 1440 → sheet=420, main=780, sidebar=240.
+ *
+ * Scoped to <main className="tp-trips-shell"> so other 3-pane pages
+ * (TripPage with rich TripSheet) keep their wider sheet. */
+@media (min-width: 1024px) {
+  .app-shell:has(> main .tp-trips-shell)[data-layout="3pane"] {
+    grid-template-columns: 240px 1fr min(420px, 32vw);
+  }
+}
 .tp-trips-shell {
   min-height: 100%;
   padding: 32px 24px 64px;
@@ -269,6 +283,7 @@ const NEW_TRIP_HREF = '/manage';
 
 export default function TripsListPage() {
   useRequireAuth();
+  const { user } = useCurrentUser();
   const navigate = useNavigate();
   const isDesktop = useMediaQuery('(min-width: 1024px)');
   const [searchParams, setSearchParams] = useSearchParams();
@@ -434,6 +449,7 @@ export default function TripsListPage() {
       sidebar={<DesktopSidebarConnected />}
       sheet={sheet}
       main={main}
+      bottomNav={<GlobalBottomNav authed={!!user} />}
     />
   );
 }

--- a/tests/unit/quick-panel.test.js
+++ b/tests/unit/quick-panel.test.js
@@ -85,10 +85,11 @@ describe('TripPage Ocean topbar', () => {
     expect(tripPageTsx).not.toContain('QuickPanel');
   });
 
-  it('topbar 直接暴露 緊急 / 列印 / AI 編輯', () => {
+  it('topbar 直接暴露 緊急 / 列印（AI 編輯 link 移除 — 走 sidebar 「行程」 → /manage）', () => {
     expect(tripPageTsx).toContain("setActiveSheet('emergency')");
     expect(tripPageTsx).toContain('togglePrint');
-    expect(tripPageTsx).toContain('AI 編輯');
+    // AI 編輯 link removed per user direction; sidebar 行程 nav still routes to /manage
+    expect(tripPageTsx).not.toContain('AI 編輯');
   });
 
   it('topbar 不含死連結（PR3 Item 9：ocean-nav-tabs shell 已移除）', () => {


### PR DESCRIPTION
## Summary

Four /design-review findings on /trips landing addressed in one PR (per user spec).

| # | Finding | Fix |
|---|---------|-----|
| 1 | 三欄比例不正確 | Override grid for /trips: `240px 1fr min(420px, 32vw)` → at 1440 main=780, sheet=420 (was 624/576). 2 cards per row + trailing `新增行程` card |
| 2 | sheet 日期要用手機版 mockup | TripsPreviewSheet day-strip rewritten: filled-pill style with 1px border + accent fill on active |
| 3 | 手機版 day nav 與 mockup 不同 | DayNav mobile @media: flex-direction column + min-height 44px (was inline-flex 36px) |
| 4 | 手機版 bottom nav bar 消失 | New `<GlobalBottomNav>` (5-tab IA) wired to TripsListPage via AppShell.bottomNav |
| + | top AI 編輯 移除 | TripPage topbar's `<a href=/manage>AI 編輯</a>` removed; sidebar 行程 nav still routes to /manage |

## Visual QA (1440 desktop + 375 mobile)

Screenshots in `.gstack/devex/v2-trips-{d1440,m375}.png`:
- Desktop: sidebar 240 / main 780 (2 cards + 新增行程 dashed) / sheet 420 (Ray's day strip pill + stops)
- Mobile: cards stacked + 5-tab GlobalBottomNav (聊天/行程/地圖/探索/帳號) at bottom

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx vitest run` → **1000/1000 pass**
- [x] Visual QA on dev server with mocked APIs (chromium playwright)
- [ ] Cloudflare Pages preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)