### PR TITLE
docs(design): sync mockup S23 + DESIGN.md to PR #449 (radius-md + DayNav underline)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -266,15 +266,18 @@
 **Action button (`.tp-titlebar-action`)**
 - 唯一合法 class，禁止自製 ad-hoc class
 - 兩 variant: default outline / `.is-primary` accent filled
-- 桌機: pill (radius full) + 1px border + icon + 文字 label
-- 手機: round (radius full) + 1px border + icon-only (label hidden via `.tp-titlebar-action-label` @media)
+- 桌機: rounded rect (radius-md 8px) + 1px border + icon + 文字 label
+- 手機: square 44×44 + radius-md (rounded corners) + 1px border + icon-only (label hidden via `.tp-titlebar-action-label` @media)
 - 44×44 min tap target
 - 多 action 水平排列, `.tp-titlebar-actions` wrapper, gap 6px
 
-**例外 button class**
-- `.tp-titlebar-back` — 左側返回 button, 36×36 transparent icon-only
-- `.tp-titlebar-icon-btn` — OverflowMenu kebab trigger, icon-only no border
-- `.tp-embedded-menu-trigger` — EmbeddedActionMenu 內部 kebab, 36×36 square; 不得用作 primary action
+**Button family radius 統一規則**
+所有 TitleBar button (含返回 / icon trigger / action) **一律 radius-md (8px)** — 不用 radius-full pill。對齊 mockup S23 spec + `.tp-embedded-menu-trigger` 既有 36×36 square + radius-md 視覺風格。
+
+**例外 button class** (都用 radius-md，差別在 size + border)
+- `.tp-titlebar-back` — 左側返回 button, 44×44 transparent icon-only + radius-md
+- `.tp-titlebar-icon-btn` — OverflowMenu kebab trigger, 44×44 icon-only no border + radius-md
+- `.tp-embedded-menu-trigger` — EmbeddedActionMenu 內部 kebab, 36×36 square + radius-md (smaller size for sub-trigger context)
 
 **Sub-content 規則 (TitleBar 下方)**
 - eyebrow + meta: 用 `.tp-page-eyebrow` + `.tp-page-meta` inline 在 TitleBar 下方第一行 (settings/list page 資訊密度需求)
@@ -307,10 +310,24 @@
 | `/explore`、探索結果、POI 詳細 | 探索 |
 | `/account`、connected apps、developer apps | 帳號 |
 
-### Trip Detail DayNav
-- Sticky 在 titlebar 下方，與 bottom nav 使用同一套 hide-on-scroll 行為。
-- Day item 可使用 data visualization day color，但外框、文字與 inactive state 仍跟 Terracotta 系統。
-- Compact 以水平 scroll + scroll snap；desktop 可保留較寬 chip。
+### Day Nav (Trip Detail + Map page 共用視覺)
+
+統一 colorful underline tab format — `.ocean-day-strip` (TripPage `<DayNav>`) 與 `.tp-map-day-tabs` (MapPage) 視覺對齊。
+
+**Tab 規格 (`[data-dn]` / `.tp-map-day-tab`)**
+- text-only (eyebrow + date)，無 chip background fill / border
+- Eyebrow: `DAY 01` 套 per-day color (`dayColor(dayNum)` from `src/lib/dayPalette` — 10-tone Tailwind -500 palette)
+- Date: 14px / 600 weight, `color-foreground` (active 套 accent color)
+- Active state: 2px `border-bottom` 用 `--day-color` inline override (per-day color underline)
+- Idle: muted text + transparent border-bottom
+- Hover (idle): `color-foreground`
+- 44px min tap target
+
+**Strip container (`.ocean-day-strip` / `.tp-map-day-tabs`)**
+- Sticky chrome group: 緊接 TitleBar (top: 64px desktop / 56px compact, mobile top:0)
+- Background glass blur 14px + 1px bottom hairline border
+- Horizontal scroll, scrollbar hidden
+- 右側 mask 漸層 fade 暗示「還有更多 day 可水平捲」
 
 ### Trip Detail Page
 - Desktop / compact 共用同一份 `TripDetail` 內容樹：DayNav、stop list、住宿、交通、地圖摘要、錯誤訊息、空狀態都不可拆成兩套邏輯。
@@ -340,11 +357,6 @@
 - Modal backdrop / portal 浮層
 - 大型 split hero / 形象圖
 - Loading 蓋住 page (改用 `<PageErrorState>` 或 inline skeleton)
-
-### Day Chip（`[data-dn]`）
-- 160×auto（compact 140/130）。
-- Border hairline，active = terracotta 實心白字；地圖 day indicator 可套 day color 例外。
-- 內容三段：`DAY 01` / 日期 / area label。Progress marks 僅在資訊密度需要時使用。
 
 ### Stop Card
 - 4-col grid：`68px time | 48px icon box | content | actions`，compact 可收斂到 3-col。

--- a/docs/design-sessions/terracotta-preview-v2.html
+++ b/docs/design-sessions/terracotta-preview-v2.html
@@ -566,7 +566,7 @@
     font-size: 12px;
     font-weight: 600;
     padding: 4px 10px;
-    border-radius: 9999px;
+    border-radius: 8px;
     letter-spacing: 0;
     display: inline-flex;
     align-items: center;
