### PR TITLE
docs(openspec): propose terracotta-mockup-parity-v2 change

### DIFF
--- a/openspec/changes/terracotta-mockup-parity-v2/.openspec.yaml
+++ b/openspec/changes/terracotta-mockup-parity-v2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/terracotta-mockup-parity-v2/design.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/design.md
@@ -1,0 +1,351 @@
+## Context
+
+`docs/design-sessions/terracotta-preview-v2.html` 是 Terracotta layout v2 的單一 source of truth：
+
+- 7,950 行 / 14 個 page section + 5 design-token reference section
+- 涵蓋全 IA：DesktopSidebar / BottomNav / NewTripModal / TripPage Detail (Desktop+Compact) / Day hero+chips+stop card / AddStopModal / TripsListPage / ChatPage / ExplorePage / AccountPage / MapPage / Error & Status surfaces
+- v2 是上版「terracotta-page-layout」spec 的 visual evolution（已 archive change `2026-04-27-terracotta-pages-refactor` 完成 1st pass）
+
+當前 React 實作已對齊 v2 大部分結構（commit `2b0dc54 refactor(shell): finalize terracotta pages refactor` 跟 archive change 是上次同步點），但累積到 2026-04-28 vs mockup 仍有 ~46 missing / 42 inconsistent / 11 extra finding。Audit 完整結果在本文件 §Audit。
+
+不對齊原因 attribution：
+- 部分 section 從 mockup 加入 v2 後 React 還沒 implement（Account hub / AddStopModal modal pattern / TripsListPage filter+search）
+- 部分是 IA divergence 由 product 推進方向不同（BottomNav 4-tab trip-scoped vs mockup 5-tab global）
+- 部分是 incremental refactor 的 leftover（emoji icon、ExplorePage POI card 結構、ChatPage 文案）
+
+## Goals / Non-Goals
+
+**Goals:**
+- 把 14 page section 全部對齊 mockup（visible regression / mockup-defined affordance 缺漏優先）
+- 不破壞既有 data / API / route（除新增 `/account` route + 可能新增 `/account/notifications`）
+- 拆 5 獨立 capability 各自獨立 ship（不互相依賴），其中 `terracotta-bottom-nav-ia-decision` 需 product decision 才解鎖
+- 本 change 全部 capability done 才 archive（跟 `ideas-drag-to-itinerary` archive 條件一致）
+- Test：每 capability 自帶 unit test；Account page 加 Playwright E2E；emoji sweep 加 source-grep contract test 防 regression
+
+**Non-Goals:**
+- 不重做 mockup 設計（mockup 是固定 reference，發現實作優於 mockup 的 case 個別 propose deviation 不在本 change 內 batch）
+- 不改 D1 schema（Account hub 用既有 user / trip / permission table；NewTripModal 多目的地拖拉用 client-side state）
+- 不重做整套 IA 架構（除 BottomNav decision 後可能調整 5-tab vs 4-tab）
+- 不 mockup section 05-09 / 15（design token / palette / typography / button / DV palette）— 這些是 reference，已落在 css/tokens.css
+
+## Decisions
+
+### 1. Umbrella change with 5 capability spec（vs 5 獨立 change）
+
+**為何**：
+- 5 主題互相不 break（emoji sweep 不影響 Account / modal 不影響 nav），但同屬 mockup parity 主題，archive 一次更乾淨
+- `ideas-drag-to-itinerary` 已立 1-change-多-capability 先例（drag-to-promote / drag-to-reorder / trip-sheet-state 三 spec dir）
+- 各 capability 仍可分別 ship（tasks.md 5 sections），不 force batch ship
+
+**備選**：拆 5 獨立 change — 每個 archive 各自 timeline。Trade-off 是 review overhead 5×；本 change 把 ship 拆給 task section 達同樣 incremental 效果。
+
+### 2. 5 capability 拆分線
+
+| Capability | 主軸 | 為何獨立 | 風險 |
+|---|---|---|---|
+| `terracotta-icon-svg-sweep` | emoji → SVG | 純視覺 swap，無邏輯改 | 既有 unit test snapshot 要更新 |
+| `terracotta-account-hub-page` | 新建 `/account` page + nav | 整頁新增 + sidebar IA 微調 | 跟現有 `/settings/*` page 整合 entry，不重做設定本身 |
+| `terracotta-add-stop-modal` | InlineAddPoi → modal 4-tab | UI pattern 大改寫 + interaction model 從 inline expand 改 modal | 跟既有 day-level POI add flow 平滑切換，需 decommission 舊 inline UI |
+| `terracotta-ui-parity-polish` | 散落 inconsistency sweep | 跨 13 file 各小 finding，集中 sweep 比 5 個獨立 change 高效 | 變動分散、review 表面廣 |
+| `mobile-bottom-nav` (MODIFIED) | 5-tab vs 4-tab IA decision | product 決策題，需先收斂 | 可能 block 其他 page entry 邏輯（探索 / 帳號 tab） |
+
+### 3. `bottom-nav-ia-decision` 第一個 task 必為 product decision
+
+**為何**：5-tab 跟 4-tab 不只是 UI 改動，是「mobile user 的 mental model」決策。mockup 是 global app（每 tab 切 page），React 4-tab 是 trip-scoped（更多 = action sheet）。先決定再實作，避免做完一個方向後 product reverse。
+
+**Decision 路徑**：tasks.md 第一 task 是 invoke `/office-hours` 或 `/plan-ceo-review`，輸出 decision doc 後解鎖後續 implementation task。
+
+### 4. emoji sweep 用既有 `<Icon>` SVG sprite 而非新建 icon
+
+**為何**：`src/components/shared/Icon.tsx` 已含 ~40 SVG sprite（包含 trash / x / search / check 等），新增 emoji 對應只需 path append（lucide / heroicons style 1.5px stroke）。**不**引入新 icon library 增加 bundle。
+
+**對應表**：
+- `🗑` → `<Icon name="trash" />` (新增)
+- `✕` → `<Icon name="x" />` 或 `close`（既有）
+- `⛶` → `<Icon name="maximize" />`（新增）
+- `⎘` → `<Icon name="copy" />`（既有）
+- `⇅` → `<Icon name="arrows-vertical" />`（新增）
+- `🔍` → `<Icon name="search" />`（既有）
+- `✓` → `<Icon name="check" />`（既有）
+
+### 5. Account hub `/account` 是 entry hub 不重做 settings
+
+**為何**：既有 `/settings/sessions`、`/settings/connected-apps`、`/settings/developer-apps` 各自 implementation 完整，沒理由全部重寫。Account hub 角色是「unified settings entry」，每 row click navigate 到既有 page。新建的只有：
+- `AccountPage.tsx` 自身（hub）
+- `NotificationsSettingsPage.tsx`（mockup 規定有「通知設定」row 但目前完全沒 page，本次新建 minimal stub + 之後 polish）
+
+### 6. AddStopModal 重構從 trigger 改成 trip-level
+
+**為何**：mockup 規定 trigger 在 trip detail page 上方（line 6277-6280 `.tp-detail-add-poi`），開啟 modal 後選 day。React 既有 trigger 在 day-level（每 DaySection 末尾「+ 加景點」）。改 trip-level + modal 內選 day 對齊 mockup user flow。
+
+**過渡策略**：先建 modal + 並行保留 inline trigger 1 個 minor 版本確認 UX 沒退化，再拿掉 inline。或直接全切（要看 ship 順序，預設一次切）。
+
+### 7. UI polish capability 內部 sub-grouping by file
+
+**為何**：14 個小 finding 分散 13 個 file，tasks.md 內按 file group 比按 finding type group 高效（同 file 一次改完省 context switch）。tasks Section 5 sub-section 對齊 file boundary。
+
+## Risks / Trade-offs
+
+- **[Risk] 5 capability 並行 implement 互踩腳**（NewTripModal 多目的地拖拉是 polish 但跟 add-stop-modal redesign 都動 modal pattern）
+  → Mitigation: tasks.md 標 dependency；polish 內 NewTripModal 部分排在 add-stop-modal capability 之後
+- **[Risk] BottomNav IA 決策久久不出**（office-hours / CEO 排期）卡住 polish 的 mobile path 改動
+  → Mitigation: polish capability 不含 BottomNav 變動，BottomNav 等 decision 完成才動
+- **[Risk] AccountPage 整合 settings 入口時，sidebar 「帳號」nav item 跟現有 logged-in user card 重複** 
+  → Mitigation: tasks 含明確「拿掉 user card 或保留 + 「帳號」nav 同時並存」決策子任務
+- **[Risk] AddStopModal 重構讓既有 saved POI 流程斷掉**（ExplorePage 儲存池現在透過「加入行程」modal 加進 trip，跟新 AddStopModal「收藏」tab 概念重疊）
+  → Mitigation: 重構時 spec 明確兩流程是同個 saved POI table 不同 entry point；ExplorePage saved 流程不動，AddStopModal「收藏」 tab read-only consume 同 store
+- **[Trade-off] 「completeness 修一波」vs「incremental 修細」**：本 change 採前者（一次 audit / 5 capability 一起 implement / 全 done 才 archive），加快 mockup 對齊；缺點是 archive timeline 拉長，兩個月內可能因 mockup itself iterate 又 drift
+- **[Trade-off] 不改 D1 schema 限制 Account hub stats**：3 個 stats（N 個行程 / N 天旅程 / N 位旅伴）需 client-side aggregate；trip 多的 user 可能 N+1 fetch 慢。Mitigation: 用 SUM 先寫一個 `/api/account/stats` aggregate endpoint 避免 client-side 算
+
+## Migration Plan
+
+5 capability ship 順序建議：
+
+1. **Week 1**: `terracotta-icon-svg-sweep` (1 PR, ~1 day) — 最低風險、純視覺
+2. **Week 1-2**: `mobile-bottom-nav` decision sub-task → office-hours / CEO review → decision doc → 不解鎖後續 task
+3. **Week 2**: `terracotta-ui-parity-polish` Section 5.1-5.4 (CSS-only finding，1 PR ~2 day)
+4. **Week 3**: `terracotta-account-hub-page` (1 PR, ~3-4 day) — 含新 page + sidebar nav 微調 + stats endpoint
+5. **Week 4**: `terracotta-add-stop-modal` (1 PR, ~5 day) — 大改寫，含 modal + 3 tab + batch select
+6. **Week 5**: `mobile-bottom-nav` implementation（依 decision 結果）+ `terracotta-ui-parity-polish` 剩餘 Section 5.5+ (mobile path 改動)
+7. **Week 5**: `/opsx:archive` 一次 archive 整 change
+
+**Rollback**：每 capability commit 集中在 1 PR，revert 該 PR 即 rollback 該 capability。Account hub 整 page revert 需注意 sidebar nav item 是否一起拿掉。
+
+## Open Questions
+
+- BottomNav IA 5-tab vs 4-tab — **product decision 待回答**：對齊 mockup global IA 還是保留 trip-scoped？
+- AddStopModal「收藏」 tab vs ExplorePage「儲存池」tab — 實作上算同一概念，UI 是否該指向同一 model？mockup 視覺處理不一樣（modal vs page），是 design 故意還是 modeling oversight？
+- Notifications page 內容 — mockup row 寫「行程更新 / 旅伴邀請 / 系統通知」分組但沒 mock 實際 page，初版做什麼 minimum？
+- Stop card emoji icon 替換是否同時改 trash confirm flow（mockup section 12 lead 吐槽 `window.confirm`）— 算同 capability 還是 polish 內？建議 polish 內處理，icon sweep 純視覺
+
+---
+
+## Audit
+
+完整 mockup vs React 實作對照（2026-04-28 audit）：
+
+### Summary 表
+
+| Section | React file | Missing | Incon. | Extra | 嚴重度 |
+|---|---|---|---|---|---|
+| 01 Desktop Sidebar | `DesktopSidebar.tsx` | 1 | 4 | 2 | MEDIUM |
+| 02 Bottom Nav | `BottomNavBar.tsx` | 0 | 4 | 0 | HIGH (IA 5→4 tab) |
+| 03 New Trip Modal | `NewTripModal.tsx` | 5 | 4 | 1 | HIGH |
+| 04 Error & Status | `Toast/InlineError/ErrorPlaceholder` | 3 | 2 | 0 | MEDIUM |
+| 10 Day hero | `DaySection.tsx` | 1 | 1 | 0 | LOW |
+| 11 Day chips | `DayNav.tsx` | 1 | 2 | 1 | LOW |
+| 12 Stop card | `TimelineRail.tsx` (RailRow) | 0 | 5 | 1 | MEDIUM (emoji icons) |
+| 13 Trip Detail full layout | `TripPage + DaySection` | 4 | 3 | 1 | HIGH (travel pill 缺) |
+| 14 Add Stop Modal | `InlineAddPoi.tsx` | 6 | 3 | 0 | HIGH (整 modal 不存在) |
+| 16 Trip List | `TripsListPage.tsx` | 4 | 3 | 1 | MEDIUM |
+| 17 Chat | `ChatPage.tsx` | 4 | 3 | 1 | MEDIUM |
+| 18 Explore | `ExplorePage.tsx` | 5 | 4 | 1 | HIGH |
+| 19 Account | (無對應頁面) | 10+ | — | — | HIGH (整 page 不存在) |
+| 20 Map | `MapPage + GlobalMapPage` | 2 | 4 | 2 | MEDIUM |
+
+**Total**: ~46 missing / 42 inconsistent / 11 extra（不含 Section 19 的延伸缺口）
+
+### 細節 per section
+
+#### 01 Desktop Sidebar
+
+**Missing**:
+- HIGH: 底部 sticky 帳號卡 (avatar + name + email) — mockup line 5114-5117 規範「avatar + name + email」三行區塊；React 已實作 (`tp-account-card`) 但已登入時 name 跟 email 完整顯示沒有 mockup 規定的「name.length > 10 ? slice(0,10)+'…'」JS-level 截字 (line 5132 強制規定)，僅靠 CSS overflow:ellipsis fallback
+
+**Inconsistent**:
+- HIGH: Mockup nav item active 樣式為「accent 實心」(`background: --color-accent`, line 5128)；React 用 `background: var(--color-foreground)` + `color: var(--color-background)`（深棕底白字）— 完全不同顏色語意
+- MEDIUM: Mockup sidebar 背景應該是 `--color-foreground`（深棕，dark sidebar on cream page，line 5126）；React 用 `var(--color-background)` 米白底 — 整體 sidebar 視覺風格相反
+- MEDIUM: Mockup IA 順序「聊天 / 行程 / 地圖 / 探索 / 帳號」(line 5108-5112)；React 第 5 項是「登入」(`label: '登入'`)，logged-in 時就直接 filter 掉 → 沒有「帳號」入口在 nav，只在底部 account card
+- LOW: Mockup item 字級規格 14px / lh 20 / weight 600 (line 5129)；React `font-weight: 500`，active 才升 600
+
+**Extra**:
+- React 有 `ThemeToggle` 在 sidebar 底部 CTA 區（line 217）— mockup 完全沒有此元件
+- React 有「Tripline.」brand 紅點 `.accent-dot`（line 196）— mockup 有相同 `tp-accent-dot`，OK 對得上
+
+#### 02 Bottom Nav
+
+**Inconsistent**:
+- HIGH: Mockup IA 為 5-tab「聊天/行程/地圖/探索/帳號」(line 5160-5164)；React 是 4-tab「行程/地圖/助理/更多」(line 78-81) — IA 完全不同，缺「探索」「帳號」入口，多了「更多」action sheet
+- HIGH: Mockup tab label 「訊息」(來自 Section 09 `tp-nav-tabs`) 或「聊天」(主 IA)；React 第 3 tab 文案「助理」+ icon 用 `phone` — 跟 mockup「聊天」+ chat icon 不符
+- MEDIUM: Mockup 規定 active 樣式「accent-subtle 底 + 2px top indicator + accent text」(line 5228)；React 走 `ocean-bottom-nav` class（在 tokens.css），缺少 mockup 規定的 2px top indicator 元件結構
+- LOW: Mockup label 11px/lh 14/weight 700 (line 5227)；React 樣式定義在外部 `ocean-bottom-nav-btn`，需驗證
+
+#### 03 New Trip Modal
+
+**Missing**:
+- HIGH: 多目的地拖拉排序 — mockup 核心 spec (line 5254-5283)，每個 dest row 有 grip / 編號 / name / region / remove；React 用 chips list（line 687-708）一行排隊，無拖拉、無編號、無 region 顯示
+- HIGH: 目的地數量分配天數 stepper + 推薦地區 chips（mockup Frame 3，line 5424-5448）— React 完全無此 UI
+- HIGH: 熱門目的地 chips + recent searches 分組（mockup Frame 2，line 5341-5396）— React dropdown 平鋪 results 無分組
+- MEDIUM: Mockup section label「目的地（可加多筆，拖拉排序）」(line 5254)；React label「目的地」(line 685)
+- LOW: Mockup helper「行程跨 N 個目的地 · 順序決定地圖 polyline 串接方向」(line 5288)；React 無此 helper
+
+**Inconsistent**:
+- HIGH: Mockup title「新增行程」(line 5247)；React title「想去哪裡？」(line 681) — 完全不同文案語氣
+- HIGH: Mockup 日期 mode tabs 文案「固定日期 / 大概時間」(line 5295-5296)；React「選日期 / 彈性日期」(line 762, 772)
+- MEDIUM: Mockup actions footer「取消 / 建立行程」對齊右側，無 summary（line 5319-5322）；React 有「summary text + 取消 + 建立行程」三段式 footer（line 866-885）
+- LOW: Mockup close button 在 dialog header 內部（line 5248）；React 用 absolute position 浮在右上 covering form pane（line 81-94）
+
+**Extra**:
+- React 有 sub-headline「先說目的地跟想做什麼，AI 會幫你排日程、餐廳、住宿。」(line 682) — mockup 無此 copy
+
+#### 04 Error & Status surfaces
+
+**Missing**:
+- HIGH: `tp-alert-panel` persistent surface（icon + title + message + action button，mockup line 5632-5648）— React 無此 component；只有 `Toast`、`InlineError`、`ErrorPlaceholder` 三種樣式都不對應 alert panel 結構
+- MEDIUM: `tp-alert-panel.is-warning` variant（line 5641-5648）— React 無 warning 等級的 persistent banner（`Toast` 無 warning type，`InlineError` 永遠 destructive）
+- MEDIUM: `tp-page-error-box` 全頁錯誤容器（line 5660-5666，「找不到這個行程」+ CTA back to trip）— React 有對應 inline early-return 在 TripPage.tsx 但 styling 不對齊 mockup
+
+**Inconsistent**:
+- LOW: Mockup `tp-status-toast`「已恢復連線，正在同步最新行程」(line 5656) — React `Toast` 有 `online` type 但 message 內容由呼叫方決定
+- LOW: Mockup `tp-field-error-text`「請選擇出發日期，行程天數才能正確產生。」(line 5653) — React `InlineError` 樣式對齊（destructive footnote）但 message format 與 line-height 1.4 一致
+
+#### 10 Trip day hero
+
+**Missing**:
+- LOW: Mockup hero chips area 文案是「水族館・古宇利」一個 chip（line 5914）；React 把 `area` 顯示為單獨 `ocean-hero-chip-muted`（line 131）— 結構對得上
+- 注意：mockup 有 `<span class="tp-chip-sep">·</span>` 分隔（line 5911、5913），React 用 `${eyebrow} · ${dateLabel}` template literal 直接拼字串到一個 chip 內 (line 127-130)
+
+**Inconsistent**:
+- LOW: Mockup title「美ら海＋古宇利島一日跑」(line 5916) 是日主題 string；React 用 `area || Day ${dayNum}` (line 134) — area 字段是 mockup 的「水族館・古宇利」這種地理 tag，不是日主題字。資料結構未支援 day title 概念
+
+#### 11 Day chips
+
+**Missing**:
+- LOW: Mockup chip 顯示「area 字（北谷 / 浮潛・瀨底 / 水族館・古宇利）」(line 5943, 5948, 5953) 在 chip body 第三行；React `dn-area` 已渲染（line 292），結構對齊但 `max-width: 80px` truncation 比 mockup 寬
+
+**Inconsistent**:
+- LOW: Mockup eyebrow 為「DAY 03 · 今天」用 `·` 分隔 + 中文「今天」(line 5951)；React eyebrow `parts.eyebrow` 只放 `DAY 03`，今天標記 `<span className="dn-weather">TODAY</span>` 是另一獨立 pill（line 286）— 文案 + 視覺實作不同
+- LOW: Mockup `tp-day-chip-date` 顯示「7/29」「7/30」(line 5942, 5947)；React `dn-date` 渲染 `${month}/${day}` + `<span className="dn-dow">` 多加週幾英文 — extra 元素
+
+**Extra**:
+- React `ocean-day-strip` 有 `MAP 全覽` chip 在尾端（line 306-322）— mockup 無此 overview chip
+
+#### 12 Stop card
+
+**Inconsistent**:
+- HIGH: Mockup expanded toolbar 有 6 個 SVG icon button：放大 / 複製 / 移動 / 編輯備註 / [spacer] / 刪除 / 收闔 (line 6074-6080)；React `tp-rail-actions`（line 401-469）有：放大檢視（chip with text 不是 icon-only）+ 複製 + 移動 + 刪除 + 收闔，缺少「編輯備註」獨立按鈕（備註 inline click-to-edit）
+- HIGH: Mockup 用 unified `<svg><use href="#i-trash"/>` SVG sprites；React 用 emoji unicode：`🗑` (line 457)、`✕` (line 467)、`⛶` (line 409)、`⎘` (line 423)、`⇅` (line 433) — 即 mockup section 12 lead 明文吐槽的問題：「`⎘⇅🗑✕` 是 unicode/emoji 跨字型不一致」(line 5971)
+- MEDIUM: Mockup 規定「delete confirm 不應用 `window.confirm`」(line 5971 lead)；React `handleDelete` line 297 仍用 `window.confirm`
+- MEDIUM: Mockup `tp-stop-v-grip` collapsed 狀態低調，hover row 才浮現（line 6034 tagline）；React `ocean-rail-grip` 永遠可見，無 hover 邏輯切換
+- LOW: Mockup row 結構：grip / time / icon (poi type) / type label + name + meta / caret (line 6043-6053)；React 結構：time / dot (number) / grip / icon / content / caret — `.ocean-rail-dot` 是 React 多出的 numbered dot
+
+**Extra**:
+- React `tp-rail-detail` 有「備註」section with click-to-edit textarea + ⌘+Enter / Esc keyboard shortcuts（line 504-558）— mockup 沒有此 inline note editing UI（mockup 只有 toolbar pencil button）
+
+#### 13 Trip Detail full layout
+
+**Missing**:
+- HIGH: Mockup desktop titlebar 有「建議 / 共編 / 下載」三個 ghost buttons + 更多 icon button（line 6100-6103）；React TripPage titlebar 只有 3 個 icon-only buttons (lightbulb / group / download) + OverflowMenu (line 710-744)，沒文字 label 且 mockup 是 `tp-btn is-ghost` icon+text combo
+- HIGH: Mockup 用 travel pill 元件 (line 6179-6184) 顯示「🚗 10 min · 4.2 km」在每兩個 stop 之間；React TimelineRail 完全無 travel pill 渲染（無 inter-stop transit 視覺）
+- HIGH: Mockup expanded entry 有「說明 / 備註」結構化 sections（h4 + body, line 6231-6238）；React `tp-rail-detail-section` (line 471-502) 結構對齊但 mockup 還有「+ 加備註」 empty state link（React 用 `tp-rail-note-value.is-empty` 字串「+ 加備註」line 556 — 對齊 OK）
+- MEDIUM: Mockup compact 版本 day nav pill 用「D 02 / D 03」縮寫 (line 6298, 6303)；React `DayNav` 永遠用「DAY 02」+ 7/30 兩段格式，無 compact 縮寫切換
+
+**Inconsistent**:
+- HIGH: Mockup `tp-detail-rail-header` 顯示 `Itinerary · 7 stops · 08:00–21:00`（line 6155-6158）；React `ocean-rail-header` 渲染相同結構（line 639-643）— 對齊 OK
+- MEDIUM: Mockup row 有 `tp-detail-dot` 顯示 1 / 2 / 3 序號（line 6166, 6189, 6215）；React 有對應 `ocean-rail-dot` (line 351) — 對齊 OK
+- LOW: Mockup hero `tp-detail-hero-eyebrow` 一行「DAY 03 · 2026-07-31（五）· 水族館・古宇利」(line 6136)；React DaySection 拆成兩個 chips (line 127-131)
+
+**Extra**:
+- React TitleBar 有 back button + back to /trips (line 706)；mockup 用 `tp-preview-icon-button`「返回列表」(line 6097) — 都有 back affordance OK
+
+#### 14 Add Stop Modal
+
+**Missing**:
+- HIGH: Modal 整體結構完全不存在 — mockup line 6428-6711 規範 4-frame modal (搜尋/收藏/自訂 3-tab + 兩種 saved state)。React 用 `InlineAddPoi` 在 DaySection 內 inline expand（不是 modal），沒 tabs、沒 modal layout
+- HIGH:「收藏」tab 完整流程 (mockup Frame 2 + 3，line 6527-6640) — React 無 saved-pois-in-context 概念；saved POI 只在 ExplorePage `儲存池` tab 看，不能從 trip detail 取用
+- HIGH:「自訂」tab form (mockup Frame 4，line 6642-6709)：標題 / 地址 / 開始時間 / 結束時間 / 類型 / 預估停留 / 備註 — React `InlineAddPoi` 只能搜尋 POI，無自訂 form
+- HIGH: 2-col grid POI cards with cover photo（mockup line 6470-6515 `tp-add-poi-card`）— React 用 1-col list `tp-inline-add-result` (line 130-149)，無 cover photo
+- MEDIUM: Region selector「沖繩 ▾」(line 6452-6454)、filter button「📋 篩選」(line 6460)、subtab chips「為你推薦/景點/美食/住宿/購物」(line 6462-6467) — 全無對應 React 元件
+- MEDIUM: Mockup footer「已選 N 個 · 將加入 Day 03 · 7/31」+ 取消 / 完成 buttons (line 6517-6523)；React `InlineAddPoi` 是 single-add per click，無 batch select / footer summary
+
+**Inconsistent**:
+- HIGH: Mockup「+ 加入景點」trigger 在 trip detail page level（line 6277-6280 `.tp-detail-add-poi`）開啟 modal；React trigger 在每個 DaySection 末尾 (`.tp-inline-add-trigger`, line 286-294) inline expand — placement + interaction model 不同
+- MEDIUM: Mockup head meta「DAY 03 · 7/31（五）」(line 6442)；React inline-add head「在 Day {dayNum} 加景點」(line 305) — 文案結構不同
+- LOW: Mockup search input 用 SVG icon (`#i-search`, line 6457)；React 用 emoji `🔍` (line 318) — anti-pattern emoji
+
+#### 16 Trip List
+
+**Missing**:
+- HIGH: Mockup toolbar 有「全部 / 我的行程 / 共編行程 / 已歸檔」filter subtabs +「最新編輯 ▾」sort dropdown (line 6890-6897)；React TripsListPage 完全無 filter / sort UI
+- HIGH: Mockup desktop header 有「搜尋 / 新增行程」兩個 ghost+primary buttons (line 6884-6887)；React 只有 plus icon button (line 685-694)，無搜尋
+- HIGH: Mockup search active state 完整流程（line 6974-7016）：search bar 展開 + cancel + result count + `<mark>` highlight — React 無 search functionality
+- LOW: Mockup empty state 文案「還沒有行程 / 建立第一個行程，開始規劃你的下一趟旅程。也可以從探索頁尋找靈感。」(line 7101-7102)；React empty state 文案「還沒開始任何行程 / 建立第一個行程，AI 會幫你排日程、餐廳、住宿。」(line 713-714) — 用語不一致
+
+**Inconsistent**:
+- MEDIUM: Mockup card meta 包含「owner avatar + name + 出發日」(line 6906-6909, `tp-list-card-avatar` + `tp-list-card-meta-text`)；React card meta 只有「日期範圍 + N 旅伴」(line 378-389)，無 owner avatar、無 owner name
+- MEDIUM: Mockup eyebrow 用「日本 · 12 天」中文 (line 6904)；React eyebrow 用「JAPAN · 12 DAYS」全英文 (line 353-364)
+- LOW: Mockup card header 文案「我的行程」(line 6882) — React 對齊 (line 683)
+
+**Extra**:
+- React 有 `is-active` border highlight on selected card (line 736)；mockup 有同樣 `tp-list-card.is-active` (line 6900) — 對齊
+
+#### 17 Chat
+
+**Missing**:
+- HIGH: Chat list view（對話 list） — mockup line 7125-7167 規範一個 chat list page（每個 trip 一個對話 row，含 avatar / name / preview / time / unread badge）；React ChatPage 直接是單一 conversation view，無 list 模式，活的 trip 用 dropdown picker 切換
+- HIGH: Mockup conversation 有「day divider」`tp-chat-day-divider` (line 7226, 7233) — React 無 day divider 渲染
+- HIGH: Mockup conversation 有「bubble timestamp meta」獨立行 `tp-chat-bubble-meta` 顯示 `Tripline AI · 14:02` (line 7228, 7232) — React 用 `tp-chat-msg-time` (line 730-738) 但只顯示時間，無「Tripline AI · 」prefix
+- LOW: Mockup `tp-chat-bubble-suggestions` 用 inline 在 AI bubble 內 (line 7237-7240)；React `tp-chat-suggestions` 在 empty state 才出現 (line 688-702)
+
+**Inconsistent**:
+- MEDIUM: Mockup `tp-chat-input` 是 textarea + send icon button (line 7245-7247)；React `tp-chat-composer` 是 textarea +「送出」text button (line 769-776) — 視覺不同（mockup icon-only, React text-only）
+- MEDIUM: Mockup conversation header 文案「沖繩 + 大阪 + 京都跨城」(line 7219) 是直接顯示 trip name；React 標題永遠是「聊天」(line 627)，trip name 只在 trip-picker pill 內顯示
+- LOW: Mockup `tp-chat-avatar.is-ai` AI 標識「AI」(line 7127, 7148)；React 無 AI avatar 渲染（messages 直接顯示 bubble，無 avatar）
+
+**Extra**:
+- React 有 `tp-chat-trip-picker` pill 切 trip (line 631-641)；mockup 在 conversation 模式無此切換 affordance（chat list 才能換 thread）
+
+#### 18 Explore
+
+**Missing**:
+- HIGH: POI grid card 視覺結構完全不同 — mockup `tp-explore-card` 有 cover photo (`tp-explore-card-cover` with `data-tone`) + ❤ favorite toggle right-corner + name + ★ rating meta (line 7313-7319)；React `explore-poi-card` 是 text-only card with category eyebrow + name + address +「+ 儲存」button (line 569-587)，無 cover, 無 ❤ icon, 無 rating
+- HIGH:「我的收藏」titlebar action（mockup line 7294 ghost button with heart icon, line 7370 compact icon button）— React 用 `Icon name="star"` (line 513) 切到 saved tab — icon 跟 mockup 不同（heart vs star）
+- HIGH: Region selector「沖繩 ▾」(line 7299, 7375) — React 無 region picker UI
+- HIGH: Subtab chips「為你推薦 / 景點 / 美食 / 住宿 / 購物」(line 7305-7311, 7381-7386) — React 只有「搜尋 / 儲存池」兩 tab 結構，無 POI 類型 sub-filter
+- MEDIUM: Mockup compact 版用 `tp-page-titlebar` heart icon button (line 7370) — React 已對齊（star icon）
+
+**Inconsistent**:
+- HIGH: Mockup desktop title「探索」+ 右側「我的收藏」ghost button (line 7292-7295)；React 標題「探索」對齊 (line 503) 但 actions 用 star icon button (line 506-514)
+- MEDIUM: Mockup search 有 visual rendering 為「`tp-explore-search` flat row with icon」(line 7301-7304)；React 為 form with input + submit button (line 545-557) — 互動模型不同（mockup 用 chip-tap 觸發，React 要打字 + 按 Enter）
+- MEDIUM: Mockup card hover「accent 邊框 + lift shadow」(section lead line 7287)；React card 只有 `border-color: --color-accent` + `is-selected` state，無 hover lift transform
+- LOW: Mockup card meta「★ 4.6 · ¥2,180」(line 7318)；React card meta 顯示「address truncated」(line 572)
+
+**Extra**:
+- React 有「儲存池 multi-select + 加入行程 modal」流程 (line 620-740)；mockup 無此 batch-add-to-trip flow
+
+#### 19 Account
+
+**Missing** (10+ items, 整 page 不存在):
+- HIGH: 完整 Account page 不存在 — mockup line 7425-7581 規範一個 unified 帳號頁（profile hero + 應用程式 / 共編&整合 / 帳號 三組 settings rows）；React 無對應頁面，分散到 `/settings/sessions`、`/settings/connected-apps`、`/settings/developer-apps` 三個獨立頁
+- HIGH: Profile hero 元件（avatar 64px + name + email + 3 個 stats: N 個行程 / N 天旅程 / N 位旅伴, line 7437-7448）— React 完全無此 component
+- HIGH: Settings list rows 元件（icon 圓形 box + title + helper + chevron, line 7452-7515）— React 無此模式（各 settings page 各自做 form/table）
+- HIGH: Section labels「應用程式 / 共編 & 整合 / 帳號」分組 (line 7450, 7470, 7498) — React 無 grouping
+- HIGH:「外觀設定」row (line 7452-7459) — React 無此 standalone page，theme toggle 只在 sidebar bottom
+- HIGH:「通知設定」row (line 7460-7467) — React 完全無通知 page
+- HIGH:「已連結 App」row (line 7480-7487) — 有對應 page (`ConnectedAppsPage.tsx`) 但 entry 在 sidebar bottom + URL 直連，無 account-page 入口
+- HIGH:「開發者選項」row (line 7488-7495) — 有對應 page (`DeveloperAppsPage.tsx`)，無 account-page 入口
+- MEDIUM:「已登入裝置」row (line 7500-7507) — 有 `SessionsPage.tsx`，無 account-page 入口
+- HIGH: 登出 destructive row (line 7508-7515 `tp-account-row.is-danger`) — React 無顯式登出 UI（CLAUDE.md feedback 指 `/devex-review 2026-04-26` 把登出 link 拿掉，要求走 sessions page revoke device row）
+
+#### 20 Map
+
+**Missing**:
+- MEDIUM: Mockup 有「圖層」FAB button (`#i-layers`, line 7619) + 定位 FAB — React MapPage 沒有 FAB UI（OceanMap 內部有 controls 但不對齊 mockup `tp-map-fabs`）
+- LOW: Mockup desktop titlebar 有 trip switcher ghost button「沖繩 + 大阪 + 京都」(line 7593) — React MapPage TitleBar (line 31) 無此元件；GlobalMapPage 有 trip switcher dropdown 但放在 absolute positioned card (`tp-global-map-header`)，不在 titlebar
+
+**Inconsistent**:
+- HIGH: Mockup day tab 第一項是「總覽 · 7 天」(line 7624-7627)，無顏色點 + 無 hyphen；後續 day tabs 用 `dayColor` 著色 eyebrow + DAY 0X format (line 7628-7647)。React MapPage 用 `MapDayTab` 組件（line 33），結構應大致對齊但第一項 overview tab 視覺需驗證
+- MEDIUM: Mockup 規定 active day tab「用 dayColor border-bottom」(section lead line 7586) underline tab pattern；MapPage SCOPED_STYLES 未含對應 CSS（依賴 `MapDayTab` 內部）
+- MEDIUM: Mockup `tp-map-entry-card` 含 num badge (border 顏色 = dayColor) + D{N} prefix (顏色 = dayColor) + time + icon + title (line 7650-7660)；React 用 `MapEntryCard` 組件 — 結構需驗證 `D{N}` overview prefix 是否實作 (MapPage line 232-241 有 `entryDayMap` 邏輯但需對照 component output)
+- LOW: Mockup loading state「地圖載入中… + spinner」(line 7855-7860)；React `map-page-loading` 已實作對齊 (line 52-78)
+
+**Extra**:
+- React MapPage 有 `?day=all`、`?day=N`、`/stop/:entryId/map` deep-link routing (line 4-21) — 是 mockup 沒寫但合理擴充
+- GlobalMapPage 加 trip switcher dropdown + dropdown rows 顯示其他 trips (`tp-global-map-dropdown`) — mockup 無此 cross-trip 切換 UI
+
+### 整體觀察
+
+1. **最大缺口**：Section 19 (Account) 是新建 unified page 的需求，目前完全沒有對應實作；Section 14 (Add Stop Modal) 是大改造，目前 InlineAddPoi 不是 modal、無 tabs、無收藏 / 自訂模式
+2. **共通 anti-pattern**：emoji 用作 icon 普遍（TimelineRail 的 `🗑 ✕ ⛶ ⎘ ⇅`、InlineAddPoi 的 `🔍`、ExplorePage 的 `✓` 等），mockup 全用 SVG sprites — 違反 mockup section 12 lead 明文吐槽的問題
+3. **IA 不一致**：Bottom Nav React 走 4-tab trip-scoped（行程/地圖/助理/更多）vs mockup 5-tab global（聊天/行程/地圖/探索/帳號）— 屬於主要架構 deviation，需 product decision
+4. **共通 deviation**：mockup 多個 tab/filter 元件未實作（trip list filter subtabs、explore subtabs by POI type、region selector）— UI 框架缺口

