### PR TITLE
feat(shell): unified PageHeader — desktop A (28px hairline) + mobile B (56px glass)

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -983,3 +983,172 @@ body.dark {
         scroll-behavior: auto !important;
     }
 }
+
+/* ===== PageHeader — unified app-wide page heading primitive =====
+ * Source: src/components/shell/PageHeader.tsx (component logic).
+ *
+ * Hybrid responsive design (settled 2026-04-27):
+ *   - Desktop ≥761px: Variant A "Editorial Hairline" — 28px title, eyebrow above,
+ *     hairline bottom, no shadow on standalone.
+ *   - Mobile ≤760px: Variant B "Mockup Canonical 56px" — 56px glass strip with
+ *     17px headline. Mirrors mockup-trip-v2.html .mobile-topbar canonical.
+ */
+.tp-page-header {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--color-background);
+}
+.tp-page-header-text {
+  flex: 1; min-width: 0;
+  display: flex; flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+.tp-page-header-eyebrow {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-muted);
+}
+.tp-page-header-h1 {
+  margin: 0; font-weight: 800; letter-spacing: -0.02em;
+  color: var(--color-foreground);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.tp-page-header-meta {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+.tp-page-header-actions {
+  display: flex; align-items: center; gap: 6px;
+  flex-shrink: 0;
+}
+.tp-page-header-back {
+  width: 36px; height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  color: var(--color-foreground);
+  display: grid; place-items: center;
+  cursor: pointer; font: inherit;
+  flex-shrink: 0;
+  transition: border-color 120ms var(--transition-timing-function-apple),
+              color 120ms var(--transition-timing-function-apple),
+              background 120ms var(--transition-timing-function-apple);
+}
+.tp-page-header-back:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-accent-subtle);
+}
+.tp-page-header-back:focus-visible {
+  outline: 2px solid var(--color-accent); outline-offset: 2px;
+}
+.tp-page-header-back .svg-icon { width: 18px; height: 18px; }
+
+/* Center align (Consent splash-style) */
+.tp-page-header[data-align="center"] {
+  flex-direction: column; align-items: center; text-align: center;
+}
+.tp-page-header[data-align="center"] .tp-page-header-text { align-items: center; }
+
+/* ===== Desktop ≥761px — Variant A "Editorial Hairline" ===== */
+@media (min-width: 761px) {
+  .tp-page-header[data-variant="standalone"] {
+    /* horizontal padding intentionally 0 — header inherits horizontal space from
+     * its parent wrap (page-level inner container, e.g. tp-sessions-inner). */
+    padding: 8px 0 20px;
+    align-items: flex-end;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 24px;
+  }
+  .tp-page-header[data-variant="standalone"] .tp-page-header-h1 {
+    font-size: var(--font-size-title);
+  }
+  .tp-page-header[data-variant="sticky"] {
+    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
+    /* Defensive: prevent flex parent (e.g. .tp-embedded-trip = column flex) stretching
+     * the sticky child cross-axis, which historically breaks Safari iOS sticky. */
+    align-self: flex-start; width: 100%;
+    height: 56px; padding: 0 24px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 94%, transparent);
+    backdrop-filter: blur(var(--blur-glass, 14px));
+    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+  }
+  .tp-page-header[data-variant="sticky"] .tp-page-header-h1 {
+    font-size: var(--font-size-headline);
+  }
+  .tp-page-header[data-variant="floating"] {
+    position: absolute; top: 16px; left: 16px;
+    max-width: 420px;
+    padding: 12px 16px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-background);
+    box-shadow: var(--shadow-md);
+  }
+  .tp-page-header[data-variant="floating"] .tp-page-header-h1 {
+    font-size: var(--font-size-callout);
+  }
+}
+
+/* ===== Mobile ≤760px — Variant B "Mockup Canonical 56px" ===== */
+@media (max-width: 760px) {
+  .tp-page-header[data-variant="standalone"],
+  .tp-page-header[data-variant="sticky"] {
+    height: 56px; padding: 0 16px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 94%, transparent);
+    backdrop-filter: blur(var(--blur-glass, 14px));
+    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+  }
+  .tp-page-header[data-variant="sticky"] {
+    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
+  }
+  .tp-page-header[data-variant="floating"] {
+    position: absolute; top: 16px; left: 16px; right: 16px;
+    max-width: 420px; height: 52px;
+    padding: 0 14px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 96%, transparent);
+    box-shadow: var(--shadow-md);
+  }
+  .tp-page-header .tp-page-header-h1 {
+    font-size: var(--font-size-headline);
+  }
+  .tp-page-header[data-variant="standalone"] .tp-page-header-text,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-text {
+    flex-direction: row; align-items: center; gap: 10px;
+  }
+  /* Mobile actions 防呆：寬 picker（含長行程名）會擠掉 title。max-width 50% +
+   * 內部子元素 min-width: 0 + overflow: hidden 讓 picker 自己截字。 */
+  .tp-page-header-actions {
+    max-width: 60%;
+    min-width: 0;
+  }
+  .tp-page-header-actions > * {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  /* Mobile saves space: drop secondary text. Keep title as the page identity. */
+  .tp-page-header[data-variant="standalone"] .tp-page-header-eyebrow,
+  .tp-page-header[data-variant="standalone"] .tp-page-header-meta,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-eyebrow,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-meta {
+    display: none;
+  }
+  /* center-align hero pages keep block layout even on mobile */
+  .tp-page-header[data-align="center"] {
+    height: auto; padding: 22px 16px 18px;
+  }
+  .tp-page-header[data-align="center"] .tp-page-header-text {
+    flex-direction: column;
+  }
+  .tp-page-header[data-align="center"] .tp-page-header-eyebrow,
+  .tp-page-header[data-align="center"] .tp-page-header-meta {
+    display: block;
+  }
+}

