### PR TITLE
refactor: PoiSearchResult unify + usePoiSearch hook + tp-form consolidation + DeveloperApps in-place patch + comment cleanup

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -103,10 +103,10 @@ html { color-scheme: light dark; }
     --font-size-title2: 1.375rem;
     --font-size-title3: 1.25rem;
     --font-size-headline: 1.0625rem;
-    --font-size-body: 1rem; /* 16px — mockup body 規範（曾為 17px headline alias，2026-04-29 對齊 mockup 降 1px） */
+    --font-size-body: 1rem; /* 16px — mockup body 規範 */
     --font-size-callout: 1rem;
     --font-size-subheadline: 0.9375rem;
-    --font-size-footnote: 0.875rem; /* 14px — mockup support 規範（曾為 13px，2026-04-29 對齊 mockup 升 1px） */
+    --font-size-footnote: 0.875rem; /* 14px — mockup support 規範 */
     --font-size-caption: 0.75rem;
     --font-size-caption2: 0.6875rem;  /* 11px */
     --font-size-eyebrow: 0.625rem;    /* 10px — uppercase eyebrow labels (DAY 01, STOPS, etc.) */
@@ -159,9 +159,8 @@ html { color-scheme: light dark; }
     /* Z-index */
     --z-sticky-nav: 200;
     --z-fab: 300;
-    /* PR-S 2026-04-26：modal 必須高過所有 sticky 元素（sticky-nav 200 / fab
-     * 300 / quick-panel 350 / info-sheet 401）。9000 留 buffer 給未來更高
-     * priority overlay（emergency banner / toast 之類）。 */
+    /* modal 必須高過所有 sticky (sticky-nav 200 / fab 300 / quick-panel 350 /
+     * info-sheet 401)。9000 留 buffer 給未來 emergency banner / toast。 */
     --z-modal: 9000;
 
     /* Focus ring */
@@ -179,11 +178,8 @@ html { color-scheme: light dark; }
     --animate-toast-slide-up: toast-slide-up var(--transition-duration-normal) ease forwards;
 
     /* Layout composite */
-    /* PR-U 2026-04-26：原值 calc(48 + 12) = 60px 假設 page 有 sticky topbar，
-     * /explore /map /trips landing /sessions 等 mobile page 沒有 topbar 的，
-     * toast 60px 直接覆蓋 page heading（user 截圖回報「目前繁忙碌中」 蓋住
-     * 「探索」 標題）。改 max(16, safe-area-inset-top) 對齊 iOS HIG transient
-     * notification 慣例：頂部 safe area 下方就近顯示，跨 page 一致。 */
+    /* Toast 距頂使用 safe-area inset (對齊 iOS HIG transient notification)。
+     * 不能用固定 60px — page 沒 sticky topbar 時 toast 會直接蓋住 page heading。 */
     --spacing-toast-top: max(16px, env(safe-area-inset-top, 16px));
     --spacing-content-h: calc(100dvh - var(--spacing-nav-h));
 }
@@ -504,9 +500,8 @@ body.dark {
         display: none;
     }
 