--- a/openspec/changes/terracotta-mockup-parity-v2/proposal.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`docs/design-sessions/terracotta-preview-v2.html` 是 Terracotta 設計系統 v2 的權威 layout spec（7,950 行 / 14 個 page section + 5 個 design-token 參考 section），但 React 實作跟 mockup 之間累積了 **~46 missing / 42 inconsistent / 11 extra finding**，跨 13 個 components + 1 個整頁缺漏（Account hub）。Audit 結果在本 change `design.md` 的 §Audit 詳載。
+
+不對齊的後果：
+- mockup 是 design source of truth，跟實作 drift 後設計 review 失去 reference 基準（每次 /design-review 都得重判）
+- 部分缺漏屬於 visible regression（如 Account hub 整頁缺、Add Stop Modal 不是 modal、Stop card 用 emoji 當 icon），不是 polish
+- 多個 mockup-defined affordance（travel pill、TripsListPage filter subtabs、Explore POI cover 卡）user 已知預期但拿不到
+
+## What Changes
+
+按主題拆 5 個 capability，每個獨立 implement + ship（不互相依賴），可分批進 PR：
+
+- **icon-svg-sweep**（HIGH，跨 component）：emoji unicode (`🗑 ✕ ⛶ ⎘ ⇅ 🔍 ✓`) → 既有 `<Icon name="..." />` SVG sprites，對齊 CLAUDE.md「icon 用 inline SVG，不用 emoji」+ mockup section 12 lead 明文吐槽
+- **account-hub-page**（HIGH，新 page）：新建 `/account` route + `src/pages/AccountPage.tsx`，mockup section 19 規範的 Profile hero (avatar + name + email + 3 stats) + 3 group settings rows（應用程式 / 共編 & 整合 / 帳號）+ 登出 destructive row，整合既有 `/settings/sessions` `/settings/connected-apps` `/settings/developer-apps` 為入口
+- **add-stop-modal-redesign**（HIGH，重構）：`InlineAddPoi` day-level inline expand → trip-level modal 4-tab pattern（搜尋 / 收藏 / 自訂 + region selector + filter + 推薦 chips），POI card 改 2-col grid with cover photo，batch select footer（mockup section 14）
+- **bottom-nav-ia-decision**（HIGH，**product 決策題先**）：mockup 5-tab global（聊天/行程/地圖/探索/帳號）vs React 4-tab trip-scoped（行程/地圖/助理/更多）的 IA reconciliation。本 capability 第一個 task 是跑 office-hours / CEO review 收斂方向後再實作
+- **ui-parity-polish**（MEDIUM/LOW，跨 section sweep）：DesktopSidebar active state / NewTripModal 文案 + 多目的地拖拉 / DayNav eyebrow / TripsListPage filter+search+owner avatar / ChatPage day divider+AI avatar / ExplorePage POI cover+heart+region+subtabs / MapPage FAB / Error & Status 新 `tp-alert-panel`
+
+每個 capability 獨立可 ship；`bottom-nav-ia-decision` 在 product 決策出來前不解鎖實作 task。
+
+## Capabilities
+
+### New Capabilities
+
+- `terracotta-icon-svg-sweep`：跨 component emoji-to-SVG icon 替換的 contract（哪些 emoji / 對應 Icon name / 視覺 spec）
+- `terracotta-account-hub-page`：新 unified Account hub `/account` 的 layout / nav entry / settings rows / data 來源 contract
+- `terracotta-add-stop-modal`：trip-level modal 4-tab pattern 的結構 / interaction model / batch flow / 三 tab 各自 spec
+- `terracotta-ui-parity-polish`：各 section 的 mockup-aligned 視覺/結構 finding 集合 spec
+
+### Modified Capabilities
+
+- `mobile-bottom-nav`：mockup 規定 5-tab IA「聊天/行程/地圖/探索/帳號」vs 既有 4-tab「行程/地圖/助理/更多」的 requirement 替換，含 product decision 的 prerequisite
+
+## Impact
+
+- **新 page**：`src/pages/AccountPage.tsx` + 對應 route in `src/entries/main.tsx`；可能新建 `NotificationsSettingsPage.tsx`（mockup 通知設定 row 目前完全沒對應 page）
+- **修改 components**：
+  - `src/components/shell/DesktopSidebar.tsx`（active state 顏色 / 暗底 / 「帳號」nav item）
+  - `src/components/shell/BottomNavBar.tsx`（IA 對齊後的 tab list）
+  - `src/components/shell/TitleBar.tsx`（actions slot button label vs icon-only）
+  - `src/components/trip/TimelineRail.tsx`（icon emoji → SVG）
+  - `src/components/trip/InlineAddPoi.tsx`（重構為 modal 或新建 `<AddStopModal>` 取代）
+  - `src/components/trip/NewTripModal.tsx`（多目的地拖拉 + 文案 + tabs）
+  - `src/components/trip/DaySection.tsx`（day hero title vs area）
+  - `src/components/trip/DayNav.tsx`（eyebrow 格式）
+- **修改 pages**：
+  - `src/pages/TripPage.tsx`（titlebar actions 文字 + travel pill 介接）
+  - `src/pages/TripsListPage.tsx`（filter subtabs + search + sort + owner avatar）
+  - `src/pages/ChatPage.tsx`（day divider + AI avatar + bubble timestamp prefix）
+  - `src/pages/ExplorePage.tsx`（POI cover + heart icon + region + subtabs）
+  - `src/pages/GlobalMapPage.tsx` + `MapPage.tsx`（FAB / titlebar trip switcher）
+- **新 component**：`<AlertPanel>` (`tp-alert-panel`) persistent banner with warning/error variants
+- **無 breaking change**：所有變動是視覺/結構對齊，data model / API / route 設計不變（除新增 `/account` route）
+- **依賴**：無新 npm dep；`@dnd-kit/core` 已有（NewTripModal 多目的地拖拉重用 Section 6 ideas-drag 帶來的 dnd-kit）
+- **測試**：每 capability 自帶 unit test；`/account` route 加 Playwright E2E；emoji sweep 加 source-grep contract test 防 regression
+- **參考**：mockup 完整在 `docs/design-sessions/terracotta-preview-v2.html`，audit 細節在本 change `design.md` §Audit