@@ -8581,31 +8581,31 @@
 
   <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; padding: 24px; background: var(--color-secondary); border-radius: 12px; border: 1px solid var(--color-border);">
     <div>
-      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">DESKTOP — Outline pill (default)</p>
-      <button style="display: inline-flex; align-items: center; gap: 6px; height: 44px; padding: 0 14px; border-radius: 9999px; border: 1px solid var(--color-border); background: transparent; color: var(--color-foreground); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;">
+      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">DESKTOP — Outline rounded rect (default)</p>
+      <button style="display: inline-flex; align-items: center; gap: 6px; height: 44px; padding: 0 14px; border-radius: 8px; border: 1px solid var(--color-border); background: transparent; color: var(--color-foreground); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;">
         <span class="tp-icon" style="width: 16px; height: 16px;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
         新增行程
       </button>
       <p style="font-size: 11px; color: var(--color-muted); margin: 8px 0 0;">用例：「新增行程」/「我的收藏」/「+ 加景點」(secondary action)</p>
     </div>
     <div>
-      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">MOBILE — Outline icon-only round (label hidden)</p>
-      <button style="display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; padding: 0; border-radius: 9999px; border: 1px solid var(--color-border); background: transparent; color: var(--color-foreground); cursor: pointer;">
+      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">MOBILE — Outline icon-only square w/ rounded corners (label hidden)</p>
+      <button style="display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; padding: 0; border-radius: 8px; border: 1px solid var(--color-border); background: transparent; color: var(--color-foreground); cursor: pointer;">
         <span class="tp-icon" style="width: 18px; height: 18px;"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
       </button>
-      <p style="font-size: 11px; color: var(--color-muted); margin: 8px 0 0;">2026-05-03 polish: 加回 1px border 對齊桌機 + 強化 affordance</p>
+      <p style="font-size: 11px; color: var(--color-muted); margin: 8px 0 0;">統一 radius-md 8px (rounded corners)，跟桌機 + .tp-embedded-menu-trigger 同 family</p>
     </div>
     <div>
-      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">DESKTOP — .is-primary accent filled pill</p>
-      <button style="display: inline-flex; align-items: center; gap: 6px; height: 44px; padding: 0 14px; border-radius: 9999px; border: 1px solid var(--color-accent); background: var(--color-accent); color: var(--color-accent-foreground); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;">
+      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">DESKTOP — .is-primary accent filled rounded rect</p>
+      <button style="display: inline-flex; align-items: center; gap: 6px; height: 44px; padding: 0 14px; border-radius: 8px; border: 1px solid var(--color-accent); background: var(--color-accent); color: var(--color-accent-foreground); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;">
         <span class="tp-icon" style="width: 16px; height: 16px;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
         儲存
       </button>
       <p style="font-size: 11px; color: var(--color-muted); margin: 8px 0 0;">用例：「儲存」/「建立」/「完成」/「確認撤銷」(primary destructive 用 .is-danger 變體)</p>
     </div>
     <div>
-      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">MOBILE — .is-primary icon-only round (label hidden)</p>
-      <button style="display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; padding: 0; border-radius: 9999px; border: 1px solid var(--color-accent); background: var(--color-accent); color: var(--color-accent-foreground); cursor: pointer;">
+      <p style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-muted); margin: 0 0 8px;">MOBILE — .is-primary icon-only square w/ rounded corners (label hidden)</p>
+      <button style="display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; padding: 0; border-radius: 8px; border: 1px solid var(--color-accent); background: var(--color-accent); color: var(--color-accent-foreground); cursor: pointer;">
         <span class="tp-icon" style="width: 18px; height: 18px;"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
       </button>
     </div>


### PR DESCRIPTION
承接 PR #449 (TitleBar buttons radius-md + DayNav colorful underline) 的 SoT 同步。

## What changed

### 1. Mockup \`terracotta-preview-v2.html\` Section 23

- 4 button live demo radius 從 \`9999px\` (full pill) → **\`8px\` (radius-md rounded rect)**
- Label text 更新:
  - Outline pill → **Outline rounded rect** (default)
  - icon-only round → **icon-only square w/ rounded corners**
  - .is-primary accent filled pill → **.is-primary accent filled rounded rect**
- 移除舊「2026-05-03 polish: 加回 1px border」 stale 描述
- 統一 radius-md 8px family description (跟 .tp-embedded-menu-trigger 同 family)

### 2. DESIGN.md「Page Titlebar」 section

- Action button 規範: 桌機 pill (full) → **rounded rect (radius-md)**, 手機 round → **square + rounded corners (radius-md)**
- 加新 sub-section「Button family radius 統一規則」: 一律 radius-md, 禁止 full pill
- 例外 button class 列表更新 radius (44×44 + radius-md, 不是 full)

### 3. DESIGN.md 取代「Trip Detail DayNav」+「Day Chip」 → 統一「Day Nav」 section

- text-only colorful underline tab format
- eyebrow per-day color from \`src/lib/dayPalette\`
- active 2px border-bottom + per-day color underline
- Strip sticky chrome group (top 64/56/0 桌機/compact/mobile)
- 移除舊 chip card pill 規範 (border + filled-accent active)

## Tests

- design-md-sections 8 cases pass
- 純 docs 同步, 無 code 變化

🤖 Generated with [Claude Code](https://claude.com/claude-code)