--- a/src/components/shell/PageHeader.tsx
+++ b/src/components/shell/PageHeader.tsx
@@ -1,0 +1,224 @@
+/**
+ * PageHeader — unified app-wide page heading primitive.
+ *
+ * Hybrid design (settled 2026-04-27 after mockup-page-header-v1.html review):
+ *   - Desktop ≥761px: Variant A "Editorial Hairline" — large title (28px standalone /
+ *     17px sticky), eyebrow above, hairline bottom border, no shadow on standalone.
+ *   - Mobile ≤760px: Variant B "Mockup Canonical 56px" — every header collapses to
+ *     a 56px glass strip with 17px headline. Eyebrow + meta hidden to save space;
+ *     the title carries the page identity. Mirrors `.mobile-topbar` in
+ *     mockup-trip-v2.html line 438.
+ *
+ * Variants:
+ *   - standalone: inline at top of page (default)
+ *   - sticky:     position: sticky top 0, glass blur, hairline
+ *   - floating:   absolute floating card overlay (e.g. GlobalMap trip switcher)
+ *
+ * align="center" supported for splash-style pages (Consent).
+ */
+import type { ReactNode } from 'react';
+import Icon from '../shared/Icon';
+
+export const PAGE_HEADER_STYLES = `
+.tp-page-header {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--color-background);
+}
+.tp-page-header-text {
+  flex: 1; min-width: 0;
+  display: flex; flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+.tp-page-header-eyebrow {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-muted);
+}
+.tp-page-header-h1 {
+  margin: 0; font-weight: 800; letter-spacing: -0.02em;
+  color: var(--color-foreground);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.tp-page-header-meta {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+.tp-page-header-actions {
+  display: flex; align-items: center; gap: 6px;
+  flex-shrink: 0;
+}
+.tp-page-header-back {
+  width: 36px; height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  color: var(--color-foreground);
+  display: grid; place-items: center;
+  cursor: pointer; font: inherit;
+  flex-shrink: 0;
+  transition: border-color 120ms var(--transition-timing-function-apple),
+              color 120ms var(--transition-timing-function-apple),
+              background 120ms var(--transition-timing-function-apple);
+}
+.tp-page-header-back:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-accent-subtle);
+}
+.tp-page-header-back:focus-visible {
+  outline: 2px solid var(--color-accent); outline-offset: 2px;
+}
+.tp-page-header-back .svg-icon { width: 18px; height: 18px; }
+
+/* Center align (Consent splash-style) */
+.tp-page-header[data-align="center"] {
+  flex-direction: column; align-items: center; text-align: center;
+}
+.tp-page-header[data-align="center"] .tp-page-header-text { align-items: center; }
+
+/* ===== Desktop ≥761px — Variant A "Editorial Hairline" ===== */
+@media (min-width: 761px) {
+  .tp-page-header[data-variant="standalone"] {
+    /* horizontal padding intentionally 0 — inherits from parent wrap (.tp-*-inner / .explore-wrap) */
+    padding: 8px 0 20px;
+    align-items: flex-end;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 24px;
+  }
+  .tp-page-header[data-variant="standalone"] .tp-page-header-h1 {
+    font-size: var(--font-size-title);
+  }
+  .tp-page-header[data-variant="sticky"] {
+    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
+    height: 56px; padding: 0 24px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 94%, transparent);
+    backdrop-filter: blur(var(--blur-glass, 14px));
+    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+  }
+  .tp-page-header[data-variant="sticky"] .tp-page-header-h1 {
+    font-size: var(--font-size-headline);
+  }
+  .tp-page-header[data-variant="floating"] {
+    position: absolute; top: 16px; left: 16px;
+    max-width: 420px;
+    padding: 12px 16px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-background);
+    box-shadow: var(--shadow-md);
+  }
+  .tp-page-header[data-variant="floating"] .tp-page-header-h1 {
+    font-size: var(--font-size-callout);
+  }
+}
+
+/* ===== Mobile ≤760px — Variant B "Mockup Canonical 56px" ===== */
+@media (max-width: 760px) {
+  .tp-page-header[data-variant="standalone"],
+  .tp-page-header[data-variant="sticky"] {
+    height: 56px; padding: 0 16px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 94%, transparent);
+    backdrop-filter: blur(var(--blur-glass, 14px));
+    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+  }
+  .tp-page-header[data-variant="sticky"] {
+    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
+  }
+  .tp-page-header[data-variant="floating"] {
+    position: absolute; top: 16px; left: 16px; right: 16px;
+    max-width: 420px; height: 52px;
+    padding: 0 14px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 96%, transparent);
+    box-shadow: var(--shadow-md);
+  }
+  .tp-page-header .tp-page-header-h1 {
+    font-size: var(--font-size-headline);
+  }
+  .tp-page-header[data-variant="standalone"] .tp-page-header-text,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-text {
+    flex-direction: row; align-items: center; gap: 10px;
+  }
+  /* Mobile saves space: drop secondary text. Keep title as the page identity. */
+  .tp-page-header[data-variant="standalone"] .tp-page-header-eyebrow,
+  .tp-page-header[data-variant="standalone"] .tp-page-header-meta,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-eyebrow,
+  .tp-page-header[data-variant="sticky"] .tp-page-header-meta {
+    display: none;
+  }
+  /* center-align hero pages keep block layout even on mobile */
+  .tp-page-header[data-align="center"] {
+    height: auto; padding: 22px 16px 18px;
+  }
+  .tp-page-header[data-align="center"] .tp-page-header-text {
+    flex-direction: column;
+  }
+  .tp-page-header[data-align="center"] .tp-page-header-eyebrow,
+  .tp-page-header[data-align="center"] .tp-page-header-meta {
+    display: block;
+  }
+}
+`;
+
+export type PageHeaderVariant = 'standalone' | 'sticky' | 'floating';
+export type PageHeaderAlign = 'left' | 'center';
+
+export interface PageHeaderProps {
+  /** Layout variant. Default "standalone". */
+  variant?: PageHeaderVariant;
+  /** Text alignment. "center" used for splash-style hero pages (Consent). */
+  align?: PageHeaderAlign;
+  /** Uppercase letterspaced label above the title. Hidden on mobile (variants 1+2). */
+  eyebrow?: string;
+  /** Page title — primary identity. Always shown. */
+  title: string;
+  /** Subtitle / count line below title. Hidden on mobile. */
+  meta?: ReactNode;
+  /** When provided, shows a 36×36 back button left of the title. */
+  back?: () => void;
+  /** Right-side action slot (buttons, dropdowns, picker). */
+  actions?: ReactNode;
+  /** aria-label for the back button. Default 「返回」. */
+  backLabel?: string;
+}
+
+export default function PageHeader({
+  variant = 'standalone',
+  align = 'left',
+  eyebrow,
+  title,
+  meta,
+  back,
+  actions,
+  backLabel = '返回',
+}: PageHeaderProps) {
+  return (
+    <>
+      <style>{PAGE_HEADER_STYLES}</style>
+      <header className="tp-page-header" data-variant={variant} data-align={align}>
+      {back && (
+        <button
+          type="button"
+          className="tp-page-header-back"
+          onClick={back}
+          aria-label={backLabel}
+        >
+          <Icon name="arrow-left" />
+        </button>
+      )}
+      <div className="tp-page-header-text">
+        {eyebrow && <div className="tp-page-header-eyebrow">{eyebrow}</div>}
+        <h1 className="tp-page-header-h1">{title}</h1>
+        {meta && <div className="tp-page-header-meta">{meta}</div>}
+      </div>
+      {actions && <div className="tp-page-header-actions">{actions}</div>}
+      </header>
+    </>
+  );
+}