--- a/openspec/changes/terracotta-mockup-parity-v2/specs/mobile-bottom-nav/spec.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/specs/mobile-bottom-nav/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+> **Note**：本 spec 是對 `openspec/specs/mobile-bottom-nav.md`（既有 4-tab implementation note）的取代。實作前必須先完成 §Requirement「Bottom Nav IA 5-tab vs 4-tab decision」收斂方向。Decision 結果可能 keep 4-tab（不執行 IA 重整）或 adopt 5-tab（依下方 Requirement 實作）。Archive 時依 decision 結果決定是否覆蓋既有 spec。
+
+### Requirement: Bottom Nav IA 5-tab vs 4-tab decision（**product gate**）
+
+對應 mockup section 02 (line 5152-5238) vs React 既有 4-tab IA（archive change `2026-04-21-design-review-v2-retrofit`）的根本差異。
+
+兩種 IA 對比：
+
+| Aspect | Mockup 5-tab global | React 4-tab trip-scoped |
+|---|---|---|
+| Tab 1 | 聊天 (chat list) | 行程 (current trip) |
+| Tab 2 | 行程 (trips list) | 地圖 (current trip map) |
+| Tab 3 | 地圖 (global map) | 助理 (chat for current trip) |
+| Tab 4 | 探索 | 更多 (action sheet) |
+| Tab 5 | 帳號 | — |
+| Mental model | App-level global 切換 | Trip-level scoped + global escape via「更多」 |
+| 切 trip | 透過 chat list / trips tab | TripPickerSheet (action sheet 內) |
+
+決策題：mockup 是 trip-planner 應該成為 global app（每 tab 切 page）還是維持 trip-scoped（user 開 trip 後 4 tab 都跟當前 trip 互動）？
+
+#### Scenario: Decision 跑 office-hours / plan-ceo-review 收斂
+- **WHEN** 本 capability implement task 啟動
+- **THEN** 第一 task 是 invoke `/office-hours` 或 `/plan-ceo-review` 走 forcing question discussion
+- **AND** 輸出 decision doc 到 `openspec/changes/terracotta-mockup-parity-v2/notes/bottom-nav-ia-decision.md`
+- **AND** Decision 含：選擇方向（5-tab / 4-tab / hybrid）+ rationale + impact on existing trip-scoped UX
+
+#### Scenario: Decision = 5-tab adopt
+- **WHEN** Decision 結果是 adopt 5-tab IA
+- **THEN** 後續 task 解鎖：實作 BottomNavBar.tsx 5-tab + 各 tab page entry 對接 + 拿掉「更多」action sheet pattern + 影響範圍評估
+
+#### Scenario: Decision = keep 4-tab
+- **WHEN** Decision 結果是維持 4-tab IA
+- **THEN** 後續 task 不解鎖；本 capability 收尾為「decision 紀錄」 + mockup section 02 標 deviation accepted
+- **AND** mobile-bottom-nav existing spec 不變
+
+#### Scenario: Decision = hybrid
+- **WHEN** Decision 結果是 hybrid（如：登入後 5-tab，trip 內切回 trip-scoped 4-tab）
+- **THEN** 解鎖 hybrid 實作 task：context-aware nav + 路徑判斷 + 視覺切換 indicator
+
+### Requirement: Mobile Bottom Nav 5-tab IA（conditional on §Decision）
+
+**前置條件**：§Decision 結果為「5-tab adopt」才解鎖實作。否則本 requirement 標 N/A。
+
+修改 `src/components/shell/BottomNavBar.tsx`：
+
+| index | label | icon | onClick | active 判斷 |
+|---|---|---|---|---|
+| 0 | 聊天 | `chat` | `navigate('/chat')` | `pathname.startsWith('/chat')` |
+| 1 | 行程 | `home` | `navigate('/trips')` | `pathname.startsWith('/trips')` 或 `pathname.startsWith('/trip/')` |
+| 2 | 地圖 | `map` | `navigate('/map')` | `pathname.startsWith('/map')` 或 `pathname.startsWith('/trip/') && pathname.endsWith('/map')` |
+| 3 | 探索 | `search` | `navigate('/explore')` | `pathname.startsWith('/explore')` |
+| 4 | 帳號 | `user` | `navigate('/account')` | `pathname.startsWith('/account')` |
+
+設計規範（沿用既有 + 對齊 mockup）：
+- CSS grid `repeat(5, 1fr)`
+- 每 tab：icon (18×18 SVG) + label (`var(--font-size-caption2)` 11px / weight 700 對齊 mockup)
+- 觸控目標 `min-height: 44px`
+- Active 樣式：accent-subtle 底 + 2px top indicator (`border-top: 2px solid var(--color-accent)`) + accent text
+- Background：`rgba(255,255,255,0.97)` + `backdrop-filter: blur(var(--blur-glass))`
+- Border-top：1px `var(--color-border)`
+
+「更多」action sheet pattern 移除（內含的 collab / trip-select / appearance / export 等功能改去：collab → trip detail TitleBar、trip-select → 「行程」tab 內 picker、appearance → AccountPage「外觀設定」row、export → trip detail TitleBar OverflowMenu）。
+
+#### Scenario: 5-tab 顯示 + active 切換
+- **WHEN** mobile (≤760px) user load app
+- **THEN** Bottom nav 顯示 5 個 tab：聊天 / 行程 / 地圖 / 探索 / 帳號
+- **AND** 當前 pathname 對應的 tab active（accent-subtle 底 + 2px top indicator）
+
+#### Scenario: 「行程」tab 對 trip detail page active
+- **WHEN** user 在 `/trip/okinawa-2026`
+- **THEN** Bottom nav「行程」tab active
+
+#### Scenario: 「地圖」tab regex 不誤觸
+- **WHEN** user 在 `/manage/map-xxx`
+- **THEN** Bottom nav「地圖」tab **不** active（regex 嚴格 `/^\/(map$|trip\/[^/]+\/map$)/`）

