### PR TITLE
fix(layout): .tp-embedded-trip 改 grid layout (從 root 解 TitleBar squeeze)

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1086,6 +1086,12 @@ body.dark {
     align-self: flex-start;
     width: 100%;
     height: 64px;
+    /* 2026-05-03 fix: 加 flex-shrink: 0 防 .tp-embedded-trip flex-column container
+     * 把 TitleBar 從 64px 壓縮到 children max-height 45px。User 觀察「行程明細
+     * 標題列比其他功能頁低」 + 「加景點外框不正確」 (button 44×44 凸出 squeezed
+     * TitleBar 邊界 1px) 同 root cause — flex item default flex-shrink: 1 + min-height: auto
+     * 讓 TitleBar 在父空間不足時被壓到 content min-size。 */
+    flex-shrink: 0;
     padding: 0 24px;
     display: flex;
     align-items: center;
@@ -1119,6 +1125,8 @@ body.dark {
     align-self: flex-start;
     width: 100%;
     height: 56px;
+    /* 2026-05-03 fix: 加 flex-shrink: 0 防 flex-column container 壓縮 — 詳見 desktop rule 註釋 */
+    flex-shrink: 0;
     padding: 0 16px;
     display: flex;
     align-items: center;

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1086,12 +1086,6 @@ body.dark {
     align-self: flex-start;
     width: 100%;
     height: 64px;
-    /* 2026-05-03 fix: 加 flex-shrink: 0 防 .tp-embedded-trip flex-column container
-     * 把 TitleBar 從 64px 壓縮到 children max-height 45px。User 觀察「行程明細
-     * 標題列比其他功能頁低」 + 「加景點外框不正確」 (button 44×44 凸出 squeezed
-     * TitleBar 邊界 1px) 同 root cause — flex item default flex-shrink: 1 + min-height: auto
-     * 讓 TitleBar 在父空間不足時被壓到 content min-size。 */
-    flex-shrink: 0;
     padding: 0 24px;
     display: flex;
     align-items: center;
@@ -1125,8 +1119,6 @@ body.dark {
     align-self: flex-start;
     width: 100%;
     height: 56px;
-    /* 2026-05-03 fix: 加 flex-shrink: 0 防 flex-column container 壓縮 — 詳見 desktop rule 註釋 */
-    flex-shrink: 0;
     padding: 0 16px;
     display: flex;
     align-items: center;

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -75,9 +75,24 @@ const SCOPED_STYLES = `
  * 取代 PR-AA 的 floating sticky back btn — 那個獨佔一行、跟 mockup 不符。
  *
  * 結構：[← back btn] [trip name] — 56px 全寬、sticky top、glass blur。 */
+/* 2026-05-03 root fix:從 flex-column 改 grid 「chrome auto + content 1fr」
+ * 模式。原 flex-column + default flex-shrink:1 + min-height:auto 讓 TitleBar
+ * 在父空間不足時 (TripPage 內容很長) 被擠壓到 children max-height (45px),
+ * user 觀察「行程明細標題列比其他功能頁低」+「加景點外框不正確」(button 凸出)
+ * 同 root cause。
+ *
+ * Grid template rows:
+ *   row 1 (auto)  — TitleBar 用 CSS height: 56px (compact) / 64px (desktop) fixed
+ *   row 2 (1fr)   — TripPage .ocean-shell 撐滿剩餘 viewport
+ *
+ * 比 flex column + flex-shrink:0 更 semantic: chrome (auto) + main (1fr)
+ * 是 W3C grid layout standard pattern。同 ChatPage / MapPage 用 flex
+ * column + child explicit flex:1 一致語意,但 grid 不需依賴 child set 對的
+ * flex behavior,layout intent 完全在 parent。 */
 .tp-embedded-trip {
   position: relative;
-  display: flex; flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr;
   height: 100%;
   min-height: 100%;
 }


### PR DESCRIPTION
User 觀察 (prod \`/trips?selected=okinawa-trip-2026-HuiYun\`) + browse skill 確認:
1. 「標題列比其他功能頁高度低」 — embedded TitleBar 渲染 45px (預期 56px)
2. 「加景點外框不正確」 — 同 root cause (button 44×44 凸出 squeeze TitleBar 邊界)

User 評論首版 patch「這感覺像硬改？要從根本用正確的 css 樣式」 → 改用 root layout fix。

## Root cause (browse skill mobile audit prod)

| Page | TitleBar height | parent display |
|------|---|---|
| /trips (一覽) | 56px ✅ | block |
| **/trips?selected=... (明細)** | **45px ❌** | flex |
| /chat | 56px ✅ | flex |
| /map | 56px ✅ | flex |
| /explore /account /settings/* /developer/* | 56px ✅ | block |

關鍵: \`/chat\` /\`/map\` 也是 flex parent **但沒被 squeeze** — 因為它們的 content child (chat-body / map container) 有明確 \`flex: 1\` 撐滿剩餘空間。

\`.tp-embedded-trip\` 是 flex-column 但 child \`.ocean-shell\` (TripPage 渲染) 沒明確 flex behavior → default \`flex-shrink: 1\` + \`min-height: auto\` → 內容很長時 TitleBar 被壓縮到 children min-size (44px back/actions button + 1px border = 45px)。

## Root fix (取代 patch)

**Patch (rejected)**: \`.tp-titlebar { flex-shrink: 0 }\` 全 site
- ❌ 是 defensive patch，layout intent 不在 parent
- ❌ 依賴每個 chrome element 自己 set 對的 flex behavior

**Root fix (this PR)**: \`.tp-embedded-trip\` 從 flex column 改 grid
\`\`\`css
.tp-embedded-trip {
  display: grid;
  grid-template-rows: auto 1fr;  /* chrome auto + main 1fr */
  height: 100%;
}
\`\`\`
- ✅ Semantic: chrome (auto) + main (1fr) 是 W3C grid layout standard pattern
- ✅ Layout intent 完全在 parent，不依賴 child flex behavior
- ✅ 同 ChatPage / MapPage flex+child:flex:1 一致語意但更乾淨
- ✅ TitleBar height 永遠 respect CSS rule (56/64px fixed)，不會被 squeeze

## What changed

- **REVERT**: \`css/tokens.css\` 桌機 + 手機 \`.tp-titlebar { flex-shrink: 0 }\` 兩處 patch
- **ADD**: \`src/pages/TripsListPage.tsx\` \`.tp-embedded-trip\` 從 \`display: flex; flex-direction: column\` 改 \`display: grid; grid-template-rows: auto 1fr\`

## Tests

- 1293 unit + 598 API 全綠
- typecheck 乾淨
- prod deploy 後 browse skill 量 .tp-titlebar 56px (待 verify)

## Test plan

- [ ] CI 全綠 + Cloudflare Pages preview deploy
- [ ] /trips?selected=... mobile prod browse: \`.tp-titlebar\` height = **56px** (not 45)
- [ ] /trips 一覽頁 mobile: \`.tp-titlebar\` 56px (不變)
- [ ] /chat /map /explore /account 桌機/手機: 56/64px (不變)
- [ ] 加景點 button (44×44) 不再凸出 TitleBar 邊界

🤖 Generated with [Claude Code](https://claude.com/claude-code)