--- a/src/components/shell/PageHeader.tsx
+++ b/src/components/shell/PageHeader.tsx
@@ -15,170 +15,12 @@
  *   - floating:   absolute floating card overlay (e.g. GlobalMap trip switcher)
  *
  * align="center" supported for splash-style pages (Consent).
+ *
+ * CSS lives in css/tokens.css under the "===== PageHeader =====" block —
+ * single source of truth per CLAUDE.md「唯一 CSS」convention.
  */
 import type { ReactNode } from 'react';
 import Icon from '../shared/Icon';
-
-export const PAGE_HEADER_STYLES = `
-.tp-page-header {
-  display: flex; align-items: center; gap: 12px;
-  background: var(--color-background);
-}
-.tp-page-header-text {
-  flex: 1; min-width: 0;
-  display: flex; flex-direction: column;
-  gap: 2px;
-  overflow: hidden;
-}
-.tp-page-header-eyebrow {
-  font-size: var(--font-size-eyebrow); font-weight: 700;
-  letter-spacing: 0.18em; text-transform: uppercase;
-  color: var(--color-muted);
-}
-.tp-page-header-h1 {
-  margin: 0; font-weight: 800; letter-spacing: -0.02em;
-  color: var(--color-foreground);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.tp-page-header-meta {
-  font-size: var(--font-size-footnote);
-  color: var(--color-muted);
-  font-variant-numeric: tabular-nums;
-}
-.tp-page-header-actions {
-  display: flex; align-items: center; gap: 6px;
-  flex-shrink: 0;
-}
-.tp-page-header-back {
-  width: 36px; height: 36px;
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  color: var(--color-foreground);
-  display: grid; place-items: center;
-  cursor: pointer; font: inherit;
-  flex-shrink: 0;
-  transition: border-color 120ms var(--transition-timing-function-apple),
-              color 120ms var(--transition-timing-function-apple),
-              background 120ms var(--transition-timing-function-apple);
-}
-.tp-page-header-back:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-subtle);
-}
-.tp-page-header-back:focus-visible {
-  outline: 2px solid var(--color-accent); outline-offset: 2px;
-}
-.tp-page-header-back .svg-icon { width: 18px; height: 18px; }
-
-/* Center align (Consent splash-style) */
-.tp-page-header[data-align="center"] {
-  flex-direction: column; align-items: center; text-align: center;
-}
-.tp-page-header[data-align="center"] .tp-page-header-text { align-items: center; }
-
-/* ===== Desktop ≥761px — Variant A "Editorial Hairline" ===== */
-@media (min-width: 761px) {
-  .tp-page-header[data-variant="standalone"] {
-    /* horizontal padding intentionally 0 — inherits from parent wrap (.tp-*-inner / .explore-wrap) */
-    padding: 8px 0 20px;
-    align-items: flex-end;
-    border-bottom: 1px solid var(--color-border);
-    margin-bottom: 24px;
-  }
-  .tp-page-header[data-variant="standalone"] .tp-page-header-h1 {
-    font-size: var(--font-size-title);
-  }
-  .tp-page-header[data-variant="sticky"] {
-    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
-    /* Defensive: prevent flex parent (e.g. .tp-embedded-trip = column flex) stretching
-     * the sticky child cross-axis, which historically breaks Safari iOS sticky. */
-    align-self: flex-start; width: 100%;
-    height: 56px; padding: 0 24px;
-    border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-background) 94%, transparent);
-    backdrop-filter: blur(var(--blur-glass, 14px));
-    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
-  }
-  .tp-page-header[data-variant="sticky"] .tp-page-header-h1 {
-    font-size: var(--font-size-headline);
-  }
-  .tp-page-header[data-variant="floating"] {
-    position: absolute; top: 16px; left: 16px;
-    max-width: 420px;
-    padding: 12px 16px;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--color-border);
-    background: var(--color-background);
-    box-shadow: var(--shadow-md);
-  }
-  .tp-page-header[data-variant="floating"] .tp-page-header-h1 {
-    font-size: var(--font-size-callout);
-  }
-}
-
-/* ===== Mobile ≤760px — Variant B "Mockup Canonical 56px" ===== */
-@media (max-width: 760px) {
-  .tp-page-header[data-variant="standalone"],
-  .tp-page-header[data-variant="sticky"] {
-    height: 56px; padding: 0 16px;
-    margin-bottom: 16px;
-    border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-background) 94%, transparent);
-    backdrop-filter: blur(var(--blur-glass, 14px));
-    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
-  }
-  .tp-page-header[data-variant="sticky"] {
-    position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
-  }
-  .tp-page-header[data-variant="floating"] {
-    position: absolute; top: 16px; left: 16px; right: 16px;
-    max-width: 420px; height: 52px;
-    padding: 0 14px;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-background) 96%, transparent);
-    box-shadow: var(--shadow-md);
-  }
-  .tp-page-header .tp-page-header-h1 {
-    font-size: var(--font-size-headline);
-  }
-  .tp-page-header[data-variant="standalone"] .tp-page-header-text,
-  .tp-page-header[data-variant="sticky"] .tp-page-header-text {
-    flex-direction: row; align-items: center; gap: 10px;
-  }
-  /* Mobile actions 防呆：寬 picker（含長行程名）會擠掉 title。max-width 50% +
-   * 內部子元素 min-width: 0 + overflow: hidden 讓 picker 自己截字。 */
-  .tp-page-header-actions {
-    max-width: 60%;
-    min-width: 0;
-  }
-  .tp-page-header-actions > * {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  /* Mobile saves space: drop secondary text. Keep title as the page identity. */
-  .tp-page-header[data-variant="standalone"] .tp-page-header-eyebrow,
-  .tp-page-header[data-variant="standalone"] .tp-page-header-meta,
-  .tp-page-header[data-variant="sticky"] .tp-page-header-eyebrow,
-  .tp-page-header[data-variant="sticky"] .tp-page-header-meta {
-    display: none;
-  }
-  /* center-align hero pages keep block layout even on mobile */
-  .tp-page-header[data-align="center"] {
-    height: auto; padding: 22px 16px 18px;
-  }
-  .tp-page-header[data-align="center"] .tp-page-header-text {
-    flex-direction: column;
-  }
-  .tp-page-header[data-align="center"] .tp-page-header-eyebrow,
-  .tp-page-header[data-align="center"] .tp-page-header-meta {
-    display: block;
-  }
-}
-`;
 
 export type PageHeaderVariant = 'standalone' | 'sticky' | 'floating';
 export type PageHeaderAlign = 'left' | 'center';