--- a/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-account-hub-page/spec.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-account-hub-page/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: 新建 `/account` route + `AccountPage.tsx` 統一帳號 hub
+
+對應 mockup section 19 (line 7425-7583)。本 page 是既有分散在 `/settings/sessions` `/settings/connected-apps` `/settings/developer-apps` 的 settings entry hub，加 profile hero 與分組 settings rows，提供 mockup 規範的 unified 帳號管理介面。
+
+Page 元件結構（自上而下）：
+1. TitleBar 標題「帳號」+ 既有 back chevron pattern
+2. **Profile hero** 區塊：
+   - Avatar 64x64px（沿用既有 sidebar account chip avatar 邏輯，無自設 avatar 時用 user email 第一字母 + accent 背景）
+   - Name（DEV_MOCK_EMAIL 或 user.email）
+   - Email 文案
+   - 3 stats row：「N 個行程 / N 天旅程 / N 位旅伴」
+3. Settings rows 3 group（每 group 一個 `<section>` 含 `<h2>` group label + N 個 row）：
+   - **應用程式**：外觀設定 / 通知設定
+   - **共編 & 整合**：已連結 App / 開發者選項
+   - **帳號**：已登入裝置 / 登出 (destructive)
+
+每個 row 元件：left icon (圓形 box，accent-subtle 背景) + center title + helper text + right chevron。Click → navigate 對應 page，或 destructive 走 confirm dialog。
+
+#### Scenario: Logged-in user 訪問 /account
+- **WHEN** logged-in user 訪問 `/account`
+- **THEN** 顯示 TitleBar「帳號」+ Profile hero（avatar / name / email / 3 stats）+ 3 group settings rows
+- **AND** 7 個 row 全部可點擊（navigate 或 destructive）
+- **AND** Page 呼叫 `useRequireAuth` 強制登入
+
+#### Scenario: 未登入訪問 /account
+- **WHEN** unauth user 訪問 `/account`
+- **THEN** redirect 到 `/login?redirect_after=/account`
+
+#### Scenario: 點「已連結 App」row
+- **WHEN** 使用者點「已連結 App」row
+- **THEN** navigate `/settings/connected-apps`（既有 `ConnectedAppsPage.tsx`）
+
+#### Scenario: 點「已登入裝置」row
+- **WHEN** 使用者點「已登入裝置」row
+- **THEN** navigate `/settings/sessions`（既有 `SessionsPage.tsx`）
+
+#### Scenario: 點「開發者選項」row
+- **WHEN** 使用者點「開發者選項」row
+- **THEN** navigate `/settings/developer-apps`（既有 `DeveloperAppsPage.tsx`）
+
+#### Scenario: 點「外觀設定」row
+- **WHEN** 使用者點「外觀設定」row
+- **THEN** navigate `/account/appearance`（新建 minimal `AppearanceSettingsPage.tsx`，內容 = 既有 sidebar `<ThemeToggle>` 移到 page level）
+
+#### Scenario: 點「通知設定」row
+- **WHEN** 使用者點「通知設定」row
+- **THEN** navigate `/account/notifications`（新建 minimal `NotificationsSettingsPage.tsx` stub，初版內容「目前通知功能尚在開發中」+ 之後 polish）
+
+#### Scenario: 點「登出」destructive row
+- **WHEN** 使用者點「登出」row
+- **THEN** 顯示 confirm dialog「確認登出？」+「取消」/「登出」button
+- **AND** 確認後 POST `/api/oauth/logout` 清 session cookie + navigate `/login`
+- **AND** 此 row 視覺對齊 mockup `tp-account-row.is-danger`（destructive 紅色）
+
+### Requirement: Profile hero 3 stats 由新 endpoint `/api/account/stats` 提供
+
+新建 `functions/api/account/stats.ts` GET endpoint，aggregate 用 SQL SUM/COUNT 一次 query 回傳：
+
+```typescript
+{ tripCount: number, totalDays: number, collaboratorCount: number }
+```
+
+避免 client-side N+1 fetch。需 auth；無 trip 時三個值為 0。
+
+#### Scenario: 有 3 個 trip 的 user 取 stats
+- **WHEN** logged-in user 已建 3 個 trip 共 18 天 + 5 個其他 collaborator
+- **THEN** GET `/api/account/stats` return `{ tripCount: 3, totalDays: 18, collaboratorCount: 5 }`
+- **AND** AccountPage profile hero 顯示「3 個行程 / 18 天旅程 / 5 位旅伴」
+
+#### Scenario: 新 user 無 trip
+- **WHEN** logged-in user 還沒建任何 trip
+- **THEN** GET `/api/account/stats` return `{ tripCount: 0, totalDays: 0, collaboratorCount: 0 }`
+- **AND** AccountPage 顯示「0 個行程 / 0 天旅程 / 0 位旅伴」
+
+### Requirement: DesktopSidebar 加「帳號」nav item
+
+對應 mockup section 01 IA「聊天/行程/地圖/探索/帳號」第 5 項。
+
+修改 `src/components/shell/DesktopSidebar.tsx`：
+- 既有 logged-in 隱藏「登入」slot 改為 「帳號」item，icon `user`，target `/account`
+- Logged-out 仍顯示「登入」item
+- Sidebar 底部既有 user account chip 保留（因為 hover state 顯示 email 仍有用），但 click 改 navigate `/account`（之前 click 不動）
+
+#### Scenario: Logged-in user 看 sidebar
+- **WHEN** logged-in user load app
+- **THEN** sidebar 顯示 5 個 nav item：聊天 / 行程 / 地圖 / 探索 / 帳號
+- **AND**「帳號」item icon = user，active 判斷 `pathname.startsWith('/account')`
+
+#### Scenario: 點底部 user chip
+- **WHEN** logged-in user 點底部 sidebar account chip
+- **THEN** navigate `/account`

