### PR TITLE
fix(trips): stop click + day-nav unified pill + scroll-spy + grid 3x/2x

### DIFF
--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -33,134 +33,112 @@ const SCOPED_STYLES = `
 }
 body.print-mode .ocean-day-strip { display: none; }
 
-/* === DESKTOP tab style (≥761px): underlined tabs, no border, no rounded bg === */
+/* === Day strip — unified pill style for ALL viewports.
+ * Lifts mockup-trip-v2.html .mobile-day-strip-btn pattern verbatim.
+ * Vertical column (DAY 01 on top row, 7/26 Sat on bottom row). Border +
+ * filled-accent on active. 44px min tap target. Both desktop and mobile
+ * share this style per user direction「day-strip 比照手機版」. */
 [data-dn] {
   flex: 0 0 auto;
   scroll-snap-align: start;
-  padding: 10px 14px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
   background: transparent;
-  color: var(--color-muted);
+  color: var(--color-foreground);
   cursor: pointer;
   text-align: left;
   font-family: inherit;
-  transition: color 160ms var(--transition-timing-function-apple),
-              border-bottom-color 160ms var(--transition-timing-function-apple);
+  transition: background 160ms var(--transition-timing-function-apple),
+              border-color 160ms var(--transition-timing-function-apple),
+              color 160ms var(--transition-timing-function-apple);
   position: relative;
-  display: inline-flex; align-items: center; gap: 6px;
-  min-height: 36px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-height: 44px;
   white-space: nowrap;
 }
-[data-dn]:hover:not(.active) { color: var(--color-foreground); }
+[data-dn]:hover:not(.active) {
+  border-color: var(--color-accent);
+}
 [data-dn].active {
-  color: var(--color-accent);
-  border-bottom-color: var(--color-accent);
-  background: transparent;
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
 }
 
 [data-dn] .dn-head { display: inline-flex; align-items: center; gap: 4px; }
 [data-dn] .dn-eyebrow {
-  font-size: var(--font-size-eyebrow); font-weight: 700; letter-spacing: 0.14em;
-  opacity: 0.7; text-transform: uppercase;
+  font-size: var(--font-size-eyebrow);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  opacity: 0.6;
+  line-height: 1;
+  text-transform: uppercase;
   font-variant-numeric: tabular-nums;
 }
-[data-dn].active .dn-eyebrow { opacity: 1; }
-[data-dn] .dn-weather {
-  font-size: 9px; font-weight: 700; letter-spacing: 0.12em;
-  opacity: 0.75; text-transform: uppercase;
-  padding: 2px 5px; border-radius: 4px;
-  background: var(--color-accent-subtle); color: var(--color-accent);
+[data-dn].active .dn-eyebrow {
+  color: rgba(255, 255, 255, 0.85);
+  opacity: 0.85;
 }
-[data-dn].active .dn-weather { opacity: 1; }
-
+[data-dn] .dn-weather {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+}
+[data-dn].active .dn-weather {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
 [data-dn] .dn-date {
-  font-size: 14px; font-weight: 600;
-  font-variant-numeric: tabular-nums; letter-spacing: -0.005em;
+  font-size: 13px;
+  font-weight: 600;
   line-height: 1;
   color: var(--color-foreground);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.005em;
 }
-[data-dn].active .dn-date { color: var(--color-accent); }
+[data-dn].active .dn-date { color: #fff; }
 [data-dn] .dn-dow {
-  font-size: var(--font-size-caption2); font-weight: 500;
-  opacity: 0.55; margin-left: 4px; letter-spacing: 0.02em;
+  font-size: var(--font-size-caption2);
+  font-weight: 500;
+  opacity: 0.55;
+  margin-left: 4px;
 }
-[data-dn].active .dn-dow { opacity: 0.75; }
-
+[data-dn].active .dn-dow { opacity: 0.85; }
 [data-dn] .dn-area {
-  font-size: 12px; opacity: 0.6;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: var(--font-size-caption2);
+  opacity: 0.6;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   max-width: 80px;
-  padding-left: 6px;
+  padding-left: 0;
   line-height: 1;
-  position: relative;
 }
-[data-dn] .dn-area::before {
-  content: "·"; position: absolute; left: -1px; opacity: 0.5;
+[data-dn] .dn-area::before { display: none; }
+[data-dn].active .dn-area {
+  opacity: 0.85;
+  color: rgba(255, 255, 255, 0.85);
 }
-[data-dn].active .dn-area { opacity: 0.8; }
 
-body.dark [data-dn]:not(.active) { background: transparent; color: var(--color-muted); }
+body.dark [data-dn]:not(.active) { background: transparent; color: var(--color-foreground); }
 
-/* === MOBILE pill style (<761px): mockup-trip-v2.html .mobile-day-strip-btn ===
- * Vertical column layout (DAY 01 on top row, 7/26 on bottom row). Filled
- * accent on active. 44px min tap target. Matches mockup exactly. */
+/* Mobile-specific container tweaks: tighter side padding to bleed past
+ * .ocean-page's 16px side padding. */
 @media (max-width: 760px) {
   .ocean-day-strip {
     gap: 6px;
     padding: 8px 16px;
-    /* Topbar is hidden on mobile, so kill the negative top margin that used
-     * to pull the strip up under the topbar. Keep negative side margins so
-     * the strip can bleed to viewport edges within .ocean-page (which has
-     * 16px side padding). */
     margin: 0 -16px 16px;
   }
-  [data-dn] {
-    padding: 7px 10px;
-    border: 1px solid var(--color-border);
-    border-radius: 10px;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-    min-height: 44px;
-    color: var(--color-foreground);
-  }
-  [data-dn]:hover:not(.active) {
-    border-color: var(--color-accent);
-    border-bottom-color: var(--color-accent);
-  }
-  [data-dn].active {
-    background: var(--color-accent);
-    color: #fff;
-    border-color: var(--color-accent);
-    border-bottom-color: var(--color-accent);
-  }
-  [data-dn].active .dn-date { color: #fff; }
-  [data-dn].active .dn-eyebrow { color: rgba(255,255,255,0.85); opacity: 0.85; }
-  [data-dn] .dn-eyebrow {
-    font-size: var(--font-size-eyebrow);
-    letter-spacing: 0.14em;
-    opacity: 0.6;
-    line-height: 1;
-  }
-  [data-dn] .dn-date {
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1;
-    color: var(--color-foreground);
-  }
-  [data-dn] .dn-dow { margin-left: 4px; opacity: 0.55; }
-  [data-dn] .dn-area {
-    max-width: 80px;
-    padding-left: 0;
-    font-size: var(--font-size-caption2);
-    opacity: 0.6;
-    line-height: 1;
-  }
-  [data-dn] .dn-area::before { display: none; }
-  [data-dn] .dn-weather { background: rgba(0,0,0,0.06); color: var(--color-muted); }
-  [data-dn].active .dn-weather { background: rgba(255,255,255,0.18); color: #fff; }
 }
 
 @keyframes dn-tooltip-in {

--- a/src/components/trip/DaySection.tsx
+++ b/src/components/trip/DaySection.tsx
@@ -8,7 +8,8 @@
  */
 
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useTripId } from '../../contexts/TripIdContext';
 import clsx from 'clsx';
 import DaySkeleton from './DaySkeleton';
 import HourlyWeather from './HourlyWeather';
@@ -82,7 +83,7 @@ const DaySection = React.memo(function DaySection({
   isActive,
   timezone,
 }: DaySectionProps) {
-  const { tripId } = useParams<{ tripId: string }>();
+  const tripId = useTripId();
   const [animKey, setAnimKey] = useState(0);
   const prevActiveRef = useRef(false);
   useEffect(() => {

--- a/src/components/trip/TimelineEvent.tsx
+++ b/src/components/trip/TimelineEvent.tsx
@@ -2,7 +2,8 @@
 
 import { memo } from 'react';
 import clsx from 'clsx';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { useTripId } from '../../contexts/TripIdContext';
 import Icon from '../shared/Icon';
 import MarkdownText from '../shared/MarkdownText';
 import { type NavLocation } from './MapLinks';
@@ -42,7 +43,7 @@ interface TimelineEventProps {
 
 export const TimelineEvent = memo(function TimelineEvent({ entry, isNow, isPast }: TimelineEventProps) {
   const navigate = useNavigate();
-  const { tripId } = useParams<{ tripId: string }>();
+  const tripId = useTripId();
   const parsed = parseTimeRange(entry.time);
   const durationText = formatDuration(parsed.duration);
   const meta = deriveTypeMeta(entry);

--- a/src/components/trip/TimelineRail.tsx
+++ b/src/components/trip/TimelineRail.tsx
@@ -13,7 +13,8 @@
  */
 
 import { memo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { useTripId } from '../../contexts/TripIdContext';
 import Icon from '../shared/Icon';
 import type { TimelineEntryData } from './TimelineEvent';
 import { parseTimeRange, formatDuration, deriveTypeMeta } from '../../lib/timelineUtils';
@@ -26,7 +27,7 @@ interface TimelineRailProps {
 
 const TimelineRail = memo(function TimelineRail({ events, nowIndex = -1 }: TimelineRailProps) {
   const navigate = useNavigate();
-  const { tripId } = useParams<{ tripId: string }>();
+  const tripId = useTripId();
 
   if (!events || events.length === 0) return null;
 

--- a/src/contexts/TripIdContext.tsx
+++ b/src/contexts/TripIdContext.tsx
@@ -1,0 +1,26 @@
+/**
+ * TripIdContext — resolved tripId for components rendered inside TripPage.
+ *
+ * Why this exists separate from TripContext: TripContext carries the full
+ * useTrip() return (heavy). Many components (TimelineEvent, TimelineRail,
+ * DaySection's mapHref) only need tripId. They previously read it via
+ * `useParams<{tripId}>()`, which fails when TripPage is embedded inside
+ * `/trips?selected=:id` (URL has no :tripId param).
+ *
+ * TripPage provides this context with its resolved activeTripId in BOTH
+ * route mode (`/trip/:tripId`) and embedded mode (TripsListPage sheet/main).
+ * Consumers fall back to useParams when the context is absent (e.g., a
+ * StopDetailPage rendered directly under /trip/:tripId/stop/:eid still uses
+ * URL params via TripLayout's TripContext path).
+ */
+import { createContext, useContext } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const TripIdContext = createContext<string | null>(null);
+
+/** Get the active tripId. Prefers context (embedded mode) over URL params. */
+export function useTripId(): string | undefined {
+  const fromCtx = useContext(TripIdContext);
+  const { tripId: fromUrl } = useParams<{ tripId: string }>();
+  return fromCtx ?? fromUrl;
+}

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -12,6 +12,7 @@ import { TRIP_TIMEZONE, getLocalToday } from '../lib/constants';
 import { downloadTripFormat } from '../lib/tripExport';
 import { computeActiveDayIndex, getStableViewportH, computeInitialHash } from '../lib/scrollSpy';
 import { useScrollRestoreOnBack } from '../hooks/useScrollRestoreOnBack';
+import { TripIdContext } from '../contexts/TripIdContext';
 import DayNav from '../components/trip/DayNav';
 import DaySection from '../components/trip/DaySection';
 import TripSheetContent, { SHEET_TITLES } from '../components/trip/TripSheetContent';
@@ -106,16 +107,32 @@ function getQueryTrip(): string | null {
   return new URLSearchParams(window.location.search).get('trip');
 }
 
-/* ===== Scroll helper ===== */
+/* ===== Scroll helpers ===== */
+
+/**
+ * Find the actual scrolling ancestor of `el`. AppShell uses a constrained
+ * `.app-shell-main { overflow-y: auto }` as the scroll container, so the
+ * window doesn't scroll. Fall back to document if no ancestor scrolls.
+ */
+function findScrollContainer(el: HTMLElement): HTMLElement | Window {
+  let parent: HTMLElement | null = el.parentElement;
+  while (parent) {
+    const cs = getComputedStyle(parent);
+    const overflowY = cs.overflowY;
+    if ((overflowY === 'auto' || overflowY === 'scroll') && parent.scrollHeight > parent.clientHeight) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return window;
+}
 
 function scrollToDay(dayNum: number): void {
   const header = document.getElementById('day' + dayNum);
   if (!header) return;
-  const nav = document.getElementById('stickyNav');
-  const navH = nav ? nav.offsetHeight : 0;
-  const navTop = nav ? (parseFloat(getComputedStyle(nav).top) || 0) : 0;
-  const top = header.getBoundingClientRect().top + window.pageYOffset - navH - navTop - 4;
-  window.scrollTo({ top, behavior: 'smooth' });
+  // scroll-margin-top on the header (set in the align effect below) handles
+  // the day-strip sticky offset, so we just use scrollIntoView here.
+  header.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 /* ===== Resolve state machine ===== */
@@ -422,12 +439,17 @@ export default function TripPage({ tripId: propTripId, noShell = false }: TripPa
     return () => window.removeEventListener('resize', align);
   }, [loading]);
 
-  /* --- Scroll tracking: update active pill + hash (#6) --- */
+  /* --- Scroll tracking: update active pill + hash (#6).
+   * AppShell makes `.app-shell-main` the scroll container (overflow-y: auto).
+   * Window doesn't scroll, so listening on window misses every scroll event.
+   * Attach the listener to the scroll container of any day header. */
   useEffect(() => {
     if (loading || dayNums.length === 0) return;
-    // Print mode 下頁面用 print layout，scroll tracking 對 user 無意義且會觸發
-    // 不必要的 switchDay setState；進入 print mode 時 cleanup 就讓 effect 重跑以 detach。
     if (isPrintMode) return;
+
+    const firstHeader = document.getElementById('day' + dayNums[0]);
+    if (!firstHeader) return;
+    const scroller = findScrollContainer(firstHeader);
 
     function onScroll() {
       const nav = document.getElementById('stickyNav');
@@ -439,12 +461,10 @@ export default function TripPage({ tripId: propTripId, noShell = false }: TripPa
       const current = computeActiveDayIndex(headerTops, navH, getStableViewportH());
       if (current >= 0) {
         const activeDayNum = dayNums[current] ?? -1;
-        // #1: Only call switchDay when day actually changes (avoid redundant re-renders)
         if (activeDayNum >= 0 && activeDayNum !== scrollDayRef.current) {
           scrollDayRef.current = activeDayNum;
           switchDay(activeDayNum);
         }
-        // Update hash (debounced to avoid conflicts with manual scroll)
         if (Date.now() - manualScrollTs.current > 600) {
           const newHash = '#day' + activeDayNum;
           if (window.location.hash !== newHash) {
@@ -462,8 +482,8 @@ export default function TripPage({ tripId: propTripId, noShell = false }: TripPa
       }
     }
 
-    window.addEventListener('scroll', throttledScroll, { passive: true });
-    return () => window.removeEventListener('scroll', throttledScroll);
+    scroller.addEventListener('scroll', throttledScroll, { passive: true });
+    return () => scroller.removeEventListener('scroll', throttledScroll);
   }, [loading, dayNums, switchDay, isPrintMode]);
 
   /* --- Stops count per day for DayNav progress marks --- */
@@ -649,16 +669,24 @@ export default function TripPage({ tripId: propTripId, noShell = false }: TripPa
     </div>
   );
 
+  // Wrap content in TripIdContext so descendants (TimelineEvent, DaySection,
+  // TimelineRail) can read tripId without depending on URL useParams — needed
+  // for embedded mode where URL is /trips?selected=:id (no :tripId param).
+  const wrappedMain = (
+    <TripIdContext.Provider value={activeTripId}>
+      {mainContent}
+    </TripIdContext.Provider>
+  );
+
   // Embedded mode: host page provides AppShell + sidebar + sheet + bottomNav.
-  // We return only the inner trip content (timeline + topbar + InfoSheet).
   if (noShell) {
-    return mainContent;
+    return wrappedMain;
   }
 
   return (
     <AppShell
       sidebar={<DesktopSidebarConnected />}
-      main={mainContent}
+      main={wrappedMain}
       sheet={sheetContent}
       bottomNav={bottomNavContent}
     />

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -69,9 +69,16 @@ const SCOPED_STYLES = `
 
 .tp-trips-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  /* Mobile default: 2 columns (per user spec). Desktop overrides to 3
+   * columns below. Cards shrink/grow to fit available main width. */
+  grid-template-columns: repeat(2, 1fr);
   gap: 16px;
   margin-top: 24px;