-    /* 2026-05-01 mockup S12 Variant A 對齊 — 單層 5 欄 grid，移除冗餘 dot。
-     * Cols: grip(24) | time+dur(60) | icon(44) | content(1fr) | caret(24)。
-     * Grip 永遠淡顯（hover 變 accent），與 time/icon/content/caret 同 row。 */
+    /* mockup S12 Variant A — 單層 5 欄 grid，無冗餘 dot。
+     * Cols: grip(24) | time+dur(60) | icon(44) | content(1fr) | caret(24)。 */
     .ocean-rail-item {
         position: relative;
         display: grid;
@@ -575,9 +570,8 @@ body.dark {
         min-width: 0; overflow: hidden;
         display: flex; flex-direction: column; gap: 2px;
     }
-    /* 2026-04-29 mockup parity:meta.label 從 sub line 拉出為 chip eyebrow
-     * (mockup S12「HOTEL」「SIGHT · 景點」)— 11px caps + letter-spacing 0.12 +
-     * accent color。是 caps spacing 不是 chip background,輕量視覺權重。 */
+    /* meta chip eyebrow (mockup S12「HOTEL」「SIGHT · 景點」) — 11px caps +
+     * letter-spacing + accent color。是 caps spacing 不是 chip background。 */
     .ocean-rail-chip {
         font-size: var(--font-size-eyebrow);
         font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase;
@@ -784,8 +778,8 @@ body.dark {
         --color-cover-jp-to: #D97848;
         --color-cover-kr-from: #8A4520;
         --color-cover-kr-to: #5A4634;
-        /* PR-EE 2026-04-26：dark mode TW cover 太亮（#9E6800 amber 在深色 ui
-         * 上跳出來太搶眼），降到 deep amber-brown 跟 cover-other-from 接近。 */
+        /* dark mode TW cover 不能用 light-mode 的 amber #9E6800 — 在深色 UI
+         * 上會過度跳出，降到 deep amber-brown 跟 cover-other-from 接近。 */
         --color-cover-tw-from: #5A4220;
         --color-cover-tw-to: #4D372A;
         --color-cover-other-from: #4D372A;
@@ -880,10 +874,8 @@ body.dark {
 }
 
 
-/* ===== Page eyebrow + meta helpers (2026-05-03 PageHeader 退役後共用) =====
- * 替代原 PageHeader 的 eyebrow + meta 功能。settings 子頁 / list page 在
- * <TitleBar> 下方緊接這兩個 element 提供 context label + description。
- * Source: src/pages/ConnectedAppsPage / DeveloperAppsPage / SessionsPage. */
+/* ===== Page eyebrow + meta helpers (TitleBar 下方 context label + description) =====
+ * 用於 settings 子頁 / list page。Used by ConnectedAppsPage / DeveloperAppsPage / SessionsPage. */
 .tp-page-eyebrow {
   margin: 0 0 4px;
   font-size: var(--font-size-eyebrow);
@@ -1009,6 +1001,65 @@ body.dark {
 }
 
 
+/* ===== .tp-form / .tp-form-row — vertical form scaffold (auth + dev forms 共用) =====
+ * LoginPage / ForgotPasswordPage / DeveloperAppNewPage 原本各自重複定義。
+ * 預設輸入尺寸 = 表單密集 (10px 12px padding)；auth 變體加 .tp-form--auth
+ * 拉高 padding 到 12px 14px + 48px touch 高度。 */
+.tp-form { display: flex; flex-direction: column; gap: 16px; }
+.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
+.tp-form-row > label {
+  font-size: var(--font-size-footnote);
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.tp-form-row > input,
+.tp-form-row > textarea {
+  font-family: inherit;
+  font-size: var(--font-size-callout);
+  padding: var(--tp-form-input-pad-y, 10px) var(--tp-form-input-pad-x, 12px);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  min-height: var(--tp-form-input-min-h, auto);
+}
+.tp-form-row > textarea {
+  font-family: 'SF Mono', ui-monospace, monospace;
+  font-size: var(--font-size-footnote);
+  min-height: 80px;
+  resize: vertical;
+}
+.tp-form-row > input:focus,
+.tp-form-row > textarea:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  border-color: var(--color-accent);
+}
+.tp-form--auth {
+  --tp-form-input-pad-y: 12px;
+  --tp-form-input-pad-x: 14px;
+  --tp-form-input-min-h: 48px;
+}
+.tp-form-row .tp-hint-link {
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: var(--font-size-caption);
+  text-decoration: none;
+}
+.tp-form-row .tp-hint-link:hover { text-decoration: underline; }
+.tp-form-row .tp-hint {
+  font-size: var(--font-size-caption2);
+  color: var(--color-muted);
+  font-weight: 500;
+}
+.tp-form-row .tp-error {
+  font-size: var(--font-size-caption);
+  color: var(--color-destructive);
+}
+
+
 /* ===== MapDayTab — bottom underline tab (V2 Terracotta Map page) ===== */
 .tp-map-day-tabs {
   flex-shrink: 0;
@@ -1024,9 +1075,7 @@ body.dark {
 }
 .tp-map-day-tabs::-webkit-scrollbar { display: none; }
 .tp-map-day-tab {
-  /* 2026-04-29 mockup parity:user 反饋「Day 的格式不能太高」,padding
-   * 10/14 + min-height 44px → 6/14 + min-height 36px,跟 mockup S20 underline
-   * tabs 視覺一致(扁平 strip,不搶佔垂直空間)。 */
+  /* 扁平 strip — 不搶佔垂直空間，對齊 mockup S20 underline tabs spec。 */
   flex: 0 0 auto;
   padding: 6px 14px;
   border: none;
@@ -1273,12 +1322,9 @@ body.dark {
 .tp-titlebar-back:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
 .tp-titlebar-back .svg-icon { width: 18px; height: 18px; }
 
-/* 2026-04-29:title action button 帶文字 label。User 拍板「桌機 icon+文字、
- * 手機 icon only」是所有 title 規範。
- *
- * 用法:button class="tp-titlebar-action" 含 <Icon> + <span class="tp-titlebar-action-label">label</span>
- * 桌機(>=761):pill 樣式 icon + 文字 inline
- * 手機(<=760):縮回 icon-only 圓形(label hide) */
+/* TitleBar action button RWD：桌機 (>=761) pill 樣式 icon + 文字 inline；
+ * 手機 (<=760) 縮回 icon-only 圓形 (label hidden via @media)。
+ * 用法：<button class="tp-titlebar-action"><Icon /><span class="tp-titlebar-action-label">label</span></button> */
 .tp-titlebar-action {
   display: inline-flex;
   align-items: center;
@@ -1307,8 +1353,8 @@ body.dark {
   .tp-titlebar-action {
     width: var(--spacing-tap-min);
     padding: 0;
-    /* 2026-05-03 polish: 保留 1px border 跟桌機一致 + radius-md 跟桌機 + .tp-embedded-menu-trigger
-     * 同 family (rounded rectangle / icon-only square w/ rounded corners)。 */
+    /* mobile icon-only：保留 border + radius，跟桌機 + .tp-embedded-menu-trigger
+     * 同視覺 family (rounded rectangle)。 */
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     justify-content: center;
@@ -1316,9 +1362,8 @@ body.dark {
   .tp-titlebar-action-label { display: none; }
 }
 
-/* 2026-05-03: primary variant for confirm action button (儲存 / 完成 / 建立)。
- * Accent 實心，桌機 icon + 文字、手機 icon only (繼承 .tp-titlebar-action 的 RWD)。
- * 用法: <button class="tp-titlebar-action is-primary">…</button> */
+/* primary variant — confirm action (儲存 / 完成 / 建立)。Accent 實心，
+ * 桌機 icon+文字 / 手機 icon only (繼承 .tp-titlebar-action RWD)。 */
 .tp-titlebar-action.is-primary {
   background: var(--color-accent);
   color: var(--color-accent-foreground);
@@ -1433,8 +1478,8 @@ body.dark {
 .tp-titlebar-trip-row-title { font-weight: 700; font-size: var(--font-size-callout); }
 .tp-titlebar-trip-row-meta { font-size: var(--font-size-caption2); color: var(--color-muted); }
 
-/* mockup-parity-qa-fixes 2026-04-29: page-title compact override
- * mockup .tp-page-titlebar-title compact:4088 規範 page-title 24px on <760px viewport. */
+/* page-title compact override — mockup .tp-page-titlebar-title compact spec：
+ * 24px on <760px viewport (28px on desktop)。 */
 @media (max-width: 760px) {
   :root {
     --font-size-title: 1.5rem; /* 28px → 24px on compact */

--- a/src/components/trip/DaySection.tsx
+++ b/src/components/trip/DaySection.tsx
@@ -112,9 +112,6 @@ const DaySection = React.memo(function DaySection({
   // title (trip_days.title) → 區域 label (trip_days.label, 例「美瑛」) →「Day N」。
   const dayTitle = day?.title?.trim() || area || `Day ${dayNum}`;
 
-  // QA 2026-04-26 PR-J：拿掉每日 hero 的「📖 看地圖」 chip — user feedback
-  // 「移除每日 header 看地圖」。bottom nav 已有「地圖」 tab 入口，每天 chip 重複。
-
   return (
     <section className="ocean-day day-section" data-day={dayNum}>
       <style>{MAP_CHIP_STYLES}</style>

--- a/src/hooks/usePoiSearch.ts
+++ b/src/hooks/usePoiSearch.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import type { PoiSearchResult } from '../types/poi';
+
+interface UsePoiSearchOptions {
+  /** Disable the hook entirely (e.g. when not on search tab). Default: true (enabled). */
+  enabled?: boolean;
+  /** Search query — empty / <2 chars triggers no fetch and clears results. */
+  query: string;
+  /** Result count cap. Default: 20. */
+  limit?: number;
+  /** Debounce window in ms. Default: 300. */
+  debounceMs?: number;
+  /**
+   * Optional caller-side response normaliser. API may return either a bare
+   * array or `{ results: [...] }` wrapper, with snake_case vs camelCase row
+   * shapes. Default: cast as `PoiSearchResult[]` (assumes API returns canonical shape).
+   */
+  normalise?: (raw: unknown) => PoiSearchResult[];
+  /** Optional error callback. Default: silent. Called for non-OK HTTP + network errors (not AbortError). */
+  onError?: (kind: 'http-error' | 'network-error', err?: unknown) => void;
+}
+
+interface UsePoiSearchResult {
+  results: PoiSearchResult[];
+  searching: boolean;
+}
+
+/**
+ * usePoiSearch — debounced + abort-safe POI search hook.
+ *
+ * Replaces the duplicated ~50-LOC debounce + AbortController + fetch pattern
+ * that lived in NewTripPage / EditTripPage / AddStopPage / ExplorePage.
+ *
+ * Behaviour:
+ *   - Debounce 300ms (configurable) on `query` change
+ *   - Min query length 2 chars (shorter → empty results, no fetch)
+ *   - AbortController per request: rapid typing cancels inflight requests so
+ *     the most recent query always wins (no last-write-wins race)
+ *   - Cleanup on unmount + on `query`/`enabled`/`limit` change
+ *   - Silent on errors (caller can wrap in try/catch if needed via `normalise`)
+ */
+export function usePoiSearch({
+  enabled = true,
+  query,
+  limit = 20,
+  debounceMs = 300,
+  normalise,
+  onError,
+}: UsePoiSearchOptions): UsePoiSearchResult {
+  const [results, setResults] = useState<PoiSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setSearching(true);
+      try {
+        const resp = await fetch(
+          `/api/poi-search?q=${encodeURIComponent(trimmed)}&limit=${limit}`,
+          { signal: ctrl.signal },
+        );
+        if (!resp.ok) {
+          onError?.('http-error');
+          if (abortRef.current === ctrl) setResults([]);
+          return;
+        }
+        const raw = await resp.json() as unknown;
+        const rows = normalise ? normalise(raw) : (raw as PoiSearchResult[]);
+        if (abortRef.current === ctrl) setResults(rows);
+      } catch (err) {
+        if ((err as { name?: string })?.name === 'AbortError') return;
+        onError?.('network-error', err);
+        if (abortRef.current === ctrl) setResults([]);
+      } finally {
+        if (abortRef.current === ctrl) setSearching(false);
+      }
+    }, debounceMs);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      abortRef.current?.abort();
+    };
+  }, [enabled, query, limit, debounceMs, normalise, onError]);
+
+  return { results, searching };
+}

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -139,10 +139,8 @@ const SCOPED_STYLES = `
 }
 .tp-account-row-chevron .svg-icon { width: 14px; height: 14px; }
 
-/* Logout destructive variant — 2026-04-29 加強 visual:title + helper 都繼承
- * destructive red(原本只 row color set,但 title/helper 用 explicit color
- * override,沒繼承到 red),對齊 mockup S19 「登出」 row 整 row 紅字 visual。
- * icon 從 arrow-left 改 x-mark 對齊 mockup destructive 語意。 */
+/* destructive variant — title + helper 都覆寫成紅字（不能只設 row color，
+ * .tp-account-row-title/.tp-account-row-helper 有 explicit color 不繼承）。 */
 .tp-account-row.is-danger { color: var(--color-priority-high-dot, #c0392b); }
 .tp-account-row.is-danger .tp-account-row-title { color: var(--color-priority-high-dot, #c0392b); }
 .tp-account-row.is-danger .tp-account-row-helper { color: var(--color-priority-high-dot, #c0392b); opacity: 0.78; }
@@ -152,8 +150,6 @@ const SCOPED_STYLES = `
 }
 .tp-account-row.is-danger:hover { background: var(--color-priority-high-bg, rgba(192, 57, 43, 0.06)); }
 
-/* 2026-05-03 P3 confirm-modal cleanup: tp-logout-* CSS 退役。登出二次確認
- * 改用標準化 <ConfirmModal> 元件，視覺由 ConfirmModal SCOPED_STYLES 統一管。 */
 .tp-logout-stats-error {
   font-size: var(--font-size-caption2);
   color: var(--color-muted);
@@ -297,12 +293,6 @@ export default function AccountPage() {
         ))}
       </div>
 
-      {/* 2026-05-03 P3 confirm-modal cleanup: 取代手刻 tp-logout-modal。
-        * ConfirmModal 提供 portal + ESC + focus trap + alertdialog a11y +
-        * V2 Terracotta destructive 紅色 confirm button — 對齊 mockup S22
-        * Dialogs system. confirm 按鈕 testid 維持 account-logout-confirm
-        * (e2e backwards-compat) 透過 ConfirmModal data-testid="confirm-modal-confirm"
-        * 與 wrapper data-testid 並存。 */}
       <ConfirmModal
         open={showLogoutModal}
         title="確認登出？"

--- a/src/pages/AddStopPage.tsx
+++ b/src/pages/AddStopPage.tsx
@@ -27,7 +27,7 @@
  *   - onClose / onAdded 改 navigate(-1) + dispatch tp-entry-updated
  *   - 完成按鈕同時放 TitleBar action + bottom bar (兩處同步 disabled state)
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useCurrentUser } from '../hooks/useCurrentUser';
@@ -41,15 +41,8 @@ import TitleBar from '../components/shell/TitleBar';
 import TitleBarPrimaryAction from '../components/shell/TitleBarPrimaryAction';
 import Icon from '../components/shared/Icon';
 import ToastContainer, { showToast } from '../components/shared/Toast';
-
-interface PoiSearchResult {
-  osm_id: number;
-  name: string;
-  address: string;
-  lat: number;
-  lng: number;
-  category: string;
-}
+import { usePoiSearch } from '../hooks/usePoiSearch';
+import type { PoiSearchResult } from '../types/poi';
 
 interface SavedPoiRow {
   id: number;
@@ -601,12 +594,24 @@ export default function AddStopPage() {
   const [tab, setTab] = useState<Tab>('search');
   const [category, setCategory] = useState<AddStopCategory>('all');
   const [query, setQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<PoiSearchResult[]>([]);
   const [region, setRegion] = useState<RegionOption>('全部地區');
   const [regionMenuOpen, setRegionMenuOpen] = useState(false);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
-  const [searching, setSearching] = useState(false);
   const [selectedSearch, setSelectedSearch] = useState<Set<number>>(new Set());
+
+  // Search query falls back to region when user hasn't typed (e.g. just opened
+  // the page with region preset to 「沖繩」 — show 「熱門景點 · 沖繩」).
+  const effectiveQuery = useMemo(() => {
+    const trimmed = query.trim();
+    if (trimmed.length >= 2) return trimmed;
+    return region !== '全部地區' ? region : '';
+  }, [query, region]);
+  const { results: searchResults, searching } = usePoiSearch({
+    enabled: tab === 'search',
+    query: effectiveQuery,
+    limit: 20,
+    normalise: normalizeSearchResults,
+  });
 
   const [savedPois, setSavedPois] = useState<SavedPoiRow[] | null>(null);
   const [savedLoading, setSavedLoading] = useState(false);
@@ -620,8 +625,6 @@ export default function AddStopPage() {
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
 
   const [currentDay, setCurrentDay] = useState<DayApiRow | null>(null);
 
@@ -642,41 +645,7 @@ export default function AddStopPage() {
     return () => { cancelled = true; };
   }, [auth.user, tripId, dayNum]);
 
-  // Search debounce + abort: 快速打字時 cancel inflight 避免 last-write-wins race
-  useEffect(() => {
-    if (tab !== 'search') return;
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    const trimmed = query.trim();
-    const fallbackQuery = region !== '全部地區' ? region : '';
-    const searchTerm = trimmed.length >= 2 ? trimmed : fallbackQuery;
-    if (searchTerm.length < 2) {
-      setSearchResults([]);
-      return;
-    }
-    debounceRef.current = setTimeout(async () => {
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
-      setSearching(true);
-      try {
-        const resp = await fetch(
-          `/api/poi-search?q=${encodeURIComponent(searchTerm)}&limit=20`,
-          { signal: ctrl.signal },
-        );
-        if (resp.ok) {
-          setSearchResults(normalizeSearchResults(await resp.json()));
-        }
-      } catch (err) {
-        if ((err as { name?: string })?.name === 'AbortError') return;
-      } finally {
-        if (abortRef.current === ctrl) setSearching(false);
-      }
-    }, 300);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      abortRef.current?.abort();
-    };
-  }, [tab, query, region]);
+  // POI search 由 usePoiSearch hook 處理 (見上方 hook call) — debounce + abort 內建
 
   // Saved fetch (lazy 切到 tab 才打)
   useEffect(() => {

--- a/src/pages/DeveloperAppNewPage.tsx
+++ b/src/pages/DeveloperAppNewPage.tsx
@@ -29,6 +29,7 @@ import TitleBarPrimaryAction from '../components/shell/TitleBarPrimaryAction';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import InlineError from '../components/shared/InlineError';
+import type { ClientApp } from './DeveloperAppsPage';
 
 const SCOPED_STYLES = `
 .tp-dev-new-shell {
@@ -58,34 +59,7 @@ const SCOPED_STYLES = `
   color: var(--color-muted);
 }
 
-/* Form rows — 沿用原 modal CSS 規格 */
-.tp-form { display: flex; flex-direction: column; gap: 16px; }
-.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-form-row label {
-  font-size: var(--font-size-footnote); font-weight: 600;
-  display: flex; justify-content: space-between; align-items: baseline;
-}
-.tp-form-row .tp-hint {
-  font-size: var(--font-size-caption2);
-  color: var(--color-muted); font-weight: 500;
-}
-.tp-form-row input, .tp-form-row textarea {
-  font-family: inherit; font-size: var(--font-size-callout);
-  padding: 10px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  color: var(--color-foreground);
-}
-.tp-form-row textarea {
-  font-family: 'SF Mono', ui-monospace, monospace;
-  font-size: var(--font-size-footnote);
-  min-height: 80px; resize: vertical;
-}
-.tp-form-row input:focus, .tp-form-row textarea:focus {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-  border-color: var(--color-accent);
-}
+/* .tp-form / .tp-form-row / .tp-hint 移到 css/tokens.css 共用（DeveloperAppNew 用密集預設）。 */
 
 .tp-radio-group {
   display: flex; gap: 8px;
@@ -294,9 +268,25 @@ export default function DeveloperAppNewPage() {
   }
 
   function ackSecret() {
+    if (!secretResult) {
+      navigate(routes.developerApps());
+      return;
+    }
+    const now = new Date().toISOString();
+    const app: ClientApp = {
+      client_id: secretResult.client_id,
+      client_type: secretResult.client_type as 'public' | 'confidential',
+      app_name: secretResult.app_name,
+      app_description: null,
+      homepage_url: null,
+      redirect_uris: secretResult.redirect_uris,
+      allowed_scopes: secretResult.allowed_scopes,
+      status: secretResult.status as 'active' | 'pending_review' | 'suspended',
+      created_at: now,
+      updated_at: now,
+    };
     setSecretResult(null);
-    // Notify list page to refetch — picked up by DeveloperAppsPage 'tp-developer-app-created' listener
-    window.dispatchEvent(new CustomEvent('tp-developer-app-created'));
+    window.dispatchEvent(new CustomEvent('tp-developer-app-created', { detail: { app } }));
     navigate(routes.developerApps());
   }
 

--- a/src/pages/DeveloperAppsPage.tsx
+++ b/src/pages/DeveloperAppsPage.tsx
@@ -100,7 +100,7 @@ const SCOPED_STYLES = `
 .tp-error-banner { color: var(--color-destructive); }
 `;
 
-interface ClientApp {
+export interface ClientApp {
   client_id: string;
   client_type: 'public' | 'confidential';
   app_name: string;
@@ -112,6 +112,8 @@ interface ClientApp {
   created_at: string;
   updated_at: string;
 }
+
+export type DeveloperAppCreatedEvent = CustomEvent<{ app: ClientApp }>;
 
 // 2026-05-03 modal-to-fullpage migration: NewAppResult + SCOPE_OPTIONS 已搬到
 // src/pages/DeveloperAppNewPage.tsx (form 全頁化後 list page 不需要)。
@@ -145,11 +147,17 @@ export default function DeveloperAppsPage() {
 
   useEffect(() => { void loadApps(); }, []);
 
-  // 2026-05-03 modal-to-fullpage migration: 建立新應用走 /developer/apps/new 全頁。
-  // page submit 成功 + ack secret → dispatch tp-developer-app-created 讓列表
-  // 自動 refresh，不用 user 手動重整。
+  // tp-developer-app-created event 帶完整 ClientApp detail → in-place append
+  // (省一次 GET /api/dev/apps)。若 detail 缺漏（事件型別舊版 dispatch）退回 full refetch。
   useEffect(() => {
-    function handleAppCreated() { void loadApps(); }
+    function handleAppCreated(e: Event) {
+      const detail = (e as DeveloperAppCreatedEvent).detail;
+      if (detail?.app) {
+        setApps((prev) => prev ? [...prev, detail.app] : [detail.app]);
+      } else {
+        void loadApps();
+      }
+    }
     window.addEventListener('tp-developer-app-created', handleAppCreated);
     return () => window.removeEventListener('tp-developer-app-created', handleAppCreated);
   }, []);

--- a/src/pages/EditTripPage.tsx
+++ b/src/pages/EditTripPage.tsx
@@ -25,7 +25,7 @@
  *   - 取消改 navigate(-1)，儲存後 navigate(`/trips?selected=:id`)
  *   - Form 邏輯 + state machine 完全沿用 EditTripModal v2.19.0
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
@@ -45,18 +45,8 @@ import Icon from '../components/shared/Icon';
 import ToastContainer, { showToast } from '../components/shared/Toast';
 import { TP_DRAG_ACCESSIBILITY } from '../lib/drag-announcements';
 import { TRIP_FORM_STYLES } from '../components/trip/_tripFormStyles';
-
-interface PoiSearchResult {
-  osm_id: number;
-  osm_type?: 'node' | 'way' | 'relation' | null;
-  name: string;
-  address?: string;
-  lat: number;
-  lng: number;
-  category?: string;
-  country?: string;
-  country_name?: string;
-}
+import { usePoiSearch } from '../hooks/usePoiSearch';
+import type { PoiSearchResult } from '../types/poi';
 
 interface DestinationRow {
   osm_id: number;
@@ -95,9 +85,6 @@ interface TripApi {
   startDate?: string;
   endDate?: string;
 }
-
-const POI_SEARCH_DEBOUNCE_MS = 300;
-const POI_SEARCH_MIN_LEN = 2;
 
 /**
  * SCOPED_STYLES 含：
@@ -354,11 +341,21 @@ export default function EditTripPage() {
   // POI search inline state
   const [showSearch, setShowSearch] = useState(false);
   const [destQuery, setDestQuery] = useState('');
-  const [poiResults, setPoiResults] = useState<PoiSearchResult[] | null>(null);
-  const [poiSearching, setPoiSearching] = useState(false);
   const [poiSearchError, setPoiSearchError] = useState<string | null>(null);
-  const poiDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const poiAbortRef = useRef<AbortController | null>(null);
+  const { results: poiResults, searching: poiSearching } = usePoiSearch({
+    enabled: showSearch,
+    query: destQuery,
+    limit: 10,
+    normalise: (raw) => {
+      const arr = (raw as { results?: PoiSearchResult[] })?.results ?? [];
+      return Array.isArray(arr) ? arr : [];
+    },
+    onError: (kind) => setPoiSearchError(kind === 'http-error' ? '搜尋失敗，請稍後再試' : '網路連線失敗'),
+  });
+
+  useEffect(() => {
+    if (destQuery.trim().length < 2) setPoiSearchError(null);
+  }, [destQuery]);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -406,41 +403,6 @@ export default function EditTripPage() {
     return () => { cancelled = true; };
   }, [auth.user, tripId]);
 
-  // POI search debounce
-  useEffect(() => {
-    if (!showSearch) return;
-    if (poiDebounceRef.current) clearTimeout(poiDebounceRef.current);
-    const trimmed = destQuery.trim();
-    if (trimmed.length < POI_SEARCH_MIN_LEN) {
-      setPoiResults(null); setPoiSearching(false); setPoiSearchError(null);
-      poiAbortRef.current?.abort();
-      return;
-    }
-    poiDebounceRef.current = setTimeout(async () => {
-      poiAbortRef.current?.abort();
-      const ctrl = new AbortController();
-      poiAbortRef.current = ctrl;
-      setPoiSearching(true); setPoiSearchError(null);
-      try {
-        const resp = await fetch(`/api/poi-search?q=${encodeURIComponent(trimmed)}&limit=10`, { signal: ctrl.signal });
-        if (!resp.ok) {
-          setPoiSearchError('搜尋失敗，請稍後再試');
-          setPoiResults([]);
-          return;
-        }
-        const data = (await resp.json()) as { results: PoiSearchResult[] };
-        setPoiResults(data.results ?? []);
-      } catch (err) {
-        if ((err as Error).name === 'AbortError') return;
-        setPoiSearchError('網路連線失敗');
-        setPoiResults([]);
-      } finally {
-        setPoiSearching(false);
-      }
-    }, POI_SEARCH_DEBOUNCE_MS);
-    return () => { if (poiDebounceRef.current) clearTimeout(poiDebounceRef.current); };
-  }, [destQuery, showSearch]);
-
   // Region change hint logic — only show if (a) destinations names changed
   // vs original AND (b) user hasn't manually edited title since open AND (c)
   // hint not dismissed.
@@ -457,7 +419,7 @@ export default function EditTripPage() {
 
   function selectPoi(poi: PoiSearchResult) {
     if (destinations.some((d) => d.osm_id === poi.osm_id)) {
-      setShowSearch(false); setDestQuery(''); setPoiResults(null);
+      setShowSearch(false); setDestQuery('');
       return;
     }
     setDestinations((prev) => [
@@ -474,7 +436,6 @@ export default function EditTripPage() {
     ]);
     setShowSearch(false);
     setDestQuery('');
-    setPoiResults(null);
   }
 
   function removeDest(osmId: number) {
@@ -665,14 +626,14 @@ export default function EditTripPage() {
                             autoComplete="off"
                             data-testid="edit-trip-dest-search-input"
                           />
-                          {(poiSearching || poiResults || poiSearchError) && destQuery.trim().length >= POI_SEARCH_MIN_LEN && (
+                          {destQuery.trim().length >= 2 && (
                             <div className="tp-edit-dest-dropdown" role="listbox" data-testid="edit-trip-dest-dropdown">
                               {poiSearching && <div className="tp-edit-dest-status">搜尋中⋯</div>}
                               {!poiSearching && poiSearchError && <div className="tp-edit-dest-status">{poiSearchError}</div>}
-                              {!poiSearching && !poiSearchError && poiResults && poiResults.length === 0 && (
+                              {!poiSearching && !poiSearchError && poiResults.length === 0 && (
                                 <div className="tp-edit-dest-status">沒找到結果，試試別的關鍵字</div>
                               )}
-                              {!poiSearching && poiResults && poiResults.length > 0 && poiResults.map((p) => (
+                              {!poiSearching && poiResults.length > 0 && poiResults.map((p) => (
                                 <button
                                   key={p.osm_id}
                                   type="button"

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -32,14 +32,7 @@ import TitleBar from '../components/shell/TitleBar';
 /** Region 候選 (常用 destinations + 全部地區)。Active trip's region 自動加進來不重複。 */
 const POPULAR_REGIONS = ['全部地區', '沖繩', '東京', '京都', '首爾', '台北'] as const;
 
-interface PoiSearchResult {
-  osm_id: number;
-  name: string;
-  address: string;
-  lat: number;
-  lng: number;
-  category: string;
-}
+import type { PoiSearchResult } from '../types/poi';
 
 interface SavedPoiRow {
   id: number;
@@ -536,11 +529,11 @@ export default function ExplorePage() {
         method: 'POST',
         body: JSON.stringify({
           name: poi.name,
-          type: mapNominatimCategory(poi.category),
+          type: mapNominatimCategory(poi.category ?? ''),
           lat: poi.lat,
           lng: poi.lng,
-          address: poi.address,
-          category: poi.category,
+          address: poi.address ?? '',
+          category: poi.category ?? '',
           source: 'user-explore',
         }),
       });
@@ -810,7 +803,7 @@ export default function ExplorePage() {
                           <div className="explore-poi-body">
                             <div className="poi-category">{poi.category || 'POI'}</div>
                             <div className="poi-name">{poi.name}</div>
-                            <div className="poi-address">{poi.address}</div>
+                            <div className="poi-address">{poi.address ?? ''}</div>
                             {/* Section 4.9：rating meta — 真實 rating 待 backend
                               提供 Google rating 接入；先用 placeholder ⭐ + 「待補」 */}
                             <div className="explore-poi-rating">

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -45,25 +45,7 @@ ${AUTH_LAYOUT_STYLES}
   margin: 0; line-height: 1.5;
 }
 
-.tp-form { display: flex; flex-direction: column; gap: 16px; }
-.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-form-row label {
-  font-size: var(--font-size-footnote); font-weight: 600;
-}
-.tp-form-row input {
-  font-family: inherit; font-size: var(--font-size-callout);
-  padding: 12px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  color: var(--color-foreground);
-  min-height: 48px;
-}
-.tp-form-row input:focus {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-  border-color: var(--color-accent);
-}
-
+/* .tp-form / .tp-form-row 移到 css/tokens.css；用 .tp-form--auth 拉高觸控尺寸。 */
 /* .tp-btn family 移到 css/tokens.css 共用。 */
 
 .tp-banner {
@@ -173,7 +155,7 @@ export default function ForgotPasswordPage() {
               </div>
             )}
 
-            <form className="tp-form" onSubmit={handleSubmit} noValidate>
+            <form className="tp-form tp-form--auth" onSubmit={handleSubmit} noValidate>
               <div className="tp-form-row">
                 <label htmlFor="forgot-email">Email</label>
                 <input

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -153,32 +153,7 @@ const SCOPED_STYLES = `
   margin: 0;
 }
 
-.tp-form { display: flex; flex-direction: column; gap: 16px; }
-.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-form-row label {
-  font-size: var(--font-size-footnote); font-weight: 600;
-  display: flex; justify-content: space-between; align-items: baseline;
-}
-.tp-form-row .tp-hint-link {
-  color: var(--color-accent);
-  font-weight: 600; font-size: var(--font-size-caption);
-  text-decoration: none;
-}
-.tp-form-row .tp-hint-link:hover { text-decoration: underline; }
-.tp-form-row input {
-  font-family: inherit; font-size: var(--font-size-callout);
-  padding: 12px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  color: var(--color-foreground);
-  min-height: 48px;
-}
-.tp-form-row input:focus {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-  border-color: var(--color-accent);
-}
-
+/* .tp-form / .tp-form-row 移到 css/tokens.css；LoginPage 用 .tp-form--auth 拉高觸控尺寸。 */
 /* .tp-btn family 移到 css/tokens.css 共用。LoginPage 用 .tp-btn-block (full width) + .tp-btn-lg。 */
 
 .tp-divider {
@@ -472,7 +447,7 @@ export default function LoginPage() {
 
         {bannerError && <ErrorBanner message={bannerError} testId="login-banner-error" />}
 
-        <form className="tp-form" onSubmit={handleSubmit} noValidate>
+        <form className="tp-form tp-form--auth" onSubmit={handleSubmit} noValidate>
           <div className="tp-form-row">
             <label htmlFor="login-email">Email</label>
             <input

--- a/src/pages/NewTripPage.tsx
+++ b/src/pages/NewTripPage.tsx
@@ -29,7 +29,7 @@
  *   - 取消改 navigate(-1)，建立後 navigate(`/trips?selected=:id`)
  *   - 「建立」 primary action 在 TitleBar (responsive icon+文字 / icon-only)
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
@@ -50,20 +50,8 @@ import Icon from '../components/shared/Icon';
 import ToastContainer from '../components/shared/Toast';
 import { TP_DRAG_ACCESSIBILITY } from '../lib/drag-announcements';
 import { TRIP_FORM_STYLES } from '../components/trip/_tripFormStyles';
-
-interface PoiSearchResult {
-  osm_id: number;
-  name: string;
-  address: string;
-  lat: number;
-  lng: number;
-  category: string;
-  country?: string;
-  country_name?: string;
-}
-
-const POI_SEARCH_DEBOUNCE_MS = 300;
-const POI_SEARCH_MIN_LEN = 2;
+import { usePoiSearch } from '../hooks/usePoiSearch';
+import type { PoiSearchResult } from '../types/poi';
 
 const POPULAR_DESTINATIONS: ReadonlyArray<{ key: string; label: string }> = [
   { key: 'okinawa', label: '沖繩' },
@@ -451,11 +439,17 @@ export default function NewTripPage() {
   // Destination uses POI autocomplete. User can select multiple POIs.
   const [destQuery, setDestQuery] = useState('');
   const [selectedPois, setSelectedPois] = useState<PoiSearchResult[]>([]);
-  const [poiResults, setPoiResults] = useState<PoiSearchResult[] | null>(null);
-  const [poiSearching, setPoiSearching] = useState(false);
   const [poiSearchError, setPoiSearchError] = useState<string | null>(null);
-  const poiDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const poiAbortRef = useRef<AbortController | null>(null);
+  const { results: poiResults, searching: poiSearching } = usePoiSearch({
+    query: destQuery,
+    limit: 10,
+    normalise: (raw) => {
+      // API returns `{ results: [] }` wrapper
+      const arr = Array.isArray(raw) ? raw : (raw as { results?: PoiSearchResult[] })?.results ?? [];
+      return arr as PoiSearchResult[];
+    },
+    onError: (kind) => setPoiSearchError(kind === 'http-error' ? '搜尋失敗，請稍後再試' : '網路連線失敗'),
+  });
 
   const [dateMode, setDateMode] = useState<DateMode>('select');
   const [startDate, setStartDate] = useState('');
@@ -514,54 +508,16 @@ export default function NewTripPage() {
     });
   }
 
-  // POI search debounce
+  // Clear error when query empties
   useEffect(() => {
-    if (poiDebounceRef.current) clearTimeout(poiDebounceRef.current);
-    const trimmed = destQuery.trim();
-    if (trimmed.length < POI_SEARCH_MIN_LEN) {
-      setPoiResults(null);
-      setPoiSearching(false);
-      setPoiSearchError(null);
-      poiAbortRef.current?.abort();
-      return;
-    }
-    poiDebounceRef.current = setTimeout(async () => {
-      poiAbortRef.current?.abort();
-      const ctrl = new AbortController();
-      poiAbortRef.current = ctrl;
-      setPoiSearching(true);
-      setPoiSearchError(null);
-      try {
-        const resp = await fetch(
-          `/api/poi-search?q=${encodeURIComponent(trimmed)}&limit=10`,
-          { signal: ctrl.signal },
-        );
-        if (!resp.ok) {
-          setPoiSearchError('搜尋失敗，請稍後再試');
-          setPoiResults([]);
-          return;
-        }
-        const data = (await resp.json()) as { results: PoiSearchResult[] };
-        setPoiResults(data.results ?? []);
-      } catch (err) {
-        if ((err as Error).name === 'AbortError') return;
-        setPoiSearchError('網路連線失敗');
-        setPoiResults([]);
-      } finally {
-        setPoiSearching(false);
-      }
-    }, POI_SEARCH_DEBOUNCE_MS);
-    return () => {
-      if (poiDebounceRef.current) clearTimeout(poiDebounceRef.current);
-    };
+    if (destQuery.trim().length < 2) setPoiSearchError(null);
   }, [destQuery]);
 
   function selectPoi(poi: PoiSearchResult) {
     setSelectedPois((prev) => (
       prev.some((p) => p.osm_id === poi.osm_id) ? prev : [...prev, poi]
     ));
-    setDestQuery('');
-    setPoiResults(null);
+    setDestQuery(''); // Clearing query auto-clears poiResults via hook
     setPoiSearchError(null);
     pushRecentDest(poi.name);
     setRecentDests(loadRecentDests());
@@ -758,7 +714,7 @@ export default function NewTripPage() {
                     autoComplete="off"
                     data-testid="new-trip-destination-input"
                   />
-                  {(poiSearching || poiResults || poiSearchError) && destQuery.trim().length >= POI_SEARCH_MIN_LEN && (
+                  {(poiSearching || poiResults.length > 0 || poiSearchError) && destQuery.trim().length >= 2 && (
                     <div className="tp-new-dest-dropdown" role="listbox" data-testid="new-trip-dest-dropdown">
                       {poiSearching && <div className="tp-new-dest-status">搜尋中⋯</div>}
                       {!poiSearching && poiSearchError && <div className="tp-new-dest-status">{poiSearchError}</div>}

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -50,33 +50,7 @@ ${AUTH_LAYOUT_STYLES}
   margin: 0;
 }
 
-.tp-form { display: flex; flex-direction: column; gap: 16px; }
-.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-form-row label {
-  font-size: var(--font-size-footnote); font-weight: 600;
-  display: flex; justify-content: space-between; align-items: baseline;
-}
-.tp-form-row .tp-hint {
-  font-size: var(--font-size-caption2);
-  color: var(--color-muted); font-weight: 500;
-}
-.tp-form-row input {
-  font-family: inherit; font-size: var(--font-size-callout);
-  padding: 12px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  color: var(--color-foreground);
-  min-height: 48px;
-}
-.tp-form-row input:focus {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-  border-color: var(--color-accent);
-}
-.tp-form-row .tp-error {
-  font-size: var(--font-size-caption);
-  color: var(--color-destructive);
-}
+/* .tp-form / .tp-form-row 移到 css/tokens.css；用 .tp-form--auth 拉高觸控尺寸。 */
 
 .tp-pw-strength {
   display: flex; flex-direction: column; gap: 8px; margin-top: 4px;
@@ -306,7 +280,7 @@ export default function ResetPasswordPage() {
           </div>
         )}
 
-        <form className="tp-form" onSubmit={handleSubmit} noValidate>
+        <form className="tp-form tp-form--auth" onSubmit={handleSubmit} noValidate>
           <div className="tp-form-row">
             <label htmlFor="reset-password">
               新密碼 <span className="tp-hint">至少 8 字元</span>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -52,29 +52,7 @@ ${AUTH_LAYOUT_STYLES}
   margin: 0;
 }
 
-.tp-form { display: flex; flex-direction: column; gap: 16px; }
-.tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-form-row label {
-  font-size: var(--font-size-footnote); font-weight: 600;
-  display: flex; justify-content: space-between; align-items: baseline;
-}
-.tp-form-row .tp-hint { font-size: var(--font-size-caption2); color: var(--color-muted); font-weight: 500; }
-.tp-form-row input {
-  font-family: inherit; font-size: var(--font-size-callout);
-  padding: 12px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  color: var(--color-foreground);
-  min-height: 48px;
-}
-.tp-form-row input:focus {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-  border-color: var(--color-accent);
-}
-.tp-form-row .tp-error {
-  font-size: 12px; color: var(--color-destructive);
-}
+/* .tp-form / .tp-form-row 移到 css/tokens.css；用 .tp-form--auth 拉高觸控尺寸。 */
 
 /* .tp-btn family 移到 css/tokens.css 共用。 */
 
@@ -233,7 +211,7 @@ export default function SignupPage() {
           </div>
         )}
 
-        <form className="tp-form" onSubmit={handleSubmit} noValidate>
+        <form className="tp-form tp-form--auth" onSubmit={handleSubmit} noValidate>
           <div className="tp-form-row">
             <label htmlFor="signup-email">Email</label>
             <input

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -59,36 +59,16 @@ const SCOPED_STYLES = `
 /* heading 改用統一 <TitleBar>。.tp-trips-heading 已退役。 */
 
 .tp-trips-grid {
-  /* 2026-04-29:user 反饋「行程版面超出版面」 — repeat(2, 1fr) 等同
-   * repeat(2, minmax(auto, 1fr)),當某張 card 內容(title)寬過 1fr 計算值時
-   * column auto 撐大,導致第二 col 超出 grid right edge(實測 viewport 390 +
-   * 第二 card right 418,overflow 28px)。改 minmax(0, 1fr) 強制 min: 0 不
-   * 被內容撐大,column 等寬。 */
+  /* minmax(0, 1fr) 不是 1fr：1fr 的 min 是 auto，會被 card title 撐大讓第二
+   * column 溢出 grid right edge。0 強制 min: 0 → column 等寬。 */
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
   margin-top: 24px;
 }
 
-/* PR-NN 2026-04-26：mobile embedded mode 改成完整 mobile-topbar 模式
- * （對齊 docs/design-sessions/mockup-trip-v2.html line 438 .mobile-topbar）。
- * 取代 PR-AA 的 floating sticky back btn — 那個獨佔一行、跟 mockup 不符。
- *
- * 結構：[← back btn] [trip name] — 56px 全寬、sticky top、glass blur。 */
-/* 2026-05-03 root fix:從 flex-column 改 grid 「chrome auto + content 1fr」
- * 模式。原 flex-column + default flex-shrink:1 + min-height:auto 讓 TitleBar
- * 在父空間不足時 (TripPage 內容很長) 被擠壓到 children max-height (45px),
- * user 觀察「行程明細標題列比其他功能頁低」+「加景點外框不正確」(button 凸出)
- * 同 root cause。
- *
- * Grid template rows:
- *   row 1 (auto)  — TitleBar 用 CSS height: 56px (compact) / 64px (desktop) fixed
- *   row 2 (1fr)   — TripPage .ocean-shell 撐滿剩餘 viewport
- *
- * 比 flex column + flex-shrink:0 更 semantic: chrome (auto) + main (1fr)
- * 是 W3C grid layout standard pattern。同 ChatPage / MapPage 用 flex
- * column + child explicit flex:1 一致語意,但 grid 不需依賴 child set 對的
- * flex behavior,layout intent 完全在 parent。 */
+/* grid template rows (chrome auto + main 1fr) 取代 flex column —
+ * flex 的 default flex-shrink:1 會讓 TitleBar 在 main 內容很長時被擠壓。 */
 .tp-embedded-trip {
   position: relative;
   display: grid;
@@ -96,16 +76,6 @@ const SCOPED_STYLES = `
   height: 100%;
   min-height: 100%;
 }
-/* PR-QQ 2026-04-27：對齊 mockup-trip-selected-v1.html Variant A
- * （+ B 的單行 title）— 對齊 mockup-trip-v2.html line 438 .mobile-topbar
- * canonical 規格：56px 高、16px padding、glass blur、border-bottom hairline。
- * Back btn 36×36 帶 border + bg-background = mockup .icon-btn pattern，比原
- * 40×40 transparent 更貼齊 mockup affordance。Title 17px bold 單行，
- * 不加 day eyebrow（保持簡潔）。 */
-/* embedded topbar 改用統一 <TitleBar>。
- * 舊 .tp-embedded-topbar / -back / -trip-name / -actions CSS 已退役。
- * .tp-embedded-trip 仍是 wrapper（含 height: 100%），保留。
- * .tp-embedded-menu* 給 EmbeddedActionMenu sub-component 用，保留。 */
 .tp-embedded-menu-trigger {
   width: 36px; height: 36px;
   border-radius: var(--radius-md);
@@ -175,8 +145,8 @@ const SCOPED_STYLES = `
     gap: 16px;
   }
 }
-/* PR-Q 2026-04-26：每張 trip card 加 ... menu。card 改 wrapper（position:
- * relative）裝 button + menu trigger 兩個 children，避免 button-in-button。 */
+/* card wrapper 必須 position: relative — kebab menu trigger absolute positioned。
+ * 兩個 sibling button 取代 button-in-button (a11y + nested click target 衝突)。 */
 .tp-trip-card-wrap {
   position: relative;
 }
@@ -578,9 +548,6 @@ function cardMeta(trip: TripInfo): string {
   return '';
 }
 
-/* PR-UU 2026-04-27：embedded topbar 漢堡選單 — 共編 / 列印 / 下載 (4 formats)。
- * 共編 走 host 的 setCollabTripId（既有 InfoSheet path）。
- * 列印 + 下載 走 TripPage forwardRef handle。 */
 const MENU_WIDTH = 200;
 const VIEWPORT_MARGIN = 8;
 
@@ -746,9 +713,8 @@ export default function TripsListPage() {
   const [allTrips, setAllTrips] = useState<TripInfo[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // PR-DD 2026-04-26：抽出 loadTrips 讓 mount + tp-trip-created event 都能觸發
-  // refetch。User onion523 反應「行程後要切換功能才看的到新行程」 — TripsListPage
-  // 原本只 mount 跑一次，新增完 navigate 過去 trip 詳情，回 list 看不到新 trip。
+  // 同 tab navigate 不會 remount TripsListPage — 必須由 tp-trip-created /
+  // tp-trip-updated event 觸發 refetch，否則新增/編輯後回 list 看不到變更。
   const loadTrips = useCallback(async () => {
     try {
       const [myRes, allRes] = await Promise.all([
@@ -775,13 +741,9 @@ export default function TripsListPage() {
 
   useEffect(() => { void loadTrips(); }, [loadTrips]);
 
-  // PR-DD：聽 NewTripContext 在 POST trips 成功後 dispatch 的 event，re-fetch
-  // list 拿新 trip。同 tab navigate 不會 remount TripsListPage，必須 explicit
-  // refetch 才會更新。
   useEffect(() => {
     function onTripCreated() { void loadTrips(); }
     window.addEventListener('tp-trip-created', onTripCreated);
-    // 2026-05-03: EditTripPage 儲存後 dispatch tp-trip-updated → 同 loadTrips refresh
     window.addEventListener('tp-trip-updated', onTripCreated);
     return () => {
       window.removeEventListener('tp-trip-created', onTripCreated);
@@ -854,16 +816,9 @@ export default function TripsListPage() {
     return visibleTrips[0]?.tripId ?? null;
   }, [selectedFromUrl, visibleTrips]);
 
-  // Both viewports: clicking a card sets ?selected=tripId. Mobile then
-  // renders the embedded TripPage as full-screen main; desktop swaps the
-  // right sheet to that trip. Per user direction the unified URL pattern is
-  // /trips?selected=X (no /trip/:id route navigation).
-  //
-  // 2026-04-29 race fix: 同步寫 ActiveTripContext。原本 active trip 設定靠
-  // embedded TripPage mount 後 useEffect 觸發 setActiveTrip，但如果 user
-  // 點完 card 立刻走 bottom-nav 切到 /chat，TripPage 還沒 mount → ChatPage
-  // 拿到舊 activeTripId，訊息會送錯 trip（lean.lean@gmail trip_requests:162
-  // 的 sympton：台南內容送進沖繩 trip）。Card click 同步寫 context 解決。
+  // Card click 同步寫 ActiveTripContext — 不能等 embedded TripPage mount 才設，
+  // 否則 user 點完立刻切 bottom-nav 到 /chat，ChatPage 拿舊 activeTripId 會把
+  // 訊息送錯 trip。
   const { setActiveTrip } = useActiveTrip();
   function handleCardClick(tripId: string, e: React.MouseEvent | React.KeyboardEvent) {
     e.preventDefault();
@@ -873,29 +828,17 @@ export default function TripsListPage() {
     setSearchParams(next, { replace: false });
   }
 
-  // v2.18.0:共編 sheet 升格獨立頁面 /trip/:id/collab。
-  // card kebab + EmbeddedActionMenu「共編」 → navigate 過去,不再開 InfoSheet。
-  /* PR-UU 2026-04-27:embedded TripPage forwardRef handle,給漢堡選單呼叫
-   * 列印 / 下載(TripPage 內部 state-bound handlers)。 */
   const tripPageRef = useRef<TripPageHandle>(null);
   const handleMenuCollab = useCallback(
     (tripId: string) => { navigate(`/trip/${encodeURIComponent(tripId)}/collab`); },
     [navigate],
   );
 
-  // 2026-05-03 modal-to-fullpage migration: card kebab「編輯行程」改 navigate
-  // 到 /trip/:id/edit page (取代原本開 EditTripModal)。EditTripPage 自己處理
-  // load + submit + 成功後 navigate back + dispatch tp-trip-updated event。
-  // TripsListPage 只需 listen tp-trip-updated 來 refresh list（已有 listener
-  // 在另一個 useEffect — 見 PR-DD comment）。
   const handleMenuEdit = useCallback(
     (tripId: string) => { navigate(`/trip/${encodeURIComponent(tripId)}/edit`); },
     [navigate],
   );
 
-  // PR-Q：card kebab 「刪除行程」 → ConfirmModal + DELETE /api/trips/:id +
-  // optimistic remove from local list（避免 user 等待 reload）。
-  // 兩階段 state：requestMenuDelete 開 modal、handleConfirmDelete 真的執行。
   const [deleteTarget, setDeleteTarget] = useState<{ tripId: string; label: string } | null>(null);
   const [deleting, setDeleting] = useState(false);
 
@@ -943,11 +886,8 @@ export default function TripsListPage() {
   // Heading meta 已棄用 — mockup 規定 TitleBar 單行 chrome 不放 meta。
   // 行程數隱性，user 看 cards 自然知道；toolbar 子 tabs / search / 排序 留 future PR。
 
-  // Mobile + ?selected → embedded TripPage IS the main content (full-screen
-  // trip detail). Cards hide. Per user spec, /trips?selected=X is the unified
-  // entry, no /trip/:id route navigation.
-  /* PR-PP：去 sheet 後，embedded mode 不分 mobile/desktop — 兩邊都把 main
-   * 換成滿版 TripPage（topbar [← back] [trip name] + timeline）。 */
+  // Mobile + desktop 共用 entry: ?selected=X 切換 main 為 embedded TripPage
+  // (滿版)。Cards 隱藏。/trip/:id 路由不再使用。
   const showEmbeddedTrip = !!effectiveSelectedId && !!selectedFromUrl;
 
   const cardGridMain = (
@@ -973,7 +913,6 @@ export default function TripsListPage() {
               aria-label="新增行程"
               data-testid="trips-list-new-trip-titlebar"
             >
-              {/* 2026-04-29:title action 統一規範 — 桌機 icon+文字,手機 icon only */}
               <Icon name="plus" />
               <span className="tp-titlebar-action-label">新增行程</span>
             </button>
@@ -1166,11 +1105,6 @@ export default function TripsListPage() {
     </>
   );
 
-  // PR-PP 2026-04-26：架構改 2-pane，sheet 不再用，永遠 undefined。
-
-  // PR-NN 2026-04-26：mobile embedded mode 改 .tp-embedded-topbar pattern
-  // （[← back] [trip name]）。原 PR-AA floating back btn 自己一行 + 跟 mockup
-  // mobile-topbar 不符，已棄用。
   function clearSelected() {
     /* Capture the trip id user was viewing BEFORE we drop ?selected — used
      * to restore keyboard focus to the originating card after re-render
@@ -1201,13 +1135,6 @@ export default function TripsListPage() {
         backLabel="返回行程列表"
         actions={effectiveSelectedId && (
           <>
-            {/* Section 3 (terracotta-add-stop-modal)：embedded mode 也提供
-              * 「加景點」 trigger，呼叫 TripPage exposed handle openAddStop。
-              * 否則 user 在 /trips?selected= flow（主要 entry）找不到加景點。
-              * 2026-05-03 polish：改用 .tp-titlebar-action 對齊 DESIGN.md
-              * 2026-05-03 v2.19.x「桌機 icon+text / 手機 icon-only」 規則,
-              * 跟一覽頁「新增行程」 button 視覺一致(取代原 .tp-embedded-menu-trigger
-              * square icon-only)。 */}
             <button
               type="button"
               className="tp-titlebar-action"
@@ -1232,17 +1159,14 @@ export default function TripsListPage() {
 
   return (
     <>
-      {/* PR-TT 2026-04-27：SCOPED_STYLES hoist 到頂層，永遠注入。
-       * 原本在 cardGridMain 內 → embedded mode 不渲染 cardGridMain → CSS
-       * 沒注入 → .tp-embedded-topbar 用 <header> UA 預設 display: block，
-       * 子元素 stack vertically (back btn + 共編 chip 變兩行)。 */}
+      {/* SCOPED_STYLES 必須 hoist 到頂層 — embedded mode 不渲染 cardGridMain，
+        * 注入在 cardGridMain 內就失效。 */}
       <style>{SCOPED_STYLES}</style>
       <AppShell
         sidebar={<DesktopSidebarConnected />}
         main={main}
         bottomNav={<GlobalBottomNav authed={!!user} />}
       />
-      {/* v2.18.0:共編 sheet 升格 /trip/:id/collab 獨立頁,既有 InfoSheet wrapper 移除。 */}
     </>
   );
 }

--- a/src/types/poi.ts
+++ b/src/types/poi.ts
@@ -1,0 +1,26 @@
+/**
+ * POI (Point of Interest) shared types.
+ *
+ * Used by NewTripPage / EditTripPage / AddStopPage / ExplorePage POI search +
+ * the `usePoiSearch` hook (`src/hooks/usePoiSearch.ts`).
+ *
+ * Source backend: `functions/api/poi-search.ts` returns OSM-derived rows
+ * (Nominatim + Overpass enrichment). The most permissive shape (EditTripPage)
+ * is canonical here so all consumers can reuse without re-typing.
+ */
+
+export interface PoiSearchResult {
+  osm_id: number;
+  osm_type?: 'node' | 'way' | 'relation' | null;
+  name: string;
+  /** Human-readable address. May be empty for some OSM nodes. */
+  address?: string;
+  lat: number;
+  lng: number;
+  /** OSM tag-derived category (e.g. 'tourism', 'amenity'). May be normalised by `mapNominatimCategory`. */
+  category?: string;
+  /** ISO country code (e.g. 'JP', 'TW'). Optional — Nominatim returns it when zoom>0. */
+  country?: string;
+  /** Localised country name (e.g. 'Japan', 'Taiwan'). */
+  country_name?: string;
+}


### PR DESCRIPTION
## Summary

PR #451 simplify follow-up backlog 的剩餘項目，繼續清掉 25 commits review 找到的 reuse / quality / efficiency hotspots。

- **PoiSearchResult 型別統一** (`src/types/poi.ts`)：4 個檔案各自定義過，現在全 import canonical 版（取自 EditTripPage 最寬鬆 shape）
- **usePoiSearch hook** (`src/hooks/usePoiSearch.ts`)：debounced + AbortController + cleanup pattern 從 NewTripPage / EditTripPage / AddStopPage 抽出，共省 ~150 LOC。ExplorePage 是 submit-driven 不適用，只做 type 統一
- **.tp-form / .tp-form-row / .tp-form-row .tp-error 進 css/tokens.css**：5 個檔案 (LoginPage / SignupPage / ForgotPasswordPage / ResetPasswordPage / DeveloperAppNewPage) 各自重複定義過。新增 `.tp-form--auth` 變體（12px/14px padding + 48px min-height）給 auth pages 用，dev form 用密集預設
- **DeveloperApps in-place patch**：`tp-developer-app-created` event payload 改帶完整 `ClientApp` detail，listener 直接 append 進本地 state 取代 full GET re-fetch；detail 缺漏時 fallback 走 loadApps() 退路
- **Comment cleanup**：清掉 TripsListPage / AccountPage / DaySection / tokens.css 的 `PR-XX 2026-MM-DD` dated narrative。WHY 註解（race fix / 視覺意圖 / mockup spec 對照）保留

Net: **-136 LOC** (16 files changed, 324 insertions, 460 deletions)。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 155 test files / 1292 tests 全綠
- [x] `npm run build` — 466ms 成功
- [ ] /trips 新增行程 → POI 搜尋 dropdown 正常 (NewTripPage usePoiSearch)
- [ ] /trip/:id/edit → POI 搜尋 dropdown 正常 (EditTripPage usePoiSearch)
- [ ] /trip/:id/days/N/stops/new → POI 搜尋 list 正常 (AddStopPage usePoiSearch)
- [ ] /explore 搜尋 + 收藏正常 (ExplorePage type-only)
- [ ] /login /signup /login/forgot /reset-password /developer/apps/new 5 頁 form 視覺一致 (`.tp-form--auth` for auth)
- [ ] /developer/apps 建立應用 → ack secret → list 直接 in-place 出現新 row (in-place patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)