--- a/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-add-stop-modal/spec.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-add-stop-modal/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: 新建 `<AddStopModal>` 取代 `<InlineAddPoi>` 為加景點 entry
+
+對應 mockup section 14 (line 6428-6714)。`InlineAddPoi` day-level inline expand 模式改為 trip-level modal，UI 跟 interaction model 對齊 mockup 4-frame 規範。
+
+新 component `src/components/trip/AddStopModal.tsx`：
+- Modal layout（backdrop + centered card），開啟由 trip detail page-level「+ 加入景點」button 觸發
+- Header: 標題「加景點」+ 「DAY 03 · 7/31（五）」meta + close button
+- Region selector pill「沖繩 ▾」(default 用 trip.countries) + 「📋 篩選」 ghost button
+- 3 tabs：搜尋 / 收藏 / 自訂
+- 每 tab content 區
+- Footer: 「已選 N 個 · 將加入 Day 03 · 7/31」+ 取消 / 完成 buttons
+
+舊 `InlineAddPoi.tsx` 在本 capability 完成後移除（trigger 從每 DaySection 末尾改為 TripPage TitleBar actions 加「+ 加入景點」 chip 或 trip detail content top）。
+
+#### Scenario: 點 trip-level「+ 加入景點」 trigger
+- **WHEN** 使用者在 trip detail page 點「+ 加入景點」 trigger
+- **THEN** AddStopModal 以 modal pattern 開啟（backdrop + center card + Esc 關閉 + click backdrop 關閉）
+- **AND** modal Header 顯示當前選中 day（`activeDayNum`）的 meta
+- **AND** 預設停留在「搜尋」tab
+
+#### Scenario: 切換 day 在 modal 內
+- **WHEN** 使用者在 modal 內切換 day（切 day picker 或切 modal-internal day chip）
+- **THEN** modal Header meta 更新為新 day
+- **AND** Footer 「將加入 Day X」更新
+
+### Requirement: 「搜尋」tab 含 region selector + subtab chips + POI grid
+
+「搜尋」tab 內容：
+1. Subtab chips：為你推薦 / 景點 / 美食 / 住宿 / 購物（POI category filter）
+2. POI 2-col grid card，每張 card 含：
+   - Cover photo (`tp-add-poi-card-cover` with `data-tone` placeholder when no real photo)
+   - Name + ★ rating + distance
+   - 多選 checkbox（batch add）
+3. 點 POI card 切多選狀態
+4. 「為你推薦」subtab 預設顯示 region 內 trending POI（用 `/api/poi-search?q=trending&region={region}` 或類似）
+
+#### Scenario: 預設 subtab「為你推薦」+ 沖繩 region
+- **WHEN** 使用者開啟 modal「搜尋」tab
+- **THEN** 顯示 region selector「沖繩 ▾」+ subtab chips 5 項，「為你推薦」active
+- **AND** 顯示 2-col POI grid（推薦 POI list）
+
+#### Scenario: 切 subtab「美食」
+- **WHEN** 使用者點 subtab「美食」chip
+- **THEN** 重新 fetch POI list filtered by category=`restaurant`
+- **AND** Grid 重 render 美食 POI
+
+### Requirement: 「收藏」tab 對接既有 saved POI store
+
+「收藏」tab 列出 user 既有 saved POI（同 ExplorePage `儲存池` tab data source `/api/saved-pois`），但提供 batch add to 當前 trip 的 inline UX：
+- POI grid 同搜尋 tab 結構，每 card 含 checkbox
+- 預設無選取，使用者勾選後 footer counter 更新
+
+ExplorePage 「儲存池」tab 既有功能不變（仍然可以從 explore 進來 multi-select + 加入行程），AddStopModal 「收藏」 tab 是同 data 的另一 entry point。
+
+#### Scenario: 切「收藏」tab 顯示 user 的 saved POI
+- **WHEN** 使用者點「收藏」tab
+- **THEN** GET `/api/saved-pois` + render 2-col grid
+- **AND** Card 跟「搜尋」tab 結構一致（cover / name / rating / checkbox）
+
+#### Scenario: 「收藏」tab 無資料
+- **WHEN** 使用者尚未儲存任何 POI
+- **THEN** 顯示 empty state「還沒收藏任何 POI」+ link「去探索找 POI」 navigate `/explore`
+
+### Requirement: 「自訂」tab 提供 manual entry form
+
+「自訂」tab 是純 form：
+- 標題（required）
+- 地址（optional，typeahead 用 Nominatim）
+- 開始時間 / 結束時間（time picker）
+- 類型 select（attraction / restaurant / hotel / shopping / other）
+- 預估停留 number input（min）
+- 備註 textarea
+
+提交時 POST `/api/trips/:id/days/:num/entries` 直接寫入（同既有 promote endpoint），不經 saved POI store。
+
+#### Scenario: 自訂 entry form 全填送出
+- **WHEN** 使用者在「自訂」tab 填完 form 點完成
+- **THEN** POST `/api/trips/:id/days/:num/entries`，body 含 form 欄位
+- **AND** Success 後 modal 關閉 + DaySection refetch + 新 entry 出現在 timeline
+
+#### Scenario: 自訂 form 缺 title
+- **WHEN** 使用者沒填 title 點完成
+- **THEN** 顯示 inline validation error「請輸入景點名稱」
+- **AND** 不送 POST
+
+### Requirement: Batch select footer + 完成 commit
+
+Footer 永遠顯示，內容隨 selection 變動：
+- 0 選：「還沒選任何景點」+ 完成 button disabled
+- N 選：「已選 N 個 · 將加入 Day 03 · 7/31」+ 完成 button active
+
+點完成後：
+- 「搜尋」/「收藏」 tab 選的 POI list → 並行 N 個 POST `/api/trips/:id/days/:num/entries`
+- 全部成功後 modal 關閉 + DaySection refetch + Toast 「已加入 N 個景點」
+- 任一失敗 → 顯示 error toast + modal 不關，selection 保留
+
+#### Scenario: 多選 3 個 POI 點完成
+- **WHEN** 使用者多選 3 個搜尋結果 POI 點完成
+- **THEN** 並行 POST 3 次 entries endpoint
+- **AND** 全成功後 modal 關閉 + Toast 「已加入 3 個景點」
+
+#### Scenario: 多選後切 day 重新看 footer
+- **WHEN** 使用者已選 2 POI 後在 modal 內切 day
+- **THEN** Footer 「將加入 Day X」 更新為新 day
+- **AND** 完成時新 entries 都加到新 day
+
+### Requirement: 拿掉 day-level 「+ 加景點」 inline trigger
+
+舊 `InlineAddPoi` component 從 `DaySection.tsx` 移除。Trigger 改為 trip-level（`TripPage.tsx` TitleBar actions 增加「+ 加入景點」 chip 或 trip detail content top sticky chip）。
+
+避免 user 在 day 切換時要重啟 inline UI 的麻煩，且符合 mockup section 14 的 trigger placement 規範。
+
+#### Scenario: DaySection 不再有 inline add trigger
+- **WHEN** 使用者展開任何 day section
+- **THEN** Day section 末尾不再有「+ 加景點」 inline button
+- **AND** 加景點 entry point 集中在 page-level

--- a/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-icon-svg-sweep/spec.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-icon-svg-sweep/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: 所有 user-facing icon SHALL 用 inline SVG，不允許 emoji unicode
+
+對應 mockup section 12 lead 明文要求 + CLAUDE.md「icon 用 inline SVG，不用 emoji 或 icon font」。本 capability 完成後，下列 component 的 emoji icon 全部替換為 `<Icon name="..." />`：
+
+| Component | 既有 emoji | 對應 Icon name | mockup 來源 |
+|---|---|---|---|
+| `TimelineRail.tsx` `tp-rail-actions` 放大檢視 | `⛶` | `maximize` | mockup line 6075 `<svg><use href="#i-maximize"/>` |
+| `TimelineRail.tsx` `tp-rail-actions` 複製到其他天 | `⎘` | `copy` | mockup line 6076 `#i-copy` |
+| `TimelineRail.tsx` `tp-rail-actions` 移到其他天 | `⇅` | `arrows-vertical` | mockup line 6077 `#i-move-vertical` |
+| `TimelineRail.tsx` `tp-rail-actions` 刪除景點 | `🗑` | `trash` | mockup line 6079 `#i-trash` |
+| `TimelineRail.tsx` `tp-rail-actions` 收闔 | `✕` | `x` 或 `close` | mockup line 6080 `#i-x` |
+| `InlineAddPoi.tsx` search input prefix | `🔍` | `search` | mockup line 6457 `#i-search` |
+| `ExplorePage.tsx` POI card「+ 儲存」prefix（暫無 emoji 但使用 `+`/`✓` text） | `✓ 已儲存` | `check` | mockup line 7314 `#i-heart` |
+
+新 SVG sprite 補進 `src/components/shared/Icon.tsx` switch case：`trash` / `maximize` / `arrows-vertical` 三個（其他 `copy` / `x` / `search` / `check` 已存在）。
+
+#### Scenario: TimelineRail 展開列工具列全部用 SVG icon
+- **WHEN** 使用者展開任一 timeline entry
+- **THEN** 「放大檢視 / 複製 / 移到其他天 / 刪除 / 收闔」5 個 button 全部 render `<svg>` 元素
+- **AND** 全部 button DOM 內無 emoji unicode（U+1F300 以上 / U+2700-U+27BF symbol 範圍）
+- **AND** 既有 `data-testid` 不變（不破壞 unit test 跟 E2E 取 element）
+
+#### Scenario: InlineAddPoi 搜尋欄 icon 用 SVG
+- **WHEN** 使用者展開 day-level「+ 加景點」
+- **THEN** search input 左側 icon render `<Icon name="search" />` SVG
+- **AND** input DOM 內無 `🔍` emoji 字符
+
+#### Scenario: ExplorePage 已儲存 button 文字 + icon 對齊
+- **WHEN** 使用者在 explore 搜尋結果點「+ 儲存」後 button 變「已儲存」狀態
+- **THEN** button label 含 `<Icon name="check" />` SVG icon，文案「已儲存」
+- **AND** 不再使用 `✓` 字符 prefix
+
+### Requirement: emoji-icon contract test 防 regression
+
+新增 `tests/unit/no-emoji-icons.test.ts` source-grep test，掃描 `src/components/` + `src/pages/` 下所有 .tsx file，禁止以下 emoji unicode 出現在 JSX text node 範圍：
+
+- `🗑` `🔍` `⛶` `⎘` `⇅` `❤` `🚗` `📋`（mockup 主要違規 emoji 列表）
+- 例外白名單：`src/components/shared/Icon.tsx` 自身（icon catalog comment）、`tokens.css` placeholder content 內
+
+#### Scenario: 未來 PR 引入 emoji icon 應該 CI 阻擋
+- **WHEN** 開發者 PR 加入 `<button>🗑 刪除</button>` 之類 emoji-as-icon 程式碼
+- **THEN** `npm test` 執行 `no-emoji-icons.test.ts` 失敗，列出違規 file:line
+- **AND** CI gate 阻擋 PR merge