+}
+@media (min-width: 1024px) {
+  .tp-trips-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 .tp-trip-card {
   background: var(--color-background);


### PR DESCRIPTION
## Summary

Five issues from user /design-review feedback fixed in one PR.

| # | Issue | Fix |
|---|-------|-----|
| 1 | Stop click 桌機沒反應 | `<TripIdContext>` so embedded TimelineEvent/DaySection/TimelineRail get tripId |
| 2 | 桌機 day nav 不對應 | Day-strip CSS unified — desktop now uses mobile pill style (1px border + filled-accent active + 44px min) |
| 3 | 手機點天數沒 anchor | `scrollIntoView` instead of `window.scrollTo` (works in any scroll container) |
| 4 | 手機 scroll 沒切換 day | Listener attached to scroll container (`.app-shell-main`), not window |
| 5 | 桌機 3xN / 手機 2xN 卡片 | `.tp-trips-grid` explicit `repeat(2, 1fr)` mobile, `repeat(3, 1fr)` ≥1024px |

## Architecture note

`<TripIdContext>` is intentionally minimal (just the resolved tripId
string). TripContext exists for the heavy useTrip return shared between
TripPage + StopDetailPage; this new context is for descendant components
that only need tripId without paying for the full trip data.

`useTripId()` prefers context (embedded mode at /trips?selected=) over
URL params (route mode at /trip/:tripId/stop/:eid). Both work.

## Tests
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npx vitest run` → 996/996 pass
- [ ] CF Pages preview deploy
- [ ] Mobile prod canary: tap card → /trips?selected= → tap day chip → scrolls to day section; scroll naturally → active day updates
- [ ] Desktop prod canary: cards in 3-col grid; click stop in sheet → opens StopDetailPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)