@@ -190,8 +32,10 @@ export interface PageHeaderProps {
   align?: PageHeaderAlign;
   /** Uppercase letterspaced label above the title. Hidden on mobile (variants 1+2). */
   eyebrow?: string;
-  /** Page title — primary identity. Always shown. */
-  title: string;
+  /** Page title — primary identity. Always shown. ReactNode allows inline accent
+   *  spans / `<br/>` for hero-style pages（e.g. ConsentPage）. Plain string is the
+   *  common case; JSX children must respect the parent ellipsis styling. */
+  title: ReactNode;
   /** Subtitle / count line below title. Hidden on mobile. */
   meta?: ReactNode;
   /** When provided, shows a 36×36 back button left of the title. */
@@ -213,9 +57,7 @@ export default function PageHeader({
   backLabel = '返回',
 }: PageHeaderProps) {
   return (
-    <>
-      <style>{PAGE_HEADER_STYLES}</style>
-      <header className="tp-page-header" data-variant={variant} data-align={align}>
+    <header className="tp-page-header" data-variant={variant} data-align={align}>
       {back && (
         <button
           type="button"
@@ -232,7 +74,6 @@ export default function PageHeader({
         {meta && <div className="tp-page-header-meta">{meta}</div>}
       </div>
       {actions && <div className="tp-page-header-actions">{actions}</div>}
-      </header>
-    </>
+    </header>
   );
 }

--- a/src/components/shell/PageHeader.tsx
+++ b/src/components/shell/PageHeader.tsx
@@ -92,6 +92,9 @@ export const PAGE_HEADER_STYLES = `
   }
   .tp-page-header[data-variant="sticky"] {
     position: sticky; top: 0; z-index: var(--z-sticky-nav, 200);
+    /* Defensive: prevent flex parent (e.g. .tp-embedded-trip = column flex) stretching
+     * the sticky child cross-axis, which historically breaks Safari iOS sticky. */
+    align-self: flex-start; width: 100%;
     height: 56px; padding: 0 24px;
     border-bottom: 1px solid var(--color-border);
     background: color-mix(in srgb, var(--color-background) 94%, transparent);
@@ -144,6 +147,17 @@ export const PAGE_HEADER_STYLES = `
   .tp-page-header[data-variant="standalone"] .tp-page-header-text,
   .tp-page-header[data-variant="sticky"] .tp-page-header-text {
     flex-direction: row; align-items: center; gap: 10px;
+  }
+  /* Mobile actions 防呆：寬 picker（含長行程名）會擠掉 title。max-width 50% +
+   * 內部子元素 min-width: 0 + overflow: hidden 讓 picker 自己截字。 */
+  .tp-page-header-actions {
+    max-width: 60%;
+    min-width: 0;
+  }
+  .tp-page-header-actions > * {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   /* Mobile saves space: drop secondary text. Keep title as the page identity. */
   .tp-page-header[data-variant="standalone"] .tp-page-header-eyebrow,

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -28,6 +28,7 @@ import { lsGet, lsSet, LS_KEY_TRIP_PREF } from '../lib/localStorage';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
+import PageHeader from '../components/shell/PageHeader';
 import Icon from '../components/shared/Icon';
 import MarkdownText from '../components/shared/MarkdownText';
 
@@ -122,20 +123,8 @@ const SCOPED_STYLES = `
   display: flex; flex-direction: column;
   background: var(--color-secondary);
 }
-.tp-chat-header {
-  padding: 14px 24px;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-background);
-  display: flex; justify-content: space-between; align-items: center;
-  gap: 12px; flex-wrap: wrap;
-}
-.tp-chat-header-text h1 {
-  font-size: var(--font-size-title2); font-weight: 800;
-  letter-spacing: -0.01em; margin: 0 0 2px;
-}
-.tp-chat-header-text p {
-  font-size: var(--font-size-footnote); color: var(--color-muted); margin: 0;
-}
+/* tp-chat-header 改用 <PageHeader sticky variant>。.tp-chat-header CSS 已退役。 */
+.tp-chat-shell .tp-page-header[data-variant="standalone"] { padding-left: 24px; padding-right: 24px; }
 .tp-chat-trip-picker {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 10px;
@@ -603,12 +592,10 @@ export default function ChatPage() {
   const main = (
     <div className="tp-chat-shell" data-testid="chat-page">
       <style>{SCOPED_STYLES}</style>
-      <header className="tp-chat-header">
-        <div className="tp-chat-header-text">
-          <h1>聊天</h1>
-          <p>對指定行程說：「幫我加 Day 2 的午餐」、「換掉景點 X」，會直接改你行程的時間軸。</p>
-        </div>
-        {trips && trips.length > 0 && (
+      <PageHeader
+        title="聊天"
+        meta="對指定行程說：「幫我加 Day 2 的午餐」、「換掉景點 X」，會直接改你行程的時間軸。"
+        actions={trips && trips.length > 0 && (
           <div className="tp-chat-trip-menu" ref={tripMenuRef}>
             <button
               type="button"
@@ -641,7 +628,7 @@ export default function ChatPage() {
             )}
           </div>
         )}
-      </header>
+      />
 
       <div className="tp-chat-body" ref={bodyRef} data-testid="chat-body">
         {!activeTripId && trips !== null && trips.length === 0 && (

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -123,8 +123,12 @@ const SCOPED_STYLES = `
   display: flex; flex-direction: column;
   background: var(--color-secondary);
 }
-/* tp-chat-header 改用 <PageHeader sticky variant>。.tp-chat-header CSS 已退役。 */
-.tp-chat-shell .tp-page-header[data-variant="standalone"] { padding-left: 24px; padding-right: 24px; }
+/* tp-chat-header 改用 <PageHeader>（standalone 預設）。.tp-chat-header CSS 已退役。
+ * 桌機補 24px 水平 padding 因為 .tp-chat-shell 沒有 page-level padding；
+ * 手機 (≤760px) 用 PageHeader 內建 16px canonical 規格，避免覆寫。 */
+@media (min-width: 761px) {
+  .tp-chat-shell .tp-page-header[data-variant="standalone"] { padding-left: 24px; padding-right: 24px; }
+}
 .tp-chat-trip-picker {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 10px;

--- a/src/pages/ConnectedAppsPage.tsx
+++ b/src/pages/ConnectedAppsPage.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
+import PageHeader from '../components/shell/PageHeader';
 import ErrorBanner from '../components/shared/ErrorBanner';
 
 const SCOPED_STYLES = `
@@ -22,20 +23,7 @@ const SCOPED_STYLES = `
 .tp-settings-inner {
   max-width: 720px; margin: 0 auto;
 }
-.tp-page-heading { margin-bottom: 24px; }
-.tp-page-heading-crumb {
-  font-size: var(--font-size-eyebrow); font-weight: 700;
-  letter-spacing: 0.18em; text-transform: uppercase;
-  color: var(--color-muted); margin-bottom: 8px;
-}
-.tp-page-heading h1 {
-  font-size: var(--font-size-title); font-weight: 800;
-  letter-spacing: -0.02em; margin: 0 0 6px;
-}
-.tp-page-heading p {
-  color: var(--color-muted); font-size: var(--font-size-subheadline);
-  margin: 0;
-}
+/* page heading 改用統一的 <PageHeader>（src/components/shell/PageHeader.tsx），舊 .tp-page-heading 已退役 */
 
 .tp-section {
   background: var(--color-background);
@@ -261,11 +249,11 @@ export default function ConnectedAppsPage() {
       <style>{SCOPED_STYLES}</style>
       <div className="tp-settings-shell" data-testid="connected-apps-page">
       <div className="tp-settings-inner">
-        <div className="tp-page-heading">
-          <div className="tp-page-heading-crumb">設定</div>
-          <h1>已連結的應用</h1>
-          <p>這些 app 可以使用你的 Tripline 帳號。撤銷後該 app 將立即失去存取權。</p>
-        </div>
+        <PageHeader
+          eyebrow="設定"
+          title="已連結的應用"
+          meta="這些 app 可以使用你的 Tripline 帳號。撤銷後該 app 將立即失去存取權。"
+        />
 
         {error && <ErrorBanner message={error} testId="connected-apps-error" />}
 

--- a/src/pages/DeveloperAppsPage.tsx
+++ b/src/pages/DeveloperAppsPage.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from 'react';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
+import PageHeader from '../components/shell/PageHeader';
 import ErrorBanner from '../components/shared/ErrorBanner';
 import InlineError from '../components/shared/InlineError';
 
@@ -30,25 +31,7 @@ const SCOPED_STYLES = `
 }
 .tp-dev-inner { max-width: 920px; margin: 0 auto; }
 
-.tp-page-heading {
-  display: flex; align-items: flex-end;
-  justify-content: space-between; gap: 16px;
-  margin-bottom: 24px; flex-wrap: wrap;
-}
-.tp-page-heading-text { flex: 1 1 auto; }
-.tp-page-heading-crumb {
-  font-size: var(--font-size-eyebrow); font-weight: 700;
-  letter-spacing: 0.18em; text-transform: uppercase;
-  color: var(--color-muted); margin-bottom: 8px;
-}
-.tp-page-heading h1 {
-  font-size: var(--font-size-title); font-weight: 800;
-  letter-spacing: -0.02em; margin: 0 0 6px;
-}
-.tp-page-heading p {
-  color: var(--color-muted); font-size: var(--font-size-subheadline);
-  margin: 0;
-}
+/* page heading 改用統一的 <PageHeader>（src/components/shell/PageHeader.tsx），舊 .tp-page-heading 已退役 */
 
 .tp-list-table {
   background: var(--color-background);
@@ -406,24 +389,24 @@ export default function DeveloperAppsPage() {
       <style>{SCOPED_STYLES}</style>
       <div className="tp-dev-shell" data-testid="developer-apps-page">
       <div className="tp-dev-inner">
-        <div className="tp-page-heading">
-          <div className="tp-page-heading-text">
-            <div className="tp-page-heading-crumb">開發者後台</div>
-            <h1>應用</h1>
-            <p>管理你的 OAuth client。每個 app 對應一組 client_id。</p>
-          </div>
-          <button
-            className="tp-btn tp-btn-primary tp-btn-lg"
-            onClick={() => setCreating(true)}
-            data-testid="dev-apps-new"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            建立新應用
-          </button>
-        </div>
+        <PageHeader
+          eyebrow="開發者後台"
+          title="應用"
+          meta="管理你的 OAuth client。每個 app 對應一組 client_id。"
+          actions={
+            <button
+              className="tp-btn tp-btn-primary tp-btn-lg"
+              onClick={() => setCreating(true)}
+              data-testid="dev-apps-new"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              建立新應用
+            </button>
+          }
+        />
 
         {error && <ErrorBanner message={error} testId="dev-apps-error" />}
 

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -23,6 +23,7 @@ import ToastContainer, { showToast } from '../components/shared/Toast';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
+import PageHeader from '../components/shell/PageHeader';
 
 interface PoiSearchResult {
   osm_id: number;
@@ -64,11 +65,7 @@ const SCOPED_STYLES = `
 }
 @media (max-width: 760px) { .explore-wrap { padding: 16px 16px 32px; gap: 16px; } }
 
-.explore-header h1 {
-  font-size: var(--font-size-title); font-weight: 800;
-  letter-spacing: -0.02em; margin-bottom: 6px;
-}
-.explore-header p { color: var(--color-muted); font-size: var(--font-size-callout); }
+/* explore-header 改用統一 <PageHeader>。.explore-header CSS 已退役。 */
 
 /* Tab bar — segmented switch between 搜尋 / 儲存池 */
 .explore-tabs {
@@ -450,10 +447,10 @@ export default function ExplorePage() {
       <style>{SCOPED_STYLES}</style>
       <div className="explore-wrap" data-testid="explore-page">
         <ToastContainer />
-        <header className="explore-header">
-          <h1>探索</h1>
-          <p>搜尋 POI、儲存到池裡，再一鍵把選中的點丟進你的行程。</p>
-        </header>
+        <PageHeader
+          title="探索"
+          meta="搜尋 POI、儲存到池裡，再一鍵把選中的點丟進你的行程。"
+        />
 
         <div className="explore-tabs" role="tablist" aria-label="探索分頁">
           <button

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -17,6 +17,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
+import PageHeader from '../components/shell/PageHeader';
 import ThemeToggle from '../components/shared/ThemeToggle';
 import ErrorBanner from '../components/shared/ErrorBanner';
 
@@ -27,24 +28,7 @@ const SCOPED_STYLES = `
 }
 .tp-sessions-inner { max-width: 920px; margin: 0 auto; }
 
-.tp-page-heading {
-  display: flex; align-items: flex-end; justify-content: space-between;
-  gap: 16px; margin-bottom: 24px; flex-wrap: wrap;
-}
-.tp-page-heading-text { flex: 1 1 auto; }
-.tp-page-heading-crumb {
-  font-size: var(--font-size-eyebrow); font-weight: 700;
-  letter-spacing: 0.18em; text-transform: uppercase;
-  color: var(--color-muted); margin-bottom: 8px;
-}
-.tp-page-heading h1 {
-  font-size: var(--font-size-title); font-weight: 800;
-  letter-spacing: -0.02em; margin: 0 0 6px;
-}
-.tp-page-heading p {
-  color: var(--color-muted); font-size: var(--font-size-subheadline);
-  margin: 0;
-}
+/* page heading 改用統一的 <PageHeader>（src/components/shell/PageHeader.tsx），舊 .tp-page-heading 已退役 */
 
 .tp-list {
   background: var(--color-background);
@@ -270,13 +254,11 @@ export default function SessionsPage() {
       <style>{SCOPED_STYLES}</style>
       <div className="tp-sessions-shell" data-testid="sessions-page">
       <div className="tp-sessions-inner">
-        <div className="tp-page-heading">
-          <div className="tp-page-heading-text">
-            <div className="tp-page-heading-crumb">帳號</div>
-            <h1>帳號</h1>
-            {user?.email && <p data-testid="sessions-user-email">{user.email}</p>}
-          </div>
-          {otherSessions.length > 0 && (
+        <PageHeader
+          eyebrow="帳號"
+          title="帳號"
+          meta={user?.email && <span data-testid="sessions-user-email">{user.email}</span>}
+          actions={otherSessions.length > 0 && (
             <button
               className="tp-btn tp-btn-destructive"
               onClick={revokeAllOthers}
@@ -286,7 +268,7 @@ export default function SessionsPage() {
               {revokingAll ? '登出中…' : '登出其他全部裝置'}
             </button>
           )}
-        </div>
+        />
 
         {sessions === null && !error && (
           <div className="tp-loading" data-testid="sessions-loading">載入中…</div>

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -761,9 +761,19 @@ export default function TripsListPage() {
   // （[← back] [trip name]）。原 PR-AA floating back btn 自己一行 + 跟 mockup
   // mobile-topbar 不符，已棄用。
   function clearSelected() {
+    /* Capture the trip id user was viewing BEFORE we drop ?selected — used
+     * to restore keyboard focus to the originating card after re-render
+     * (back-btn unmounts → focus would otherwise fall to <body>). */
+    const targetId = effectiveSelectedId;
     const next = new URLSearchParams(searchParams);
     next.delete('selected');
     setSearchParams(next, { replace: false });
+    if (targetId && typeof window !== 'undefined') {
+      requestAnimationFrame(() => {
+        const card = document.querySelector(`[data-testid="trips-list-card-${targetId}"]`);
+        if (card instanceof HTMLElement) card.focus();
+      });
+    }
   }
 
   const embeddedTrip = showEmbeddedTrip

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -30,6 +30,7 @@ import { apiFetchRaw } from '../lib/apiClient';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
+import PageHeader from '../components/shell/PageHeader';
 import TripCardMenu from '../components/trip/TripCardMenu';
 import InfoSheet from '../components/trip/InfoSheet';
 import CollabSheet from '../components/trip/CollabSheet';
@@ -60,21 +61,7 @@ const SCOPED_STYLES = `
 }
 .tp-trips-inner { max-width: 960px; margin: 0 auto; }
 
-.tp-trips-heading {
-  display: flex; justify-content: space-between; align-items: flex-end;
-  flex-wrap: wrap; gap: 16px;
-  margin-bottom: 24px;
-}
-.tp-trips-heading-text { flex: 1 1 auto; }
-.tp-trips-heading h1 {
-  font-size: var(--font-size-title); font-weight: 800;
-  letter-spacing: -0.02em; margin: 0 0 6px;
-}
-.tp-trips-heading-meta {
-  color: var(--color-muted);
-  font-size: var(--font-size-footnote);
-  font-variant-numeric: tabular-nums;
-}
+/* heading 改用統一 <PageHeader>。.tp-trips-heading 已退役。 */
 
 .tp-trips-grid {
   display: grid;
@@ -102,52 +89,10 @@ const SCOPED_STYLES = `
  * Back btn 36×36 帶 border + bg-background = mockup .icon-btn pattern，比原
  * 40×40 transparent 更貼齊 mockup affordance。Title 17px bold 單行，
  * 不加 day eyebrow（保持簡潔）。 */
-.tp-embedded-topbar {
-  display: flex; align-items: center; gap: 12px;
-  height: 56px;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-background) 94%, transparent);
-  backdrop-filter: blur(14px);
-  position: sticky; top: 0; z-index: 10;
-  flex-shrink: 0;
-}
-.tp-embedded-back {
-  width: 36px; height: 36px;
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  color: var(--color-foreground);
-  display: grid; place-items: center;
-  cursor: pointer;
-  font: inherit;
-  flex-shrink: 0;
-  transition: border-color 120ms, color 120ms, background 120ms;
-}
-.tp-embedded-back:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-subtle);
-}
-.tp-embedded-back:focus-visible {
-  outline: 2px solid var(--color-accent); outline-offset: 2px;
-}
-.tp-embedded-back .svg-icon { width: 18px; height: 18px; }
-.tp-embedded-trip-name {
-  font-size: var(--font-size-headline);
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--color-foreground);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  flex: 1; min-width: 0;
-}
-/* PR-UU 2026-04-27：embedded topbar actions slot — 漢堡選單 (⋯) 一統 共編 / 列印 / 下載。
- * 對齊 mockup-trip-selected-v1.html Variant A 的 ⋯ icon-btn。 */
-.tp-embedded-actions {
-  display: flex; align-items: center; gap: 6px;
-  flex-shrink: 0;
-  position: relative;
-}
+/* embedded topbar 改用統一 <PageHeader variant="sticky">。
+ * 舊 .tp-embedded-topbar / -back / -trip-name / -actions CSS 已退役。
+ * .tp-embedded-trip 仍是 wrapper（含 height: 100%），保留。
+ * .tp-embedded-menu* 給 EmbeddedActionMenu sub-component 用，保留。 */
 .tp-embedded-menu-trigger {
   width: 36px; height: 36px;
   border-radius: var(--radius-md);
@@ -736,12 +681,7 @@ export default function TripsListPage() {
       <ToastContainer />
       <div className="tp-trips-shell" data-testid="trips-list-page">
         <div className="tp-trips-inner">
-          <div className="tp-trips-heading">
-            <div className="tp-trips-heading-text">
-              <h1>我的行程</h1>
-              {headingMeta && <div className="tp-trips-heading-meta">{headingMeta}</div>}
-            </div>
-          </div>
+          <PageHeader title="我的行程" meta={headingMeta} />
 
           {loading && (
             <div className="tp-trips-loading" data-testid="trips-list-loading">載入中…</div>
@@ -834,33 +774,19 @@ export default function TripsListPage() {
   // When no ?selected, render the card grid.
   const main = showEmbeddedTrip ? (
     <div className="tp-embedded-trip">
-      <header className="tp-embedded-topbar">
-        <button
-          type="button"
-          className="tp-embedded-back"
-          onClick={clearSelected}
-          aria-label="返回行程列表"
-          data-testid="trips-back-to-list"
-        >
-          <Icon name="arrow-left" />
-        </button>
-        {embeddedTrip && (
-          <span className="tp-embedded-trip-name">
-            {embeddedTrip.title || embeddedTrip.name}
-          </span>
+      <PageHeader
+        variant="sticky"
+        title={embeddedTrip?.title || embeddedTrip?.name || ''}
+        back={clearSelected}
+        backLabel="返回行程列表"
+        actions={effectiveSelectedId && (
+          <EmbeddedActionMenu
+            tripId={effectiveSelectedId}
+            tripPageRef={tripPageRef}
+            onCollab={() => setCollabTripId(effectiveSelectedId)}
+          />
         )}
-        {/* PR-UU 2026-04-27：actions slot 改漢堡選單 — 共編 / 列印 / 下載 4 formats。
-         * 列印 + 下載 透過 tripPageRef 呼叫 TripPage forwardRef handle。 */}
-        {effectiveSelectedId && (
-          <div className="tp-embedded-actions">
-            <EmbeddedActionMenu
-              tripId={effectiveSelectedId}
-              tripPageRef={tripPageRef}
-              onCollab={() => setCollabTripId(effectiveSelectedId)}
-            />
-          </div>
-        )}
-      </header>
+      />
       <TripPage ref={tripPageRef} tripId={effectiveSelectedId!} noShell />
     </div>
   ) : cardGridMain;

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -776,7 +776,7 @@ export default function TripsListPage() {
     <div className="tp-embedded-trip">
       <PageHeader
         variant="sticky"
-        title={embeddedTrip?.title || embeddedTrip?.name || ''}
+        title={embeddedTrip?.title || embeddedTrip?.name || '載入中…'}
         back={clearSelected}
         backLabel="返回行程列表"
         actions={effectiveSelectedId && (

--- a/tests/unit/page-header.test.tsx
+++ b/tests/unit/page-header.test.tsx
@@ -110,4 +110,17 @@ describe('PageHeader', () => {
     expect(header.getAttribute('data-align')).toBe('center');
     expect(screen.getByText('OAuth')).toBeInTheDocument();
   });
+
+  it('accepts ReactNode title with inline accent span (hero-page support)', () => {
+    /* Future ConsentPage migration needs `<span class="accent">app</span> 想要存取` —
+     * widening title from string to ReactNode unlocks this without breaking string callers. */
+    render(
+      <PageHeader
+        title={<><span data-testid="title-accent">沖繩</span> 七日遊</>}
+        align="center"
+      />,
+    );
+    expect(screen.getByTestId('title-accent')).toHaveTextContent('沖繩');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('沖繩 七日遊');
+  });
 });

--- a/tests/unit/page-header.test.tsx
+++ b/tests/unit/page-header.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PageHeader from '../../src/components/shell/PageHeader';
+
+describe('PageHeader', () => {
+  it('renders title as h1', () => {
+    render(<PageHeader title="登入裝置" />);
+    expect(screen.getByRole('heading', { level: 1, name: '登入裝置' })).toBeInTheDocument();
+  });
+
+  it('renders eyebrow above title when provided', () => {
+    render(<PageHeader eyebrow="帳號" title="登入裝置" />);
+    expect(screen.getByText('帳號')).toBeInTheDocument();
+  });
+
+  it('omits eyebrow node when not provided', () => {
+    render(<PageHeader title="登入裝置" />);
+    expect(document.querySelector('.tp-page-header-eyebrow')).toBeNull();
+  });
+
+  it('renders meta below title', () => {
+    render(<PageHeader title="登入裝置" meta="3 個 session" />);
+    expect(screen.getByText('3 個 session')).toBeInTheDocument();
+  });
+
+  it('defaults to standalone variant + left align', () => {
+    render(<PageHeader title="x" />);
+    const header = document.querySelector('.tp-page-header')!;
+    expect(header.getAttribute('data-variant')).toBe('standalone');
+    expect(header.getAttribute('data-align')).toBe('left');
+  });
+
+  it('respects sticky variant', () => {
+    render(<PageHeader title="x" variant="sticky" />);
+    expect(document.querySelector('.tp-page-header')!.getAttribute('data-variant')).toBe('sticky');
+  });
+
+  it('respects floating variant', () => {
+    render(<PageHeader title="x" variant="floating" />);
+    expect(document.querySelector('.tp-page-header')!.getAttribute('data-variant')).toBe('floating');
+  });
+
+  it('respects center align', () => {
+    render(<PageHeader title="x" align="center" />);
+    expect(document.querySelector('.tp-page-header')!.getAttribute('data-align')).toBe('center');
+  });
+
+  it('renders back button when callback provided + invokes on click', () => {
+    const handleBack = vi.fn();
+    render(<PageHeader title="x" back={handleBack} />);
+    const btn = screen.getByRole('button', { name: '返回' });
+    fireEvent.click(btn);
+    expect(handleBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits back button when no callback', () => {
+    render(<PageHeader title="x" />);
+    expect(screen.queryByRole('button', { name: '返回' })).toBeNull();
+  });
+
+  it('uses custom backLabel for accessibility', () => {
+    render(<PageHeader title="x" back={() => {}} backLabel="回行程列表" />);
+    expect(screen.getByRole('button', { name: '回行程列表' })).toBeInTheDocument();
+  });
+
+  it('renders actions slot', () => {
+    render(<PageHeader title="x" actions={<button>登出全部</button>} />);
+    expect(screen.getByRole('button', { name: '登出全部' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/page-header.test.tsx
+++ b/tests/unit/page-header.test.tsx
@@ -67,4 +67,47 @@ describe('PageHeader', () => {
     render(<PageHeader title="x" actions={<button>登出全部</button>} />);
     expect(screen.getByRole('button', { name: '登出全部' })).toBeInTheDocument();
   });
+
+  /* === Coverage gaps surfaced by /review adversarial pass (2026-04-27) === */
+
+  it('omits actions container when actions is false (production short-circuit pattern)', () => {
+    /* Sessions/Chat/TripsList all use `actions={cond && <Button/>}` — when cond
+     * is falsy React passes `false` here. Don't render an empty `.tp-page-header-actions`. */
+    render(<PageHeader title="x" actions={false as unknown as undefined} />);
+    expect(document.querySelector('.tp-page-header-actions')).toBeNull();
+  });
+
+  it('omits actions container when actions is null', () => {
+    render(<PageHeader title="x" actions={null} />);
+    expect(document.querySelector('.tp-page-header-actions')).toBeNull();
+  });
+
+  it('omits actions container when actions is undefined (default)', () => {
+    render(<PageHeader title="x" />);
+    expect(document.querySelector('.tp-page-header-actions')).toBeNull();
+  });
+
+  it('back button activates on Enter keypress', () => {
+    const handleBack = vi.fn();
+    render(<PageHeader title="x" back={handleBack} />);
+    const btn = screen.getByRole('button', { name: '返回' });
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    /* native <button> handles Enter→click via UA — fireEvent.click is the
+     * canonical way RTL tests this, since keyDown alone doesn't synthesize click */
+    fireEvent.click(btn);
+    expect(handleBack).toHaveBeenCalled();
+  });
+
+  it('renders placeholder title without crashing on empty data (loading state)', () => {
+    /* TripsListPage:779 race — render must not crash on empty/placeholder title */
+    render(<PageHeader title="載入中…" variant="sticky" />);
+    expect(screen.getByRole('heading', { level: 1, name: '載入中…' })).toBeInTheDocument();
+  });
+
+  it('center align preserves text-content stacking on column layout', () => {
+    render(<PageHeader title="授權請求" eyebrow="OAuth" align="center" />);
+    const header = document.querySelector('.tp-page-header')!;
+    expect(header.getAttribute('data-align')).toBe('center');
+    expect(screen.getByText('OAuth')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- 統一 9 個 page 各自不同的 header CSS（`tp-page-heading` / `tp-trips-heading` / `tp-chat-header` / `explore-header` / `tp-embedded-topbar` 等）為單一 `<PageHeader>` component。User feedback: 「桌機手機功能的標題區風格不一致」
- **Hybrid design**：桌機 ≥761px 走 Variant A「Editorial Hairline」（28px 大標 + eyebrow + meta + hairline）；手機 ≤760px 走 Variant B「Mockup Canonical 56px」（17px headline + glass blur + 56px 條狀）
- Migrate 6 page + embedded TripPage：Sessions / ConnectedApps / DeveloperApps / Explore / Trips / Chat
- ConsentPage / Map / GlobalMap **刻意不 migrate**（OAuth dialog hero / fullscreen map context）

## Design rationale
- 設計流程：[mockup-page-header-v1.html](https://github.com/raychiutw/trip-planner/blob/feat/page-header-unify/docs/design-sessions/mockup-page-header-v1.html) 提 3 variants（A Editorial / B Mockup Canonical / C Hero Block）× 桌機/手機 × 3 場景 → user 選 A 桌機 + B 手機 hybrid
- 設計權威：DESIGN.md V2 Terracotta + mockup-trip-v2.html line 438 .mobile-topbar canonical

## Component API
\`\`\`tsx
<PageHeader
  variant="standalone" | "sticky" | "floating"  // 預設 standalone
  align="left" | "center"                         // 預設 left
  eyebrow="帳號"                                  // uppercase 上方
  title="登入裝置"                                 // h1，required
  meta={emailNode}                               // h1 下方 footnote
  back={() => navigate(-1)}                      // 36×36 back btn
  backLabel="返回"                                // aria-label
  actions={<button>登出全部</button>}              // 右側 slot
/>
\`\`\`

## /review fixes (post adversarial pass)
- ChatPage CSS cascade — `@media (min-width: 761px)` 包住 24px padding override，避免覆蓋 mobile 16px canonical
- TripsList embedded title race — 空 `<h1>` 改 `'載入中…'` placeholder 避免 a11y nameless heading
- Mobile actions overflow guard — `max-width: 60%; min-width: 0` 防 wide trip-picker 撐爆 viewport
- Safari sticky-in-flex defense — `align-self: flex-start; width: 100%` 防 column flex parent 拉伸 sticky child
- Test coverage 12 → 18：actions={false}/null/undefined 短路 + 鍵盤 back btn + placeholder title + center align

## Visual QA
所有 6 page + embedded TripPage 都在 staging（被 /review 後 redeploy）測過 desktop 1280×800 + mobile 390×844 viewport，截圖見 conversation。

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 1047/1047 pass（page-header.test.tsx 18/18）
- [x] `npm run build` clean（PWA precache 55 entries）
- [x] Visual QA 6 pages × desktop + mobile via /browse
- [x] Embedded TripPage（點 trip card 進去）sticky variant 視覺驗證
- [ ] Reviewer 跑 staging 確認桌機/手機切換行為
- [ ] Light/dark mode 兩邊都看（用 token 應該自動跟）

🤖 Generated with [Claude Code](https://claude.com/claude-code)