--- a/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-ui-parity-polish/spec.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/specs/terracotta-ui-parity-polish/spec.md
@@ -1,0 +1,283 @@
+## ADDED Requirements
+
+本 capability 集中處理 14 個 page section 的散落 inconsistency / minor missing / extra finding，按 file 分組。每個 sub-section 的 finding 都對應 design.md §Audit 的細節記錄。
+
+### Requirement: DesktopSidebar 視覺對齊 mockup section 01
+
+修改 `src/components/shell/DesktopSidebar.tsx`：
+
+| Finding | Mockup spec | 修改 |
+|---|---|---|
+| Active state 顏色 | accent 實心 (`background: --color-accent`) | 改 active item bg 從 `var(--color-foreground)` → `var(--color-accent)`，文字 `var(--color-accent-foreground)` |
+| Sidebar 整體背景 | `--color-foreground` 深棕底（dark sidebar on cream page） | 改 sidebar bg 從 `var(--color-background)` → `var(--color-foreground)`，inactive item 文字 muted-light |
+| Item font-weight | mockup 600 | 改 `.tp-sidebar-item` font-weight 從 500 → 600（active 時不再 escalate，因為已是預設） |
+| Account chip name truncation | mockup `name.length > 10 ? slice(0,10)+'…'` | 加 `truncate(name, 10)` JS-level 截字（不只靠 CSS ellipsis） |
+
+#### Scenario: Sidebar 視覺切換為 dark theme
+- **WHEN** logged-in user load desktop layout
+- **THEN** sidebar 背景 `rgb(42,31,24)` 深棕（var(--color-foreground)）
+- **AND** Active nav item 背景 var(--color-accent) terracotta，文字 white
+- **AND** Inactive item 文字 var(--color-muted)，hover 文字 var(--color-background)
+
+#### Scenario: 長 user name truncation
+- **WHEN** user name 超過 10 字（如「李 Maximilian 鳳梨太郎」12 字）
+- **THEN** Account chip 顯示「李 Maximilian …」（slice(0,10) + ellipsis）
+
+### Requirement: NewTripModal 文案 + tabs + 多目的地拖拉
+
+對應 mockup section 03 (line 5238-5626)。修改 `src/components/trip/NewTripModal.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| Modal title | 「新增行程」 | 改 title 從「想去哪裡？」→「新增行程」 |
+| 日期 mode tabs label | 「固定日期 / 大概時間」 | 改 tabs 文案從「選日期 / 彈性日期」→「固定日期 / 大概時間」 |
+| Section label | 「目的地（可加多筆，拖拉排序）」 | 改 destination section label 加 hint |
+| Helper 行 | 「行程跨 N 個目的地 · 順序決定地圖 polyline 串接方向」 | 加 helper 行在 destination input 下方 |
+| Sub-headline | 無 | 拿掉 React extra「先說目的地跟想做什麼，AI 會幫你排日程、餐廳、住宿。」 |
+
+新增多目的地 row 結構（取代現有 chips list）：
+- 每 row：grip handle + 編號 (1/2/3...) + name + region label + remove button
+- 用 `@dnd-kit/sortable`（既有 dependency）做拖拉重排
+- Remove 後重編號
+
+新增推薦 chips block（mockup Frame 2 + Frame 3）：
+- 「熱門目的地」chip group：日本 / 韓國 / 台灣 / 沖繩 / 京都 ...
+- 「最近搜尋」chip group：localStorage 拉前 5 個
+- Search dropdown 結果改為分組顯示（不平鋪）
+- 目的地數量 ≥2 時顯示「分配天數」stepper：每目的地 +/- N 天
+
+#### Scenario: 標題對齊 mockup
+- **WHEN** 使用者點「新增行程」 trigger 開啟 modal
+- **THEN** Modal title 顯示「新增行程」（不是「想去哪裡？」）
+
+#### Scenario: 多目的地拖拉重排
+- **WHEN** 使用者已加 3 個目的地（沖繩 / 京都 / 大阪），grip 拖第 3 個（大阪）到第 1 位
+- **THEN** Order 變「大阪 / 沖繩 / 京都」，編號 1/2/3 對應更新
+- **AND** 保留每 row 的 region 顯示
+
+#### Scenario: 「分配天數」stepper 顯示條件
+- **WHEN** 使用者加 2 個或更多目的地
+- **THEN** 顯示分配天數 stepper：每目的地 +/- N 天，總和 = trip.days
+- **AND** 1 個目的地時不顯示
+
+### Requirement: DaySection day hero 加 day title 概念
+
+對應 mockup section 10 (line 5904-5935)。修改 `src/components/trip/DaySection.tsx` 跟 data model：
+
+mockup 規範 day hero title 是「美ら海＋古宇利島一日跑」這種 user-facing 主題字串，不只是 `area || 'Day N'` fallback。
+
+需要：
+1. D1 schema：`trip_days` table 加 `title` text column (nullable)
+2. `mapDay.ts` 更新含 title
+3. DaySection hero 渲染 title 優先 → area fallback → 「Day N」最後 fallback
+4. （之後 polish）`/api/trips/:id/days/:num` PATCH 支援 day title 編輯
+
+本 capability 只做 1-3，編輯 UI 為 follow-up。
+
+#### Scenario: Day 有 title
+- **WHEN** day row `title` 欄位為「美ら海＋古宇利島一日跑」
+- **THEN** Day hero h2 顯示「美ら海＋古宇利島一日跑」
+- **AND** Area chip「水族館・古宇利」仍 render 在 chips row（meta 用）
+
+#### Scenario: Day 無 title 有 area
+- **WHEN** day row `title` 為 null，`area` 為「北谷」
+- **THEN** Day hero h2 顯示「北谷」（fallback to area）
+
+#### Scenario: Day 兩者都無
+- **WHEN** day row `title` + `area` 都 null
+- **THEN** Day hero h2 顯示「Day {dayNum}」
+
+### Requirement: DayNav 對齊 mockup section 11 day chips
+
+修改 `src/components/trip/DayNav.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| eyebrow 格式 | 「DAY 03 · 今天」（中文「今天」`·` 分隔） | 改 eyebrow logic：今天 day 加「· 今天」suffix（取代既有 `<span class="dn-weather">TODAY</span>` 獨立 pill） |
+| date 顯示 | mockup「7/29」 | 拿掉 React `<span class="dn-dow">` 週幾英文 extra 元素 |
+| area truncation | mockup 無截字 | 拿掉 `max-width: 80px` truncation 限制（或 raise 到 120px） |
+
+#### Scenario: 今天 chip eyebrow 含「· 今天」
+- **WHEN** day chip 對應 today
+- **THEN** eyebrow text「DAY 03 · 今天」
+- **AND** 無獨立 TODAY pill
+
+#### Scenario: 一般 day chip date 簡潔
+- **WHEN** day chip 對應 7/30
+- **THEN** date 顯示「7/30」
+- **AND** 無週幾英文 extra row
+
+### Requirement: TimelineRail 加結構化「說明 / 備註」section + 編輯備註 toolbar button
+
+對應 mockup section 12 + 13。修改 `src/components/trip/TimelineRail.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| Toolbar「編輯備註」button | mockup 有 (line 6078) `tp-rail-actions` 第 4 個 icon | Inline note click-to-edit 已 cover 但缺 toolbar entry — 加一個 pencil icon button 在 toolbar |
+| `tp-rail-actions` `window.confirm` | mockup 規定不用 native confirm | Delete 改用 ConfirmModal（既有 component pattern） |
+| Grip collapsed 狀態 | mockup hover row 才顯 | `.ocean-rail-grip` 預設 `opacity: 0`，row hover 變 `opacity: 1`（聚焦時也 visible） |
+
+#### Scenario: 點「編輯備註」toolbar button
+- **WHEN** 使用者展開 timeline entry 後點 toolbar 鉛筆 icon button
+- **THEN** 直接 focus note textarea（同 click note value 行為）
+
+#### Scenario: 刪除 entry 用 ConfirmModal
+- **WHEN** 使用者展開 entry 點 trash icon button
+- **THEN** 顯示 destructive ConfirmModal「確定刪除「XX」？此操作無法復原」+ 取消/確認 button
+- **AND** 不再用 `window.confirm`
+
+#### Scenario: Grip handle hover 才浮現
+- **WHEN** Timeline row 未 hover
+- **THEN** grip handle `opacity: 0`（不可見但 keyboard-focusable）
+- **WHEN** mouse hover row
+- **THEN** grip handle `opacity: 1`
+
+### Requirement: TripPage TitleBar 加文字 label + travel pill
+
+對應 mockup section 13。修改 `src/pages/TripPage.tsx` + TimelineRail：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| TitleBar actions | mockup 「建議 / 共編 / 下載」三 ghost button + icon+text combo + 更多 icon button | 改 TripPage actions 從 icon-only 為 ghost button with icon + text label（同 PageHeader pattern） |
+| Travel pill | mockup `tp-travel-pill` 「🚗 10 min · 4.2 km」於每兩 stop 之間 | TimelineRail render 兩 entry 間的 travel info pill（資料來源既有 `entry.travel_type/travel_min/travel_desc`） |
+
+#### Scenario: TripPage TitleBar 顯示 label
+- **WHEN** 使用者進 trip detail
+- **THEN** TitleBar 右側 actions 顯示「建議」+「共編」+「下載」3 個 ghost button (icon + text)，後接 OverflowMenu kebab
+- **AND** Mobile (≤760px) collapse 為 icon-only
+
+#### Scenario: 兩 stop 間 travel pill
+- **WHEN** 兩個 entry 之間有 `travel_type` + `travel_min` 資料
+- **THEN** 中間 render `tp-travel-pill`「🚗 10 min · 4.2 km」（icon + duration + distance）
+- **AND** 無 travel data 不 render
+
+### Requirement: TripsListPage 加 search + filter subtabs + sort + owner avatar
+
+對應 mockup section 16。修改 `src/pages/TripsListPage.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| Search bar | mockup desktop 有「搜尋」ghost button + active state expand | 加 search button + expanding search input + result count + `<mark>` highlight |
+| Filter subtabs | mockup「全部 / 我的行程 / 共編行程 / 已歸檔」 | 加 4 個 tab subtabs (segmented control) |
+| Sort dropdown | mockup「最新編輯 ▾」 | 加 sort dropdown（最新編輯 / 出發日近 / 名稱 a-z） |
+| Card meta | mockup 含 owner avatar + name | Card meta 加 owner avatar 32x32 + name |
+| Eyebrow 中文化 | mockup「日本 · 12 天」 | 改 eyebrow 從「JAPAN · 12 DAYS」全英文 → 中文「日本 · 12 天」 |
+| Empty state 文案 | mockup「還沒有行程 / 建立第一個行程，開始規劃你的下一趟旅程。也可以從探索頁尋找靈感。」 | 對齊 mockup 文案 |
+
+#### Scenario: 搜尋 trip
+- **WHEN** 使用者點 search button + type「沖繩」
+- **THEN** Trip list filtered + result count「找到 N 個」+ 名字內「沖繩」字 highlight
+- **AND** Cancel 收回 search bar
+
+#### Scenario: 切 filter「共編行程」subtab
+- **WHEN** 使用者點「共編行程」subtab
+- **THEN** Trip list 只剩 user 為 collaborator 不是 owner 的 trip
+
+#### Scenario: 排序「出發日近」
+- **WHEN** 使用者選 sort「出發日近」
+- **THEN** Trip list 按 `start_date` ascending 排（未開始的最近的最上面）
+
+#### Scenario: 中文 eyebrow
+- **WHEN** Render trip card 對應日本 12 天 trip
+- **THEN** eyebrow 顯示「日本 · 12 天」
+
+### Requirement: ChatPage 加 day divider + AI avatar + bubble timestamp prefix
+
+對應 mockup section 17。修改 `src/pages/ChatPage.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| Day divider | `tp-chat-day-divider` 在跨日訊息之間 | rowToMessages 邏輯加 day boundary detection，render `<div class="tp-chat-day-divider">2026-04-27</div>` |
+| AI avatar | mockup AI message 左側有「AI」 avatar pill | Assistant bubble 加 avatar 32x32 圓形 with「AI」text |
+| Bubble timestamp prefix | mockup「Tripline AI · 14:02」 | 改 `tp-chat-msg-time` 加 prefix「Tripline AI · 」for assistant message |
+| Conversation header | mockup 顯示 trip name | TitleBar 標題從「聊天」改為當前 trip name（picker pill 隨之收進 dropdown） |
+| Send button | mockup icon-only | 改「送出」 text button → icon-only with `<Icon name="send" />`（保留 aria-label「送出」） |
+
+#### Scenario: 跨日訊息間 render day divider
+- **WHEN** 同 conversation 兩條 messages 跨日（4/26 23:00 + 4/27 09:00）
+- **THEN** 兩條之間 render `<div class="tp-chat-day-divider">2026-04-27（六）</div>`
+
+#### Scenario: AI message bubble 含 avatar + timestamp prefix
+- **WHEN** Assistant message render
+- **THEN** Bubble 左側 avatar 顯示「AI」text on accent-subtle 背景
+- **AND** Timestamp 行顯示「Tripline AI · 14:02」（user message 不加 prefix）
+
+#### Scenario: ChatPage TitleBar 顯示 trip name
+- **WHEN** 使用者選定 trip 進 chat
+- **THEN** TitleBar 主標題 = trip.name（如「2026 沖繩五日自駕遊行程表」）
+- **AND** Trip switcher 改為 TitleBar overflow menu
+
+### Requirement: ExplorePage POI card 加 cover photo + ❤ + ★ rating + region selector + subtabs
+
+對應 mockup section 18。修改 `src/pages/ExplorePage.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| Card cover | `tp-explore-card-cover` placeholder color tone | Card 上半 100% width 16:9 cover image (POI photo URL or `data-tone` placeholder) |
+| ❤ favorite icon | top-right corner | Card overlay 右上角 heart toggle (favorite ≠ saved，是另一概念 — 或合併為 saved 同時是 favorite) |
+| ★ rating meta | `★ 4.6 · ¥2,180` | Card meta 加 ★ rating + 價位 ¥ 區間（既有 `googleRating` 對應） |
+| TitleBar action | mockup heart icon | 改既有 star icon → heart icon 對齊 mockup |
+| Region selector | mockup「沖繩 ▾」 | 加 region selector pill（default 用 user 最近 trip's region） |
+| Subtab chips | mockup「為你推薦 / 景點 / 美食 / 住宿 / 購物」 | 加 5 個 POI category subtab chips |
+| Card hover | accent border + lift shadow | 加 `:hover` accent border + `transform: translateY(-2px)` + shadow-md |
+
+#### Scenario: POI card 結構含 cover + heart + rating
+- **WHEN** Render POI card
+- **THEN** Card 上半 cover image (如無 POI photo URL，用 `data-tone` 預設 8 種顏色 placeholder)
+- **AND** 右上 heart icon button（toggle saved）
+- **AND** Card meta「★ 4.6 · ¥2,180」（無 rating 隱藏 ★ 區）
+
+#### Scenario: 切 subtab「美食」
+- **WHEN** 使用者點 subtab「美食」chip
+- **THEN** POI search 重 fetch with category=`restaurant` filter
+- **AND** Grid 重 render
+
+#### Scenario: 切 region
+- **WHEN** 使用者點 region selector「沖繩 ▾」+ 選「京都」
+- **THEN** POI search 重 fetch with region=`京都`
+- **AND** Region selector label 更新「京都 ▾」
+
+### Requirement: MapPage 加 FAB buttons (圖層 / 定位)
+
+對應 mockup section 20。修改 `src/pages/MapPage.tsx` + `GlobalMapPage.tsx`：
+
+| Finding | Mockup | 修改 |
+|---|---|---|
+| 圖層 FAB | `#i-layers` icon | Map 右下加 FAB button「圖層」open layer picker（衛星 / 街道 / 地形） |
+| 定位 FAB | mockup 有 | Map 右下加 FAB button「定位」 trigger geolocation API + flyTo |
+| Day tab overview 第一項 | 「總覽 · 7 天」無顏色點 | MapDayTab 第一項保持 `total days` summary 樣式 |
+| Active day tab underline | dayColor border-bottom | MapDayTab active 用 `border-bottom: 2px solid var(--day-color)` |
+
+#### Scenario: 點圖層 FAB 切 layer
+- **WHEN** 使用者點地圖右下「圖層」FAB
+- **THEN** Popover 顯示 3 layer 選項：街道（default）/ 衛星 / 地形
+- **AND** 選後 Leaflet tile layer 切換
+
+#### Scenario: 點定位 FAB
+- **WHEN** 使用者點地圖右下「定位」FAB
+- **THEN** Browser 提示 geolocation 權限 → 取得位置後地圖 flyTo + 顯示 user marker
+
+### Requirement: 新建 `<AlertPanel>` persistent banner with warning/error variants
+
+對應 mockup section 04 (line 5626-5678)。新 component `src/components/shared/AlertPanel.tsx`：
+
+| Variant | Mockup | 用途 |
+|---|---|---|
+| `error` | `tp-alert-panel.is-error` | persistent error banner（如「無法載入行程，請檢查網路」） |
+| `warning` | `tp-alert-panel.is-warning` | persistent warning（如「離線模式，部分功能受限」） |
+| `info` | `tp-alert-panel`（default） | persistent info（如「已恢復連線，正在同步」） |
+
+Component prop：`variant`、`icon`、`title`、`message`、`actionLabel`、`onAction`、`onDismiss`。
+
+跟既有 `Toast`（短暫）、`InlineError`（form field-level）、`ErrorPlaceholder`（empty state-level）區別：AlertPanel 是 page-top persistent banner。
+
+#### Scenario: TripPage 載入失敗顯示 error panel
+- **WHEN** TripPage `loadTrip` 失敗
+- **THEN** Page 上方 render `<AlertPanel variant="error" title="無法載入行程" message="..." actionLabel="重試" onAction={refetch} />`
+- **AND** Panel 不自動消失（需 user 點 dismiss 或 retry 成功）
+
+#### Scenario: 離線時顯示 warning panel
+- **WHEN** `useOnlineStatus` 偵測到 offline
+- **THEN** App 上方 render `<AlertPanel variant="warning" title="離線模式" message="部分功能受限，連線恢復後會自動同步" />`
+- **WHEN** 連線恢復
+- **THEN** Panel 切換為 info variant「已恢復連線，正在同步」5 秒後 dismiss

