### PR TITLE
fix(trip): hide empty topbar on mobile + day-strip sticky to top

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -704,17 +704,21 @@ body.dark {
      * viewport ≥768px stays on desktop type scale.
      */
     @media (max-width: 760px) {
+        /* Mobile: topbar has no visible content (brand label hidden ≥1100px,
+         * all right-side buttons hidden, AI 編輯 link removed). Hide the
+         * entire bar so day-strip becomes the top sticky element with no
+         * empty cream band + line above it. */
+        .ocean-topbar { display: none; }
         .ocean-nav-tabs { display: none; }
         .ocean-tb-divider { display: none; }
-        .ocean-topbar-right .ocean-tb-btn:not(.ocean-tb-ai) { display: none; }
         .ocean-overflow-wrap { display: none; }
-        .ocean-page { padding: 18px 16px calc(80px + env(safe-area-inset-bottom)); }
+        .ocean-page { padding: 0 16px calc(80px + env(safe-area-inset-bottom)); }
         .ocean-hero { padding: 22px 20px; border-radius: var(--radius-md); }
         .ocean-hero-title { font-size: 24px; } /* F003: DESIGN.md mobile hero title = 24px */
         .ocean-stop { grid-template-columns: 56px 44px 1fr; padding: 14px; gap: 12px; }
         .ocean-stop-actions { grid-column: 1 / -1; justify-content: flex-end; }
         .ocean-stop-icon { width: 44px; height: 44px; }
-        .ocean-day { scroll-margin-top: 190px; }
+        .ocean-day { scroll-margin-top: 130px; }
     }
 
     /* Mobile bottom tab bar (只在 ≤760px 顯示) */

--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -27,6 +27,10 @@ const SCOPED_STYLES = `
 @media (max-width: 1100px) {
   .ocean-day-strip { top: 56px; }
 }
+/* Mobile: topbar is hidden, so day-strip is the top sticky element. */
+@media (max-width: 760px) {
+  .ocean-day-strip { top: 0; }
+}
 body.print-mode .ocean-day-strip { display: none; }
 
 /* === DESKTOP tab style (≥761px): underlined tabs, no border, no rounded bg === */
@@ -106,7 +110,11 @@ body.dark [data-dn]:not(.active) { background: transparent; color: var(--color-m
   .ocean-day-strip {
     gap: 6px;
     padding: 8px 16px;
-    margin: -18px -16px 16px;
+    /* Topbar is hidden on mobile, so kill the negative top margin that used
+     * to pull the strip up under the topbar. Keep negative side margins so
+     * the strip can bleed to viewport edges within .ocean-page (which has
+     * 16px side padding). */
+    margin: 0 -16px 16px;
   }
   [data-dn] {
     padding: 7px 10px;


### PR DESCRIPTION
## Symptom
User screenshot shows empty cream band + thin horizontal line above the day-nav on mobile TripPage (above the DAY 01 / DAY 02 pills).

## Root cause
`.ocean-topbar` had its visible content progressively stripped:
- Brand label hidden at ≥1100px
- Right-side buttons hidden at ≤760px
- `AI 編輯` link removed in #325

But the topbar element itself still rendered with `padding: 10px 16px` + `border-bottom: 1px solid border`, leaving an empty bar with a faint line.

## Fix

**`css/tokens.css` @media (max-width: 760px):**
- `.ocean-topbar { display: none }` — topbar fully gone on mobile
- `.ocean-page` padding-top `18px → 0` (page no longer offsets for topbar)
- `.ocean-day` scroll-margin-top `190 → 130` (no topbar height to skip past)

**`src/components/trip/DayNav.tsx` @media (max-width: 760px):**
- `.ocean-day-strip { top: 0 }` — day-strip sticks to viewport top instead of `56px` below the now-gone topbar
- `margin: -18px → 0` on top (kill the pull-up that hid behind topbar)

Desktop / tablet ≥761px unchanged: topbar still shows brand + DestinationArt + buttons + OverflowMenu, day-strip still sticks at `top: 64px`.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx vitest run` → **1000/1000 pass**
- [ ] Cloudflare Pages preview deploy
- [ ] Mobile prod re-test: empty band gone, day-nav at top, scrolling sticks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)