### PR TITLE
docs(claude): TRIPLINE_API_URL 改正 funnel :443 + /tripline/api 路徑前綴

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ V2-P6 cutover 後 Cloudflare Access 已拆,所有 auth 走 tripline 自建 V2 OA
   # → outputs TRIPLINE_API_CLIENT_ID + TRIPLINE_API_CLIENT_SECRET (一次性,DB 只存 hash)
   ```
   記得把 secret 加進 `.env.local` 跟 launchd plist 給 scheduler scripts 用。
-- **Required env(prod)**:`SESSION_SECRET`(簽 cookie,32+ char)、`OAUTH_SIGNING_PRIVATE_KEY`(只有發 id_token 給 OAuth client app 時用,本人帳號自登入不需)、`TRIPLINE_API_URL`(mac mini funnel `https://...:8443`，verify/forgot/reset/invite email + tp-request trigger 都走這條)、`TRIPLINE_API_SECRET`(Bearer token，與 mac mini 同一組)
+- **Required env(prod)**:`SESSION_SECRET`(簽 cookie,32+ char)、`OAUTH_SIGNING_PRIVATE_KEY`(只有發 id_token 給 OAuth client app 時用,本人帳號自登入不需)、`TRIPLINE_API_URL`(mac mini funnel，**含路徑前綴**：`https://ray-chiudemac-mini.tail2750c0.ts.net/tripline/api`，funnel listen :443 → proxy mac mini :8080。verify/forgot/reset/invite email + tp-request trigger 都走這條。**注意**：早期 cutover doc 寫 `:8443` 是錯的,funnel 實際 listen :443)、`TRIPLINE_API_SECRET`(Bearer token，與 mac mini 同一組)
 - **Optional env**:`TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`(失敗通知 admin，未設則 silent skip)、`GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET`(Google 登入 button)
 - **Mac mini env**(在 mac mini `.env.local`，由 `tripline-api-server.ts` 載入)：`GMAIL_USERNAME` + `GMAIL_APP_PASSWORD`(App Password 不是 Gmail 登入密碼)、`EMAIL_FROM`
 - **Deprecated**:`RESEND_API_KEY` + `EMAIL_FROM`(CF Pages 端，2026-05-02 cutover 後改用 mac mini Gmail SMTP)


### PR DESCRIPTION
## Summary

修正 CLAUDE.md 對 \`TRIPLINE_API_URL\` 的過時描述。2026-05-02 cutover doc (commit 3365d9c) 寫成 \`https://...:8443\`，但 Tailscale Funnel 實際 listen \`:443\`、mac mini server 真正路由前綴是 \`/tripline/api/*\`。

## Diagnosis

POST \`/api/requests\` 後 \`context.waitUntil(fetch(\${TRIPLINE_API_URL}/trigger?source=api))\` 100% 失敗（自 2026-05-02 22:22 silent-fail-fix landing 後可觀測）。

| 時間 | 觸發者 | CF 錯誤 |
|------|------|------|
| 2026-05-03 05:40 | (latest) | trigger-failed |
| 2026-05-03 05:29 | penyin@gmail | 530 (origin DNS) |
| 2026-05-02 22:22 | lean.lean@gmail | 525 (SSL handshake) |

統計（cutover 後 ~31 hr）：
- trip_requests 總數：3
- trigger fetch 失敗：3 (100%)
- 15min cron 兜底處理：3 (全救回)

## Root Cause

| 層 | 真實狀態 |
|---|---|
| Tailscale Funnel | \`https://ray-chiudemac-mini.tail2750c0.ts.net\` (Funnel on) → proxy \`127.0.0.1:8080\` 預設 :443 |
| Mac mini API server | Caddy on :8080，真正路由 \`/tripline/api/*\`（直連 \`POST /tripline/api/trigger\` → 401 needs Bearer ✓ route 存在） |
| .env.local (local dev) | ✓ \`https://...ts.net/tripline/api\` (對的) |
| **CF Pages prod env (推測)** | ✗ \`https://...ts.net:8443\` → :8443 不 listen → CF 525/530 |

## Action Required (NOT in this PR)

User 需手動更新 prod secret：
\`\`\`bash
wrangler pages secret put TRIPLINE_API_URL --project-name trip-planner
# 貼: https://ray-chiudemac-mini.tail2750c0.ts.net/tripline/api
\`\`\`

## Test plan

- [x] \`tailscale funnel status\` 確認 :443 + proxy :8080
- [x] mac mini :8080 直連測 \`/tripline/api/trigger\` → 401 (route 存在)
- [x] audit_log query 確認 100% trigger-failed
- [ ] secret 更新後再發一筆 tp-request → 確認 trigger-failed audit 不再寫入

🤖 Generated with [Claude Code](https://claude.com/claude-code)