--- a/openspec/changes/terracotta-mockup-parity-v2/tasks.md
+++ b/openspec/changes/terracotta-mockup-parity-v2/tasks.md
@@ -1,0 +1,199 @@
+> Implementation tasks 對照 5 capability spec。Section 1-5 各自獨立 PR ship；Section 5 (mobile-bottom-nav) 第一 task 是 product decision，decision 結果決定後續 task 解鎖與否。
+
+## 1. terracotta-icon-svg-sweep
+
+對應 `specs/terracotta-icon-svg-sweep/spec.md`。預估 1 PR / ~1 天。
+
+- [ ] 1.1 補 `src/components/shared/Icon.tsx` 新 SVG sprite：`trash` / `maximize` / `arrows-vertical`（lucide / heroicons style 1.5px stroke），含 unit test 驗 case 切換正確 path
+- [ ] 1.2 替換 `src/components/trip/TimelineRail.tsx` `tp-rail-actions` 5 個 emoji button：`🗑→<Icon name="trash" />` / `✕→<Icon name="x" />` / `⛶→<Icon name="maximize" />` / `⎘→<Icon name="copy" />` / `⇅→<Icon name="arrows-vertical" />`
+- [ ] 1.3 替換 `src/components/trip/InlineAddPoi.tsx` search input prefix：`🔍→<Icon name="search" />`
+- [ ] 1.4 替換 `src/pages/ExplorePage.tsx` POI card「+ 儲存」/「✓ 已儲存」 button：`✓` text prefix → `<Icon name="check" />`
+- [ ] 1.5 寫 `tests/unit/no-emoji-icons.test.ts` source-grep contract test：掃 `src/components/` + `src/pages/` 全 .tsx，禁止 emoji unicode (`🗑 🔍 ⛶ ⎘ ⇅ ❤ 🚗 📋`) 在 JSX text node，例外 `Icon.tsx` self
+- [ ] 1.6 修改 `tests/unit/timeline-rail-inline-expand.test.tsx` 既有 toolbar test：改用 `data-testid` 取 button 不依賴 emoji text content
+- [ ] 1.7 跑 `npm test` + `npx tsc --noEmit` 全 green
+- [ ] 1.8 commit `style(icons): emoji unicode → SVG sprite cross-component sweep` + push + 開 PR + ship
+
+## 2. terracotta-account-hub-page
+
+對應 `specs/terracotta-account-hub-page/spec.md`。預估 1 PR / ~3-4 天。
+
+- [ ] 2.1 寫 failing test：`tests/unit/account-page.test.tsx` 驗 unauth 時 redirect /login，logged-in 顯示 hero + 7 rows
+- [ ] 2.2 寫 failing integration test：`tests/api/account-stats.integration.test.ts` 驗 `/api/account/stats` 回 `{ tripCount, totalDays, collaboratorCount }`，含 0 trip 跟 multi-trip case
+- [ ] 2.3 建 `functions/api/account/stats.ts` GET endpoint：requireAuth + SQL aggregate (COUNT trips / SUM days / COUNT distinct collaborators)
+- [ ] 2.4 新建 `src/pages/AccountPage.tsx`：TitleBar「帳號」+ ProfileHero (avatar + name + email + 3 stats fetch from /api/account/stats) + 3 group settings rows
+- [ ] 2.5 建 `<SettingsRow>` 共用 component：left icon (圓形 box accent-subtle) + center title + helper + right chevron + onClick navigate
+- [ ] 2.6 設 row navigate：外觀→`/account/appearance`、通知→`/account/notifications`、連結 App→`/settings/connected-apps`、開發者→`/settings/developer-apps`、裝置→`/settings/sessions`、登出→ConfirmModal + POST /api/oauth/logout + navigate /login
+- [ ] 2.7 新建 `src/pages/AppearanceSettingsPage.tsx` minimal：page header + 既有 `<ThemeToggle>` + 主題選擇 grid（沿用 TripSheetContent 'appearance' case 內容）
+- [ ] 2.8 新建 `src/pages/NotificationsSettingsPage.tsx` stub：page header + 文案「通知設定 coming soon」+ link 回 /account
+- [ ] 2.9 加 4 條 routes 到 `src/entries/main.tsx`：`/account` `/account/appearance` `/account/notifications`（`/settings/*` 既有）
+- [ ] 2.10 修改 `src/components/shell/DesktopSidebar.tsx`：logged-in 隱藏「登入」slot 改為「帳號」item (icon=user, target=/account, active=startsWith('/account'))；logged-out 仍顯「登入」
+- [ ] 2.11 修改 sidebar 底部 user account chip click 行為：navigate('/account')（之前無 onClick）
+- [ ] 2.12 寫 Playwright E2E `tests/e2e/account-page.spec.js`：login → /account → 驗 hero 3 stats + 7 rows visible + 點「已登入裝置」navigate /settings/sessions
+- [ ] 2.13 跑 `npm test` + `npm run test:api` + `npx tsc --noEmit` 全 green
+- [ ] 2.14 commit `feat(account): unified Account hub page + sidebar 「帳號」 nav item` + push + 開 PR + ship
+
+## 3. terracotta-add-stop-modal
+
+對應 `specs/terracotta-add-stop-modal/spec.md`。預估 1 PR / ~5 天。
+
+- [ ] 3.1 寫 failing test：`tests/unit/add-stop-modal.test.tsx` 驗 modal open/close + tab switch + footer counter + 點完成 batch POST
+- [ ] 3.2 寫 failing test：「自訂」tab form validation（缺 title 顯示 inline error）
+- [ ] 3.3 新建 `src/components/trip/AddStopModal.tsx`：Modal layout (backdrop + center card + Esc/click-backdrop 關) + Header (標題 + day meta + close) + region selector + 3 tabs + content + Footer
+- [ ] 3.4 「搜尋」tab：subtab chips 5 項 (為你推薦/景點/美食/住宿/購物) + 2-col POI grid 用 `<AddPoiCard>` (cover photo + name + rating + checkbox)
+- [ ] 3.5 「為你推薦」default subtab 內容：fetch trending POI by region（暫用既有 `/api/poi-search?q=`+region 名稱 trending hack，或新建 `/api/poi-search/trending?region=` endpoint，看 backend lift）
+- [ ] 3.6 「收藏」tab：fetch `/api/saved-pois` (既有 endpoint) + render 同 grid + checkbox 多選；empty state「還沒收藏任何 POI」+ link /explore
+- [ ] 3.7 「自訂」tab：form (title required / address typeahead Nominatim / time pickers / type select / duration min input / note textarea) + 提交 POST /api/trips/:id/days/:num/entries
+- [ ] 3.8 Footer 邏輯：counter「已選 N 個 · 將加入 Day X · MM/DD」+ 完成 button (disabled when 0 selected) + 取消 button
+- [ ] 3.9 完成 commit：並行 N POST /api/trips/:id/days/:num/entries（搜尋 + 收藏 tab）；自訂 tab 單筆；任一失敗 inline error toast 並保留 selection
+- [ ] 3.10 修改 `src/pages/TripPage.tsx`：trip detail content top 加 sticky「+ 加入景點」 chip 或 TitleBar actions 加，open AddStopModal 帶當前 activeDayNum
+- [ ] 3.11 修改 `src/components/trip/DaySection.tsx`：移除 `<InlineAddPoi>` import + 渲染（保留 component file 為 follow-up cleanup）
+- [ ] 3.12 既有 `src/components/trip/InlineAddPoi.tsx` mark deprecated（comment header 標 + 不刪 file 為避免 PR 過大，下個 PR cleanup）
+- [ ] 3.13 寫 Playwright E2E `tests/e2e/add-stop-modal.spec.js`：login → trip → 點「+ 加入景點」 trigger → modal 開 → 切 3 tab + 「自訂」tab 提交 form → 驗 timeline 出現新 entry
+- [ ] 3.14 跑 `npm test` + `npx tsc --noEmit` 全 green
+- [ ] 3.15 commit `feat(add-stop): modal 4-tab pattern (搜尋/收藏/自訂) + batch select + trip-level trigger` + push + 開 PR + ship
+
+## 4. terracotta-ui-parity-polish
+
+對應 `specs/terracotta-ui-parity-polish/spec.md`。按 file group 拆 sub-section，預估 2 PR / ~5-7 天（Section 4.1-4.4 = PR1，Section 4.5-4.10 = PR2）。
+
+### 4.1 DesktopSidebar 視覺對齊（mockup section 01）
+
+- [ ] 4.1.1 寫 failing test：`tests/unit/desktop-sidebar-visual.test.tsx` 驗 sidebar 背景 var(--color-foreground) + active item 背景 var(--color-accent) + name truncation > 10 字加 ellipsis
+- [ ] 4.1.2 修改 `src/components/shell/DesktopSidebar.tsx`：sidebar bg → var(--color-foreground) 深棕 + inactive item 文字 muted-light
+- [ ] 4.1.3 修改 active item 樣式：bg → var(--color-accent) + 文字 var(--color-accent-foreground)
+- [ ] 4.1.4 修改 `.tp-sidebar-item` font-weight 500 → 600
+- [ ] 4.1.5 加 `truncate(name, 10)` JS-level：account chip name 超過 10 字 slice + ellipsis
+- [ ] 4.1.6 視覺驗證：local dev sidebar 切 dark theme + 截圖比 mockup section 01
+
+### 4.2 NewTripModal 文案 + 多目的地拖拉（mockup section 03）
+
+- [ ] 4.2.1 寫 failing test：`tests/unit/new-trip-modal-multidest.test.tsx` 驗多目的地拖拉重排 + 編號更新 + region 顯示 + helper 行渲染
+- [ ] 4.2.2 改 modal title 文案：「想去哪裡？」→「新增行程」
+- [ ] 4.2.3 改日期 mode tabs label：「選日期 / 彈性日期」→「固定日期 / 大概時間」
+- [ ] 4.2.4 改 destination section label：「目的地」→「目的地（可加多筆，拖拉排序）」
+- [ ] 4.2.5 加 helper 行：「行程跨 N 個目的地 · 順序決定地圖 polyline 串接方向」
+- [ ] 4.2.6 拿掉 sub-headline「先說目的地跟想做什麼，AI 會幫你排日程、餐廳、住宿。」
+- [ ] 4.2.7 重 build destination input：用 `@dnd-kit/sortable` 做 sortable list，每 row = grip + 編號 + name + region + remove；取代既有 chips list
+- [ ] 4.2.8 加「熱門目的地」chip group + 「最近搜尋」chip group（localStorage 取前 5）
+- [ ] 4.2.9 dropdown search results 改分組顯示
+- [ ] 4.2.10 加「分配天數」stepper：dest count ≥ 2 時顯示，每 dest +/- N 天，總和 = trip.days
+- [ ] 4.2.11 視覺驗證：local dev 開 NewTripModal + 加 3 dest 拖拉 + 截圖比 mockup section 03
+
+### 4.3 DaySection day hero 加 day title（mockup section 10）
+
+- [ ] 4.3.1 寫 failing test：`tests/unit/day-section-title.test.tsx` 驗 day hero title fallback 邏輯（title → area → 「Day N」）
+- [ ] 4.3.2 D1 migration：建 `migrations/00XX_add_trip_days_title.sql` 加 `title TEXT` column
+- [ ] 4.3.3 跑 migration: dev → staging → production（按 CLAUDE.md 三環境順序）
+- [ ] 4.3.4 修改 `src/lib/mapDay.ts`：`Day` interface 加 `title?: string`
+- [ ] 4.3.5 修改 `src/components/trip/DaySection.tsx` hero：title || area || `Day ${dayNum}` 三層 fallback
+- [ ] 4.3.6 follow-up issue 紀錄：「day title 編輯 UI（PATCH /api/trips/:id/days/:num）」留下個 PR
+
+### 4.4 DayNav eyebrow 對齊（mockup section 11）
+
+- [ ] 4.4.1 寫 failing test：`tests/unit/day-nav-eyebrow.test.tsx` 驗今天 chip eyebrow「DAY 03 · 今天」+ 一般 chip 不含週幾英文 extra row
+- [ ] 4.4.2 修改 `src/components/trip/DayNav.tsx` eyebrow logic：今天 day 加「· 今天」suffix（拿掉獨立 TODAY pill）
+- [ ] 4.4.3 拿掉 `<span class="dn-dow">` 週幾英文 extra row
+- [ ] 4.4.4 area max-width 80px → 拿掉或 raise 120px
+
+### 4.5 TimelineRail 加結構 section + 編輯備註 button + ConfirmModal（mockup section 12）
+
+- [ ] 4.5.1 寫 failing test：`tests/unit/timeline-rail-toolbar-pencil.test.tsx` 驗 toolbar 含 pencil button click → focus note textarea
+- [ ] 4.5.2 加 toolbar 鉛筆 icon button：order 在「移到其他天」後「刪除」前；click → focus note textarea (`tp-rail-note-input` autoFocus)
+- [ ] 4.5.3 替換 `handleDelete` `window.confirm` → ConfirmModal pattern（destructive variant，沿用 DemoteConfirmModal 結構）
+- [ ] 4.5.4 修改 `.ocean-rail-grip` CSS：default `opacity: 0`，row hover 變 `opacity: 1`，keyboard focus 也 visible
+
+### 4.6 TripPage TitleBar + travel pill（mockup section 13）
+
+- [ ] 4.6.1 寫 failing test：`tests/unit/trip-page-titlebar-actions.test.tsx` 驗 TitleBar 顯示「建議 / 共編 / 下載」3 個 ghost button (icon + text) + OverflowMenu kebab
+- [ ] 4.6.2 改 TripPage TitleBar actions 從 icon-only 為 ghost button with icon + text label；mobile (≤760px) collapse 為 icon-only
+- [ ] 4.6.3 寫 failing test：`tests/unit/timeline-rail-travel-pill.test.tsx` 驗兩 entry 間有 travel data 時 render `tp-travel-pill`「🚗 N min · X km」
+- [ ] 4.6.4 修改 `src/components/trip/TimelineRail.tsx` 渲染：兩 RailRow 之間 conditional render `<TravelPill>` (data: entry.travel_type / travel_min / travel_desc)
+- [ ] 4.6.5 新建 `<TravelPill>` 共用 component：travel_type → icon (車/走路/船...) + min + desc text
+
+### 4.7 TripsListPage filter+search+sort+owner+中文化（mockup section 16）
+
+- [ ] 4.7.1 寫 failing test：`tests/unit/trips-list-page-filters.test.tsx` 驗 filter subtabs (4 個) + sort dropdown (3 option) + search expanding bar
+- [ ] 4.7.2 加 filter subtabs (segmented control)：全部 / 我的行程 / 共編行程 / 已歸檔；用 client-side filter 既有 trips list（archived 需 D1 schema 支援，archived 為 follow-up）
+- [ ] 4.7.3 加 sort dropdown：最新編輯 / 出發日近 / 名稱 a-z；client-side sort
+- [ ] 4.7.4 加 search expanding bar：button → expand input + 即時 filter trips by name + result count + `<mark>` highlight matched 字
+- [ ] 4.7.5 改 card eyebrow 從「JAPAN · 12 DAYS」全英文 → 中文「日本 · 12 天」（country code → 中文 map）
+- [ ] 4.7.6 加 card meta 含 owner avatar 32x32 + name (`tp-list-card-avatar` + `tp-list-card-meta-text`)
+- [ ] 4.7.7 改 empty state 文案「還沒開始任何行程 / 建立第一個行程，AI 會幫你排...」→「還沒有行程 / 建立第一個行程，開始規劃你的下一趟旅程。也可以從探索頁尋找靈感。」
+
+### 4.8 ChatPage day divider + AI avatar + bubble timestamp prefix（mockup section 17）
+
+- [ ] 4.8.1 寫 failing test：`tests/unit/chat-page-day-divider.test.tsx` 驗跨日訊息間 render `tp-chat-day-divider`
+- [ ] 4.8.2 寫 failing test：`tests/unit/chat-page-ai-avatar.test.tsx` 驗 assistant message bubble 含 avatar「AI」+ timestamp 「Tripline AI · 14:02」prefix
+- [ ] 4.8.3 修改 `rowToMessages` 加 day boundary detection：兩條 message 跨日時 inject `{ id: 'day-divider-YYYY-MM-DD', type: 'day-divider', date }` 假 message
+- [ ] 4.8.4 ChatPage render loop 處理 day-divider type：render `<div class="tp-chat-day-divider">{date}（{weekday}）</div>` 不渲染 bubble
+- [ ] 4.8.5 加 `tp-chat-avatar.is-ai`「AI」avatar 32x32 在 assistant bubble 左側（user message 不加）
+- [ ] 4.8.6 修改 `tp-chat-msg-time` for assistant：prefix「Tripline AI · 」（user message 不加）
+- [ ] 4.8.7 改 ChatPage TitleBar 主標題從固定「聊天」→ 當前 trip.name；trip switcher 改進 TitleBar OverflowMenu
+- [ ] 4.8.8 改「送出」 text button → icon-only `<Icon name="send" />` button (保留 aria-label「送出」)
+
+### 4.9 ExplorePage POI card cover + heart + rating + region + subtabs（mockup section 18）
+
+- [ ] 4.9.1 寫 failing test：`tests/unit/explore-page-card-cover.test.tsx` 驗 POI card 含 cover photo + heart toggle + rating meta
+- [ ] 4.9.2 重 build `explore-poi-card`：top 100% 16:9 cover image (POI photo URL || `data-tone` 8 種顏色 placeholder) + 右上 heart icon button (toggle saved) + meta「★ 4.6 · ¥2,180」
+- [ ] 4.9.3 改 TitleBar action icon：star → heart 對齊 mockup
+- [ ] 4.9.4 加 region selector pill：「沖繩 ▾」default = user 最近 trip's countries；click open dropdown 列其他 region
+- [ ] 4.9.5 加 subtab chips「為你推薦 / 景點 / 美食 / 住宿 / 購物」5 個；click 切 POI search filter by category
+- [ ] 4.9.6 加 card hover：accent border + `transform: translateY(-2px)` + shadow-md transition
+- [ ] 4.9.7 重新評估 ExplorePage 「儲存池 multi-select + 加入行程 modal」流程在 add-stop-modal 完成後是否還必要（可能下個 PR cleanup）
+
+### 4.10 MapPage FAB + day tab overview + AlertPanel（mockup section 20 + section 04）
+
+- [ ] 4.10.1 加 `src/components/trip/MapFabs.tsx`：右下 FAB stack 「圖層」+「定位」 button
+- [ ] 4.10.2 圖層 FAB：popover 顯示街道 / 衛星 / 地形 3 選項；select 切 Leaflet tile layer
+- [ ] 4.10.3 定位 FAB：navigator.geolocation.getCurrentPosition → flyTo + 顯示 user marker
+- [ ] 4.10.4 修改 `src/components/trip/MapDayTab.tsx` active 樣式：`border-bottom: 2px solid var(--day-color)` underline
+- [ ] 4.10.5 建 `src/components/shared/AlertPanel.tsx`：variant (error/warning/info) + icon + title + message + actionLabel + onAction + onDismiss
+- [ ] 4.10.6 寫 unit test `tests/unit/alert-panel.test.tsx` 驗 3 variants render + dismiss + action callback
+- [ ] 4.10.7 接入 `useOnlineStatus`：offline 時 render warning AlertPanel；online 切回 info「已恢復連線，正在同步」5s 後 dismiss
+- [ ] 4.10.8 接入 TripPage 載入失敗：error AlertPanel + retry action
+
+### 4.11 Polish PR ship gate
+
+- [ ] 4.11.1 跑 `npm test` + `npm run test:api` + `npx tsc --noEmit` 全 green
+- [ ] 4.11.2 跑 `/design-review` 對 polish 後 page 視覺校對 mockup
+- [ ] 4.11.3 commit + push + 開 1 個 PR (Section 4.1-4.6) + ship；之後 1 個 PR (Section 4.7-4.10) + ship
+
+## 5. mobile-bottom-nav decision + conditional implement
+
+對應 `specs/mobile-bottom-nav/spec.md`。預估 decision 1 task / 實作 conditional ~3 天。
+
+### 5.1 Product decision gate
+
+- [ ] 5.1.1 invoke `/office-hours` 或 `/plan-ceo-review` 跑 forcing question discussion：5-tab global vs 4-tab trip-scoped vs hybrid 哪個 align trip-planner 的 product strategy？
+- [ ] 5.1.2 紀錄 decision 到 `openspec/changes/terracotta-mockup-parity-v2/notes/bottom-nav-ia-decision.md`：選擇方向 + rationale + impact on existing trip-scoped UX + migration risk
+
+### 5.2 Conditional implementation (only if decision = 5-tab adopt)
+
+- [ ] 5.2.1 寫 failing test：`tests/unit/bottom-nav-5-tab.test.tsx` 驗 5 tab render + active 判斷 regex + 觸控目標 ≥44px
+- [ ] 5.2.2 修改 `src/components/shell/BottomNavBar.tsx`：5 tab list (聊天/行程/地圖/探索/帳號)，CSS grid `repeat(5, 1fr)`
+- [ ] 5.2.3 加 active state 2px top indicator + accent-subtle 底
+- [ ] 5.2.4 拿掉「更多」action sheet pattern + 對應 sheet handler
+- [ ] 5.2.5 「更多」內含的功能遷移：collab → trip detail TitleBar、trip-select →「行程」tab 內 picker、appearance → AccountPage「外觀設定」row、export → trip detail TitleBar OverflowMenu
+- [ ] 5.2.6 驗證 active tab regex 不誤觸：`/manage/map-xxx` 不該觸發「地圖」tab active
+- [ ] 5.2.7 跑 Playwright E2E 驗 5 tab navigation
+- [ ] 5.2.8 寫 archive note：本 capability ship 後 archive 既有 `mobile-bottom-nav.md` 4-tab spec
+
+### 5.3 Conditional skip (if decision = keep 4-tab)
+
+- [ ] 5.3.1 mockup section 02 標 deviation accepted：在本 change `notes/` 下寫 `bottom-nav-ia-deviation.md` 紀錄為何不對齊 + 影響評估
+- [ ] 5.3.2 既有 mobile-bottom-nav.md spec 不變
+- [ ] 5.3.3 本 capability 收尾為 decision-only（無實作 commit）
+
+### 5.4 Conditional hybrid (if decision = hybrid)
+
+- [ ] 5.4.1 設計 hybrid 切換邏輯：context-aware nav (登入後 5-tab，trip 內 4-tab)
+- [ ] 5.4.2 加 path-based detect + 視覺切換 indicator
+- [ ] 5.4.3 寫 unit test 驗 path 切換 nav 正確
+- [ ] 5.4.4 ship 同 5.2.7-5.2.8
+
+## 6. Change archive
+
+- [ ] 6.1 全 5 capability 各自 ship 完成 + post-merge 24h Sentry / daily-check 監控無 regression
+- [ ] 6.2 invoke `/opsx:archive terracotta-mockup-parity-v2` 走 archive flow
+- [ ] 6.3 確認 mockup parity audit 重跑（agent 跑 audit 驗證 finding 數降到 0 或剩 acceptable deviation）
+- [ ] 6.4 紀錄 archive 結果於 `openspec/changes/archive/YYYY-MM-DD-terracotta-mockup-parity-v2/`


### PR DESCRIPTION
## Summary

依據 `docs/design-sessions/terracotta-preview-v2.html` (Terracotta v2 mockup, 7950 行 / 14 page section) 對照 React 實作的 audit 結果，發現 ~46 missing / 42 inconsistent / 11 extra finding 跨 13 components + 1 缺漏整頁 (Account hub)。

本 PR **純 OpenSpec spec docs**，無 code 變動。把 audit 完整寫入規格、拆 5 capability，之後 implementation 走 `/opsx:apply` 各自獨立 feature branch + PR。

## Artifacts (4/4)

- `proposal.md` — Why + 5 capability list + Impact
- `design.md` — Decisions + Migration plan + **§Audit 含完整 14 section finding 表**
- `specs/` × 5：
  - `terracotta-icon-svg-sweep/` — emoji unicode → SVG sprite (TimelineRail/InlineAddPoi/ExplorePage)
  - `terracotta-account-hub-page/` — 新建 `/account` unified hub + sidebar 「帳號」 nav
  - `terracotta-add-stop-modal/` — InlineAddPoi → trip-level modal 4-tab pattern
  - `terracotta-ui-parity-polish/` — 14 page section 散落 inconsistency sweep
  - `mobile-bottom-nav/` — 5-tab vs 4-tab IA decision gate (product 決策題先)
- `tasks.md` — 6 sections / ~70 task / 預估 5 PR / 4-5 週

## Migration Plan (design.md §Migration)

| Week | Capability | 預估 |
|---|---|---|
| 1 | icon-svg-sweep ship (lowest-risk warm-up) | 1 PR / 1 天 |
| 1-2 | bottom-nav decision (office-hours/CEO review parallel) | decision gate |
| 2 | ui-parity-polish PR1 (Section 4.1-4.6) | 1 PR / 3 天 |
| 3 | account-hub-page (新 page + sidebar nav + stats endpoint) | 1 PR / 3-4 天 |
| 4 | add-stop-modal (modal 4-tab + batch select) | 1 PR / 5 天 |
| 5 | bottom-nav implement (依 decision) + polish PR2 + archive | 1 PR / 3 天 |

## Test plan

- [x] OpenSpec status: 4/4 artifact done
- [x] 純 docs 變動，無 code path 影響
- [ ] CI tsc/test/build 過（spec md 無 import 不影響）
- [ ] Reviewer 看 design.md §Audit 確認 finding 列表精準
- [ ] Reviewer 看 5 spec/spec.md 確認 ADDED Requirements 完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)