### PR TITLE
refactor(daynav): TripPage day nav 共用 MapDayTab + sticky chrome group

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -312,22 +312,23 @@
 
 ### Day Nav (Trip Detail + Map page 共用視覺)
 
-統一 colorful underline tab format — `.ocean-day-strip` (TripPage `<DayNav>`) 與 `.tp-map-day-tabs` (MapPage) 視覺對齊。
+Trip detail 與 Map page 共用同一個 underline tab primitive — `<MapDayTab>` 元件 + `.tp-map-day-tab*` CSS family。Trip detail 透過 `<DayNav>` wrapper 加上 sticky modifier；MapPage 直接用 plain wrapper（黏在底部 card-rail 上方）。
 
-**Tab 規格 (`[data-dn]` / `.tp-map-day-tab`)**
+**Tab 規格 (`.tp-map-day-tab`)**
 - text-only (eyebrow + date)，無 chip background fill / border
 - Eyebrow: `DAY 01` 套 per-day color (`dayColor(dayNum)` from `src/lib/dayPalette` — 10-tone Tailwind -500 palette)
 - Date: 14px / 600 weight, `color-foreground` (active 套 accent color)
 - Active state: 2px `border-bottom` 用 `--day-color` inline override (per-day color underline)
 - Idle: muted text + transparent border-bottom
 - Hover (idle): `color-foreground`
-- 44px min tap target
+- 36px min height (扁平 strip — 不搶佔垂直空間，對齊 mockup S20)
+- Today marker: eyebrow 文字後綴「· 今天」（不是另一個 pill）
 
-**Strip container (`.ocean-day-strip` / `.tp-map-day-tabs`)**
-- Sticky chrome group: 緊接 TitleBar (top: 64px desktop / 56px compact, mobile top:0)
-- Background glass blur 14px + 1px bottom hairline border
-- Horizontal scroll, scrollbar hidden
-- 右側 mask 漸層 fade 暗示「還有更多 day 可水平捲」
+**Strip container (`.tp-map-day-tabs`)**
+- 共用 wrapper：horizontal scroll + scrollbar hidden + glass blur 14px
+- Trip detail 加 modifier `.tp-map-day-tabs--sticky`：position: sticky, top: 64px (desktop) / 56px (compact)，緊接 TitleBar 形成 sticky chrome group，加底邊 hairline + 右側 mask 漸層 fade（暗示水平可捲）
+- MapPage 不用 modifier：top border 當作底部 card-rail 上邊界，自然 stack 在頁面 flex column
+- TripPage 內 `<TitleBar>` 已 sticky top:0，`<DayNav>` 設 top:64/56px → 兩者凍結頂部成 sticky chrome group
 
 ### Trip Detail Page
 - Desktop / compact 共用同一份 `TripDetail` 內容樹：DayNav、stop list、住宿、交通、地圖摘要、錯誤訊息、空狀態都不可拆成兩套邏輯。

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1124,6 +1124,23 @@ body.dark {
   color: var(--color-accent);
 }
 
+/* Sticky chrome variant — trip detail page 把同一條 strip 黏在 TitleBar 下方，
+ * border 從 top 翻到 bottom + 加右側 mask 漸層暗示「還有更多 day 可水平捲」。
+ * MapPage 不用此 modifier (它的 tabs 是 bottom card-rail 的上邊界)。 */
+.tp-map-day-tabs--sticky {
+  position: sticky;
+  top: 64px;
+  z-index: calc(var(--z-sticky-nav, 200) - 1);
+  border-top: none;
+  border-bottom: 1px solid var(--color-border);
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
+  mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
+}
+@media (max-width: 1100px) {
+  .tp-map-day-tabs--sticky { top: 56px; }
+}
+body.print-mode .tp-map-day-tabs--sticky { display: none; }
+
 /* ===== MapEntryCard — horizontal snap-scroll item (V2 Terracotta Map page) ===== */
 .tp-map-entry-cards {
   flex-shrink: 0;

--- a/docs/design-sessions/terracotta-preview-v2.html
+++ b/docs/design-sessions/terracotta-preview-v2.html
@@ -877,58 +877,9 @@
     letter-spacing: -0.01em;
   }
 
-  /* === Day chips === */
-  .tp-day-strip {
-    display: flex;
-    gap: 8px;
-    overflow-x: auto;
-    padding-bottom: 8px;
-    scrollbar-width: thin;
-  }
-  .tp-day-chip {
-    min-width: 140px;
-    padding: 12px 14px;
-    border-radius: var(--tp-radius-md);
-    border: 1px solid var(--tp-border);
-    background: var(--tp-background);
-    cursor: pointer;
-    transition: border-color 150ms, background 150ms;
-    flex-shrink: 0;
-  }
-  .tp-day-chip:hover {
-    border-color: var(--tp-accent);
-  }
-  .tp-day-chip.is-active {
-    background: var(--tp-accent);
-    color: var(--tp-on-accent);
-    border-color: var(--tp-accent);
-  }
-  .tp-day-chip-eyebrow {
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--tp-muted);
-    margin-bottom: 6px;
-    font-variant-numeric: tabular-nums;
-  }
-  .tp-day-chip.is-active .tp-day-chip-eyebrow {
-    color: rgba(255, 251, 245, 0.85);
-  }
-  .tp-day-chip-date {
-    font-size: 18px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-    letter-spacing: -0.01em;
-  }
-  .tp-day-chip-area {
-    font-size: 12px;
-    color: var(--tp-muted);
-    margin-top: 4px;
-  }
-  .tp-day-chip.is-active .tp-day-chip-area {
-    color: rgba(255, 251, 245, 0.9);
-  }
+  /* === Day tabs (canonical) — see Section 4961 .tp-map-day-tabs / .tp-map-day-tab。
+   * Trip detail + Map page 共用同一條 underline tab strip (text-only eyebrow + date,
+   * 無 chip background fill / border)。 */
 
   /* === Stop cards === */
   .tp-stops {
@@ -1861,67 +1812,8 @@
     padding: 16px;
   }
 
-  /* DayNav strip */
-  .tp-detail-daynav {
-    display: flex;
-    gap: 6px;
-    overflow-x: auto;
-    padding: 4px 0 12px;
-    margin-bottom: 16px;
-    scrollbar-width: none;
-  }
-  .tp-detail-daynav::-webkit-scrollbar { display: none; }
-  .tp-detail-daynav-pill {
-    flex-shrink: 0;
-    min-width: 96px;
-    padding: 8px 12px;
-    border: 1px solid var(--tp-border);
-    border-radius: var(--tp-radius-md);
-    background: var(--tp-background);
-    color: var(--tp-foreground);
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
-    cursor: pointer;
-    font: inherit;
-    transition: border-color 150ms, background 150ms, color 150ms;
-    text-align: left;
-  }
-  .tp-detail-daynav-pill:hover:not(.is-active) {
-    border-color: var(--tp-accent);
-  }
-  .tp-detail-daynav-pill.is-active {
-    background: var(--tp-accent);
-    color: var(--tp-on-accent);
-    border-color: var(--tp-accent);
-  }
-  .tp-detail-daynav-pill-eyebrow {
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--tp-muted);
-  }
-  .tp-detail-daynav-pill.is-active .tp-detail-daynav-pill-eyebrow {
-    color: rgba(255, 251, 245, 0.85);
-  }
-  .tp-detail-daynav-pill-date {
-    font-size: 14px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-  }
-  .tp-detail-daynav-pill-area {
-    font-size: 11px;
-    color: var(--tp-muted);
-  }
-  .tp-detail-daynav-pill.is-active .tp-detail-daynav-pill-area {
-    color: rgba(255, 251, 245, 0.85);
-  }
-  .tp-detail-mobile-frame .tp-detail-daynav-pill {
-    min-width: 84px;
-    padding: 6px 10px;
-  }
+  /* DayNav strip — 直接套用 .tp-map-day-tabs + .tp-map-day-tabs--sticky (Section 4961)。
+   * 舊 .tp-detail-daynav-pill chip 樣式已退役。 */
 
   /* Day Hero */
   .tp-detail-hero {
@@ -6037,37 +5929,32 @@
   </div>
 </section>
 
-<!-- ===== Section 11 — Day chips ===== -->
+<!-- ===== Section 11 — Day Tabs (Trip detail + Map page 共用) ===== -->
 <section class="tp-section">
-  <h2 class="tp-section-title">Day Chips</h2>
-  <p class="tp-section-lead">Active state 實心 Terracotta。</p>
-  <div class="tp-day-strip">
-    <div class="tp-day-chip">
-      <div class="tp-day-chip-eyebrow">DAY 01</div>
-      <div class="tp-day-chip-date">7/29</div>
-      <div class="tp-day-chip-area">北谷</div>
-    </div>
-    <div class="tp-day-chip">
-      <div class="tp-day-chip-eyebrow">DAY 02</div>
-      <div class="tp-day-chip-date">7/30</div>
-      <div class="tp-day-chip-area">浮潛・瀨底</div>
-    </div>
-    <div class="tp-day-chip is-active">
-      <div class="tp-day-chip-eyebrow">DAY 03 · 今天</div>
-      <div class="tp-day-chip-date">7/31</div>
-      <div class="tp-day-chip-area">水族館・古宇利</div>
-    </div>
-    <div class="tp-day-chip">
-      <div class="tp-day-chip-eyebrow">DAY 04</div>
-      <div class="tp-day-chip-date">8/01</div>
-      <div class="tp-day-chip-area">來客夢</div>
-    </div>
-    <div class="tp-day-chip">
-      <div class="tp-day-chip-eyebrow">DAY 05</div>
-      <div class="tp-day-chip-date">8/02</div>
-      <div class="tp-day-chip-area">首里城</div>
-    </div>
-  </div>
+  <h2 class="tp-section-title">Day Tabs</h2>
+  <p class="tp-section-lead">Trip detail + Map page 同一條 underline strip — text-only eyebrow + date,active 用 per-day color underline。Trip detail 加 <code>.tp-map-day-tabs--sticky</code> 黏在 TitleBar 下方。</p>
+  <nav class="tp-map-day-tabs">
+    <button class="tp-map-day-tab" type="button">
+      <span class="tp-map-day-tab-eyebrow" style="color:#0ea5e9">DAY 01</span>
+      <span class="tp-map-day-tab-date">7/29</span>
+    </button>
+    <button class="tp-map-day-tab" type="button">
+      <span class="tp-map-day-tab-eyebrow" style="color:#14b8a6">DAY 02</span>
+      <span class="tp-map-day-tab-date">7/30</span>
+    </button>
+    <button class="tp-map-day-tab is-active" type="button" style="--day-color:#f59e0b">
+      <span class="tp-map-day-tab-eyebrow" style="color:#f59e0b">DAY 03 · 今天</span>
+      <span class="tp-map-day-tab-date">7/31</span>
+    </button>
+    <button class="tp-map-day-tab" type="button">
+      <span class="tp-map-day-tab-eyebrow" style="color:#f43f5e">DAY 04</span>
+      <span class="tp-map-day-tab-date">8/01</span>
+    </button>
+    <button class="tp-map-day-tab" type="button">
+      <span class="tp-map-day-tab-eyebrow" style="color:#8b5cf6">DAY 05</span>
+      <span class="tp-map-day-tab-date">8/02</span>
+    </button>
+  </nav>
 </section>
 
 <!-- ===== Section 12 — Stop Card Redesign (Action Affordances) ===== -->
@@ -6265,31 +6152,26 @@
       </div>
     </header>
     <div class="tp-detail-content">
-      <nav class="tp-detail-daynav" aria-label="Day navigation">
-        <button class="tp-detail-daynav-pill" type="button">
-          <span class="tp-detail-daynav-pill-eyebrow">DAY 01</span>
-          <span class="tp-detail-daynav-pill-date">7/29</span>
-          <span class="tp-detail-daynav-pill-area">北谷</span>
+      <nav class="tp-map-day-tabs tp-map-day-tabs--sticky" aria-label="Day navigation">
+        <button class="tp-map-day-tab" type="button">
+          <span class="tp-map-day-tab-eyebrow" style="color:#0ea5e9">DAY 01</span>
+          <span class="tp-map-day-tab-date">7/29</span>
         </button>
-        <button class="tp-detail-daynav-pill" type="button">
-          <span class="tp-detail-daynav-pill-eyebrow">DAY 02</span>
-          <span class="tp-detail-daynav-pill-date">7/30</span>
-          <span class="tp-detail-daynav-pill-area">瀨底浮潛</span>
+        <button class="tp-map-day-tab" type="button">
+          <span class="tp-map-day-tab-eyebrow" style="color:#14b8a6">DAY 02</span>
+          <span class="tp-map-day-tab-date">7/30</span>
         </button>
-        <button class="tp-detail-daynav-pill is-active" type="button">
-          <span class="tp-detail-daynav-pill-eyebrow">DAY 03 · 今天</span>
-          <span class="tp-detail-daynav-pill-date">7/31</span>
-          <span class="tp-detail-daynav-pill-area">水族館・古宇利</span>
+        <button class="tp-map-day-tab is-active" type="button" style="--day-color:#f59e0b">
+          <span class="tp-map-day-tab-eyebrow" style="color:#f59e0b">DAY 03 · 今天</span>
+          <span class="tp-map-day-tab-date">7/31</span>
         </button>
-        <button class="tp-detail-daynav-pill" type="button">
-          <span class="tp-detail-daynav-pill-eyebrow">DAY 04</span>
-          <span class="tp-detail-daynav-pill-date">8/01</span>
-          <span class="tp-detail-daynav-pill-area">來客夢</span>
+        <button class="tp-map-day-tab" type="button">
+          <span class="tp-map-day-tab-eyebrow" style="color:#f43f5e">DAY 04</span>
+          <span class="tp-map-day-tab-date">8/01</span>
         </button>
-        <button class="tp-detail-daynav-pill" type="button">
-          <span class="tp-detail-daynav-pill-eyebrow">DAY 05</span>
-          <span class="tp-detail-daynav-pill-date">8/02</span>
-          <span class="tp-detail-daynav-pill-area">首里城</span>
+        <button class="tp-map-day-tab" type="button">
+          <span class="tp-map-day-tab-eyebrow" style="color:#8b5cf6">DAY 05</span>
+          <span class="tp-map-day-tab-date">8/02</span>
         </button>
       </nav>
 
@@ -6453,21 +6335,18 @@
       </div>
     </header>
       <div class="tp-detail-content">
-        <nav class="tp-detail-daynav" aria-label="Day navigation">
-          <button class="tp-detail-daynav-pill" type="button">
-            <span class="tp-detail-daynav-pill-eyebrow">D 02</span>
-            <span class="tp-detail-daynav-pill-date">7/30</span>
-            <span class="tp-detail-daynav-pill-area">瀨底</span>
+        <nav class="tp-map-day-tabs tp-map-day-tabs--sticky" aria-label="Day navigation">
+          <button class="tp-map-day-tab" type="button">
+            <span class="tp-map-day-tab-eyebrow" style="color:#14b8a6">DAY 02</span>
+            <span class="tp-map-day-tab-date">7/30</span>
           </button>
-          <button class="tp-detail-daynav-pill is-active" type="button">
-            <span class="tp-detail-daynav-pill-eyebrow">D 03 · 今天</span>
-            <span class="tp-detail-daynav-pill-date">7/31</span>
-            <span class="tp-detail-daynav-pill-area">古宇利</span>
+          <button class="tp-map-day-tab is-active" type="button" style="--day-color:#f59e0b">
+            <span class="tp-map-day-tab-eyebrow" style="color:#f59e0b">DAY 03 · 今天</span>
+            <span class="tp-map-day-tab-date">7/31</span>
           </button>
-          <button class="tp-detail-daynav-pill" type="button">
-            <span class="tp-detail-daynav-pill-eyebrow">D 04</span>
-            <span class="tp-detail-daynav-pill-date">8/01</span>
-            <span class="tp-detail-daynav-pill-area">來客夢</span>
+          <button class="tp-map-day-tab" type="button">
+            <span class="tp-map-day-tab-eyebrow" style="color:#f43f5e">DAY 04</span>
+            <span class="tp-map-day-tab-date">8/01</span>
           </button>
         </nav>
 

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -63,8 +63,8 @@ export const APP_SHELL_STYLES = `
 /* Mobile <1024px：單欄 + bottom nav 常駐.
  *
  * Why height: 100dvh (not min-height): we need .app-shell-main to be a real
- * scroll container so sticky elements inside (like .ocean-day-strip) stick
- * to the top of main, not get carried away by the document scroll. With
+ * scroll container so sticky elements inside (like TitleBar + .tp-map-day-tabs)
+ * stick to the top of main, not get carried away by the document scroll. With
  * min-height the grid grows with content, main isn't constrained, and the
  * window scrolls instead — breaking sticky inside main. */
 @media (max-width: 1023px) {

--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -1,116 +1,19 @@
-import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
-import clsx from 'clsx';
+import { useRef, useEffect, useMemo } from 'react';
 import type { DaySummary } from '../../types/trip';
 import { parseLocalDate } from '../../lib/mapDay';
 import { dayColor } from '../../lib/dayPalette';
+import MapDayTab from './MapDayTab';
 
-/* ===== Scoped styles ===== */
-
-/* DayNav — sticky underline tab strip (對齊 MapPage day tab 視覺 + sticky chrome)
- * 2026-05-03: 從 chip card pill 改 colorful text + active underline,跟
- * .tp-map-day-tab 同 family。Sticky 緊接 TitleBar (top 64/56px) 形成 sticky
- * chrome group。 */
-const SCOPED_STYLES = `
-.ocean-day-strip {
-  display: flex;
-  gap: 2px;
-  overflow-x: auto;
-  scrollbar-width: none;
-  padding: 0 12px;
-  margin: 0 -40px 20px;
-  position: sticky;
-  top: 64px;
-  z-index: calc(var(--z-sticky-nav) - 1);
-  background: color-mix(in srgb, var(--color-background) 92%, transparent);
-  backdrop-filter: blur(var(--blur-glass, 14px));
-  -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
-  border-bottom: 1px solid var(--color-border);
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
-  mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
-}
-.ocean-day-strip::-webkit-scrollbar { display: none; }
-@media (max-width: 1200px) {
-  .ocean-day-strip { margin-left: -28px; margin-right: -28px; }
-}
-@media (max-width: 1100px) {
-  .ocean-day-strip { top: 56px; }
-}
-@media (max-width: 760px) {
-  .ocean-day-strip {
-    margin: 0 0 16px;
-  }
-}
-body.print-mode .ocean-day-strip { display: none; }
-
-/* DayNav button — alias of .tp-map-day-tab visual (sticky chrome group with
- * MapPage). Colorful eyebrow per dayColor + active underline 2px。 */
-[data-dn] {
-  flex: 0 0 auto;
-  padding: 6px 14px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  background: transparent;
-  color: var(--color-muted);
-  cursor: pointer;
-  font: inherit;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  min-height: 44px;
-  white-space: nowrap;
-  transition: color 150ms, border-bottom-color 150ms;
-}
-[data-dn]:hover:not(.active) { color: var(--color-foreground); }
-[data-dn].active {
-  color: var(--color-accent);
-  border-bottom-color: var(--day-color, var(--color-accent));
-}
-[data-dn] .dn-eyebrow {
-  font-size: var(--font-size-eyebrow);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-variant-numeric: tabular-nums;
-  opacity: 0.7;
-  line-height: 1;
-}
-[data-dn].active .dn-eyebrow { opacity: 1; }
-[data-dn] .dn-date {
-  font-size: var(--font-size-footnote);
-  font-weight: 600;
-  line-height: 1;
-  color: var(--color-foreground);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.005em;
-}
-[data-dn].active .dn-date { color: var(--color-accent); }
-
-[data-dn] .dn-eyebrow-today {
-  font-weight: 600;
-  opacity: 0.8;
-}
-[data-dn] .dn-area {
-  font-size: var(--font-size-caption2);
-  opacity: 0.55;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 120px;
-  line-height: 1;
-}
-
-@keyframes dn-tooltip-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(4px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-`;
-
-/* ===== Helpers ===== */
+/**
+ * DayNav — Trip detail page day strip。
+ *
+ * 視覺直接共用 MapPage 的 `<MapDayTab>` + `.tp-map-day-tabs` family，
+ * 加上 `.tp-map-day-tabs--sticky` modifier 把 strip 黏在 TitleBar 下方。
+ * Mockup spec: terracotta-preview-v2.html S20 underline tabs。
+ * DESIGN.md: Day Nav (Trip Detail + Map page 共用視覺)。
+ */
 
 const WEEKDAYS = '日一二三四五六';
-const WEEKDAYS_EN = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 /** Exposed for unit test only; not part of the public component API. */
 export function formatPillLabel(day: DaySummary): string {
@@ -119,19 +22,7 @@ export function formatPillLabel(day: DaySummary): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-function parseChipParts(day: DaySummary): { eyebrow: string; date: string; dow: string; dowZh: string } {
-  const eyebrow = `DAY ${String(day.dayNum).padStart(2, '0')}`;
-  const d = parseLocalDate(day.date);
-  if (!d) return { eyebrow, date: String(day.dayNum), dow: '', dowZh: '' };
-  return {
-    eyebrow,
-    date: `${d.getMonth() + 1}/${d.getDate()}`,
-    dow: WEEKDAYS_EN[d.getDay()] ?? '',
-    dowZh: WEEKDAYS[d.getDay()] ?? '',
-  };
-}
-
-function formatTooltip(day: DaySummary): string {
+function buildAriaLabel(day: DaySummary): string {
   const parts: string[] = [`Day ${day.dayNum}`];
   const d = parseLocalDate(day.date);
   if (d) parts.push(`${d.getMonth() + 1}/${d.getDate()}（${WEEKDAYS[d.getDay()]}）`);
@@ -139,146 +30,87 @@ function formatTooltip(day: DaySummary): string {
   return parts.join(' — ');
 }
 
-/* ===== Props ===== */
-
-interface DayNavProps {
+export interface DayNavProps {
   days: DaySummary[];
   currentDayNum: number;
   onSwitchDay: (dayNum: number) => void;
   todayDayNum?: number;
   isTripMapMode?: boolean;
   onToggleTripMap?: () => void;
-  /** Stop count per day (dayNum → count). Used to render progress marks. */
+  /** Stop count per day (dayNum → count). Reserved for future progress marks. */
   stopsByDay?: Record<number, number>;
 }
 
-/* ===== Component ===== */
+export default function DayNav({
+  days,
+  currentDayNum,
+  onSwitchDay,
+  todayDayNum,
+  isTripMapMode = false,
+  onToggleTripMap,
+}: DayNavProps) {
+  const navRef = useRef<HTMLElement>(null);
 
-export default function DayNav({ days, currentDayNum, onSwitchDay, todayDayNum, isTripMapMode = false, onToggleTripMap }: DayNavProps) {
-  const navRef = useRef<HTMLDivElement>(null);
-  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [tooltipDay, setTooltipDay] = useState<number | null>(null);
-
-  /* --- Cleanup timers on unmount --- */
-  useEffect(() => {
-    return () => {
-      if (longPressTimer.current) clearTimeout(longPressTimer.current);
-      if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
-    };
-  }, []);
-
-  /* --- Scroll active chip into view --- */
+  // Scroll active tab into horizontal view on day switch
   useEffect(() => {
     const nav = navRef.current;
     if (!nav) return;
-    const btn = nav.querySelector<HTMLElement>(`[data-dn][data-day="${currentDayNum}"]`);
+    const btn = nav.querySelector<HTMLElement>(`[data-testid="dn-day-${currentDayNum}"]`);
     if (!btn) return;
     const left = btn.offsetLeft - nav.offsetWidth / 2 + btn.offsetWidth / 2;
     nav.scrollTo({ left: Math.max(0, left), behavior: 'smooth' });
   }, [currentDayNum]);
 
-  const handleDayClick = useCallback((dayNum: number) => {
-    onSwitchDay(dayNum);
-  }, [onSwitchDay]);
-
-  /* --- Hover/touch tooltip --- */
-  const handleMouseEnter = useCallback((dayNum: number) => {
-    if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
-    tooltipTimer.current = setTimeout(() => setTooltipDay(dayNum), 400);
-  }, []);
-  const handleMouseLeave = useCallback(() => {
-    if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
-    setTooltipDay(null);
-  }, []);
-  const handleTouchStart = useCallback((dayNum: number) => {
-    longPressTimer.current = setTimeout(() => setTooltipDay(dayNum), 500);
-  }, []);
-  const handleTouchEnd = useCallback(() => {
-    if (longPressTimer.current) clearTimeout(longPressTimer.current);
-    setTimeout(() => setTooltipDay(null), 1500);
-  }, []);
-
-  // Pre-compute per-chip data once per `days`/`todayDayNum` change so render loop
-  // doesn't rerun parseChipParts + dayColor on every parent state update.
-  const chips = useMemo(
+  const tabs = useMemo(
     () => days.map((d) => {
-      const color = dayColor(d.dayNum);
+      const eyebrowBase = `DAY ${String(d.dayNum).padStart(2, '0')}`;
+      const isToday = d.dayNum === todayDayNum;
       return {
         day: d,
         dayNum: d.dayNum,
-        parts: parseChipParts(d),
-        isToday: d.dayNum === todayDayNum,
-        btnStyle: { '--day-color': color } as React.CSSProperties,
-        eyebrowStyle: { color } as React.CSSProperties,
+        dayLabel: isToday ? `${eyebrowBase} · 今天` : eyebrowBase,
+        dateLabel: formatPillLabel(d),
+        color: dayColor(d.dayNum),
+        ariaLabel: buildAriaLabel(d),
       };
     }),
     [days, todayDayNum],
   );
 
   return (
-    <>
-      <style>{SCOPED_STYLES}</style>
-      <div className="ocean-day-strip" id="navPills" ref={navRef} role="tablist" aria-label="行程日期">
-        {chips.map(({ day, dayNum, parts, isToday, btnStyle, eyebrowStyle }) => {
-          const isActive = !isTripMapMode && dayNum === currentDayNum;
-          const showTooltip = tooltipDay === dayNum;
-          const tooltipId = `dn-tooltip-${dayNum}`;
-          return (
-            <button
-              key={dayNum}
-              className={clsx('dn', isActive && 'active')}
-              data-dn=""
-              data-day={dayNum}
-              data-action="switch-day"
-              data-target={`day${dayNum}`}
-              aria-label={day.label ? `${formatPillLabel(day)} ${day.label}` : formatPillLabel(day)}
-              aria-describedby={showTooltip ? tooltipId : undefined}
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => handleDayClick(dayNum)}
-              onMouseEnter={() => handleMouseEnter(dayNum)}
-              onMouseLeave={handleMouseLeave}
-              onTouchStart={() => handleTouchStart(dayNum)}
-              onTouchEnd={handleTouchEnd}
-              style={btnStyle}
-            >
-              {/* eyebrow (DAY 01) 套 per-day color, date 跟 active state 用 accent */}
-              <span className="dn-eyebrow" style={eyebrowStyle}>
-                {parts.eyebrow}
-                {isToday && <span className="dn-eyebrow-today" aria-label="今日"> · 今天</span>}
-              </span>
-              <div className="dn-date">{parts.date}</div>
-              {day.label && <div className="dn-area">{day.label}</div>}
-              {showTooltip && (
-                <span
-                  id={tooltipId}
-                  className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 bg-secondary text-foreground text-caption font-medium py-2 px-3 rounded-sm shadow-md whitespace-nowrap z-10 pointer-events-none [animation:dn-tooltip-in_var(--transition-duration-fast)_var(--transition-timing-function-apple)]"
-                  role="tooltip"
-                >
-                  {formatTooltip(day)}
-                </span>
-              )}
-            </button>
-          );
-        })}
+    <nav
+      ref={navRef}
+      id="navPills"
+      className="tp-map-day-tabs tp-map-day-tabs--sticky"
+      role="tablist"
+      aria-label="行程日期"
+    >
+      {tabs.map(({ dayNum, dayLabel, dateLabel, color, ariaLabel }) => {
+        const isActive = !isTripMapMode && dayNum === currentDayNum;
+        return (
+          <MapDayTab
+            key={dayNum}
+            dayLabel={dayLabel}
+            dateLabel={dateLabel}
+            dayColor={color}
+            isActive={isActive}
+            onClick={() => onSwitchDay(dayNum)}
+            ariaLabel={ariaLabel}
+            testId={`dn-day-${dayNum}`}
+          />
+        );
+      })}
 
-        {onToggleTripMap && (
-          <button
-            className={clsx('dn', isTripMapMode && 'active')}
-            data-dn=""
-            aria-label="全覽地圖"
-            aria-pressed={isTripMapMode}
-            onClick={onToggleTripMap}
-            data-testid="dn-overview-btn"
-            type="button"
-          >
-            {/* Overview button: no per-day color (用 accent fallback)。 */}
-            <span className="dn-eyebrow">MAP</span>
-            <div className="dn-date">全覽</div>
-          </button>
-        )}
-      </div>
-    </>
+      {onToggleTripMap && (
+        <MapDayTab
+          dayLabel="MAP"
+          dateLabel="全覽"
+          isActive={isTripMapMode}
+          onClick={onToggleTripMap}
+          ariaLabel="全覽地圖"
+          testId="dn-overview-btn"
+        />
+      )}
+    </nav>
   );
 }

--- a/src/components/trip/MapDayTab.tsx
+++ b/src/components/trip/MapDayTab.tsx
@@ -19,9 +19,13 @@ export interface MapDayTabProps {
   isActive: boolean;
   /** 點擊 callback */
   onClick: () => void;
+  /** Optional aria-label override（trip detail 帶日期 + day.label 的完整描述） */
+  ariaLabel?: string;
+  /** Optional data-testid for test selectors */
+  testId?: string;
 }
 
-export default function MapDayTab({ dayLabel, dateLabel, dayColor, isActive, onClick }: MapDayTabProps) {
+export default function MapDayTab({ dayLabel, dateLabel, dayColor, isActive, onClick, ariaLabel, testId }: MapDayTabProps) {
   // Section 4.10 (terracotta-mockup-parity-v2)：active state border-bottom 用
   // per-day color 取代固定 accent，呼應 mockup section 20 underline 用 day color
   // 強化 day↔map polyline 視覺對應。CSS rule 讀 --day-color (有設值才覆蓋)。
@@ -33,9 +37,11 @@ export default function MapDayTab({ dayLabel, dateLabel, dayColor, isActive, onC
       type="button"
       role="tab"
       aria-selected={isActive}
+      aria-label={ariaLabel}
       className={`tp-map-day-tab${isActive ? ' is-active' : ''}`}
       onClick={onClick}
       style={style}
+      data-testid={testId}
     >
       <span
         className="tp-map-day-tab-eyebrow"

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -64,9 +64,6 @@ const SCOPED_STYLES = `
 .day-content-loaded {
   animation: fadeIn 300ms var(--transition-timing-function-apple) both;
 }
-/* Sticky-nav children z-index layering above DestinationArt */
-.sticky-nav > :not([aria-hidden="true"]) { position: relative; z-index: 1; }
-
 .trip-content { min-width: 0; }
 
 /* Compact-hidden TitleBar actions — 桌機(>=761px) 顯示「建議 / 共編 / 下載」
@@ -76,14 +73,13 @@ const SCOPED_STYLES = `
 }
 
 /* Print mode */
-.print-mode .sticky-nav { display: none; }
 .print-mode .print-exit-btn { display: block; }
 .print-mode .page-layout { padding-right: 0 !important; }
 .print-mode #tripContent section { background: var(--color-background) !important; }
 .print-mode .day-header { background: var(--color-background); position: relative !important; flex-wrap: wrap; padding: 8px 12px; }
 .print-mode .container { max-width: 210mm; margin: 0 auto; box-shadow: var(--shadow-lg); }
 @media print {
-  .sticky-nav, .print-exit-btn { display: none !important; }
+  .print-exit-btn { display: none !important; }
 }
 `;
 

--- a/tests/unit/day-nav-eyebrow.test.tsx
+++ b/tests/unit/day-nav-eyebrow.test.tsx
@@ -1,19 +1,18 @@
 /**
- * DayNav eyebrow format — Section 4.4 (terracotta-mockup-parity-v2)
+ * DayNav eyebrow format — 共用 MapDayTab 視覺後的對齊驗證
  *
- * 驗 mockup 對齊改動：
- *   - eyebrow「DAY 03 · 今天」 today suffix 取代獨立 TODAY pill
- *   - 拿掉 .dn-dow 週幾英文 extra row
+ * 驗 contract：
+ *   - eyebrow「DAY 03 · 今天」 today suffix 內嵌在 .tp-map-day-tab-eyebrow 文字內
  *   - non-today day eyebrow 純「DAY 0X」
- *   - area 仍渲染為 .dn-area
+ *   - todayDayNum 沒給 → 沒任何 day 顯示「今天」
+ *   - 不再有 .dn-area / .dn-dow / .dn-today / .dn-pill 等舊 chip 殘留
+ *   - 不再有自家 [data-dn] CSS hook，全用 .tp-map-day-tab*
  */
 import { describe, expect, it, vi, beforeAll } from 'vitest';
 import { render } from '@testing-library/react';
 import DayNav from '../../src/components/trip/DayNav';
 import type { DaySummary } from '../../src/types/trip';
 
-// jsdom 缺 Element.scrollTo，DayNav 在 mount 後對 nav container 呼叫
-// scrollTo({ left, behavior }) — 補上 noop 避免 ReactDOM commit 階段 throw。
 beforeAll(() => {
   if (!Element.prototype.scrollTo) {
     Element.prototype.scrollTo = (() => {}) as Element['scrollTo'];
@@ -28,8 +27,13 @@ function makeDays(): DaySummary[] {
   ];
 }
 
-describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
-  it('today day eyebrow 含「· 今天」 suffix', () => {
+function eyebrowTexts(): string[] {
+  return Array.from(document.querySelectorAll('.tp-map-day-tab-eyebrow'))
+    .map((el) => el.textContent ?? '');
+}
+
+describe('DayNav — MapDayTab 共用視覺對齊', () => {
+  it('today day eyebrow 文字含「· 今天」 suffix', () => {
     render(
       <DayNav
         days={makeDays()}
@@ -38,12 +42,11 @@ describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
         todayDayNum={2}
       />,
     );
-    const todaySuffix = document.querySelector('.dn-eyebrow-today');
-    expect(todaySuffix).toBeTruthy();
-    expect(todaySuffix?.textContent).toContain('今天');
+    const todayEyebrow = eyebrowTexts().find((t) => t.includes('今天'));
+    expect(todayEyebrow).toBe('DAY 02 · 今天');
   });
 
-  it('non-today day eyebrow 不含「· 今天」', () => {
+  it('non-today day eyebrow 純「DAY 0X」 不含「今天」', () => {
     render(
       <DayNav
         days={makeDays()}
@@ -52,9 +55,8 @@ describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
         todayDayNum={2}
       />,
     );
-    const todaySuffixCount = document.querySelectorAll('.dn-eyebrow-today');
-    // 整個 nav 應該只有「Day 2」一個 eyebrow 含 today
-    expect(todaySuffixCount.length).toBe(1);
+    const todayCount = eyebrowTexts().filter((t) => t.includes('今天')).length;
+    expect(todayCount).toBe(1);
   });
 
   it('todayDayNum 沒給 → 沒任何 day 顯示「今天」', () => {
@@ -65,10 +67,10 @@ describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
         onSwitchDay={vi.fn()}
       />,
     );
-    expect(document.querySelector('.dn-eyebrow-today')).toBeNull();
+    expect(eyebrowTexts().some((t) => t.includes('今天'))).toBe(false);
   });
 
-  it('TODAY pill (.dn-today / .dn-pill) 被拿掉，只用 eyebrow suffix', () => {
+  it('舊 chip CSS hooks (.dn-* / [data-dn] / .ocean-day-strip) 全清', () => {
     render(
       <DayNav
         days={makeDays()}
@@ -79,31 +81,10 @@ describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
     );
     expect(document.querySelector('.dn-today')).toBeNull();
     expect(document.querySelector('.dn-pill')).toBeNull();
-  });
-
-  it('.dn-dow 週幾英文 extra row 已移除', () => {
-    render(
-      <DayNav
-        days={makeDays()}
-        currentDayNum={1}
-        onSwitchDay={vi.fn()}
-      />,
-    );
     expect(document.querySelector('.dn-dow')).toBeNull();
-  });
-
-  it('area label 仍渲染為 .dn-area', () => {
-    render(
-      <DayNav
-        days={makeDays()}
-        currentDayNum={1}
-        onSwitchDay={vi.fn()}
-      />,
-    );
-    const areas = Array.from(document.querySelectorAll('.dn-area')).map((el) => el.textContent);
-    expect(areas).toContain('那霸');
-    expect(areas).toContain('美瑛');
-    expect(areas).toContain('富良野');
+    expect(document.querySelector('.dn-area')).toBeNull();
+    expect(document.querySelector('[data-dn]')).toBeNull();
+    expect(document.querySelector('.ocean-day-strip')).toBeNull();
   });
 
   it('eyebrow 主文字為「DAY NN」 zero-pad 格式', () => {
@@ -112,13 +93,24 @@ describe('DayNav eyebrow — Section 4.4 mockup parity', () => {
         days={makeDays()}
         currentDayNum={1}
         onSwitchDay={vi.fn()}
-        todayDayNum={2}
       />,
     );
-    const eyebrows = Array.from(document.querySelectorAll('.dn-eyebrow'))
-      .map((el) => (el.firstChild?.textContent ?? '').trim());
-    expect(eyebrows).toContain('DAY 01');
-    expect(eyebrows).toContain('DAY 02');
-    expect(eyebrows).toContain('DAY 03');
+    const texts = eyebrowTexts();
+    expect(texts).toContain('DAY 01');
+    expect(texts).toContain('DAY 02');
+    expect(texts).toContain('DAY 03');
+  });
+
+  it('共用 .tp-map-day-tabs wrapper + sticky modifier', () => {
+    render(
+      <DayNav
+        days={makeDays()}
+        currentDayNum={1}
+        onSwitchDay={vi.fn()}
+      />,
+    );
+    const nav = document.querySelector('.tp-map-day-tabs');
+    expect(nav).toBeTruthy();
+    expect(nav?.classList.contains('tp-map-day-tabs--sticky')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

行程明細頁的 DayNav 直接共用 MapPage 的 underline tab 視覺 — 一個 \`<MapDayTab>\` primitive，TripPage 套 \`.tp-map-day-tabs--sticky\` 黏在 TitleBar 下方形成凍結頂部的 sticky chrome group。

| | Before | After |
|---|---|---|
| TripPage day nav | 自家 \`[data-dn]\` CSS family，stacked column 44px，含 area label + 長按 tooltip | 共用 \`<MapDayTab>\` 元件，扁平 36px underline strip |
| Sticky 行為 | 已 sticky 但用獨立 .ocean-day-strip wrapper | 改用 \`.tp-map-day-tabs--sticky\` modifier，跟 TitleBar (top:0) 一起凍結 |
| Today marker | \`.dn-eyebrow-today\` 子節點 | eyebrow 文字後綴「DAY 03 · 今天」 |
| LOC | DayNav.tsx 298 行 | ~100 行 (-277 LOC 全 PR) |

## Files

- \`src/components/trip/DayNav.tsx\` — 重寫成 MapDayTab compose wrapper，drop 自家 CSS / area / tooltip / parseChipParts
- \`src/components/trip/MapDayTab.tsx\` — 加 \`ariaLabel\` + \`testId\` 兩個 optional prop
- \`css/tokens.css\` — 新增 \`.tp-map-day-tabs--sticky\` modifier (sticky top:64/56px + border-bottom + right mask)
- \`src/pages/TripPage.tsx\` — 順手清掉死掉的 .sticky-nav CSS rules（PR-?? 之前移除 showNavTitle 後留下）
- \`src/components/shell/AppShell.tsx\` — sticky 註解 .ocean-day-strip → .tp-map-day-tabs
- \`docs/design-sessions/terracotta-preview-v2.html\` — Section 11 Day Chips + Trip Detail mobile frame 兩處 markup 改 .tp-map-day-tab*；舊 .tp-day-chip / .tp-detail-daynav-pill CSS 退役
- \`DESIGN.md\` — Day Nav section 收緊：明確「\`<MapDayTab>\` + \`.tp-map-day-tab*\` 是共用 primitive，trip detail 加 sticky modifier」
- \`tests/unit/day-nav-eyebrow.test.tsx\` — selector 改用 .tp-map-day-tab-eyebrow，新增 sticky modifier 驗證

## Test plan

- [x] tsc clean
- [x] 全套 1291 tests pass (DayNav unit tests 9 全綠，新增 sticky modifier 驗證)
- [x] build 466ms PASS
- [x] mockup HTML 自動截圖驗證 Section 11 視覺正確（5 個 underline tabs + per-day color + active 帶 today suffix）
- [ ] 手動：開 \`/trips?selected=okinawa-trip-2026-Ray\` 確認 desktop + mobile 兩條 sticky chrome (TitleBar 64px + DayNav top:64px) 凍結頂部
- [ ] 手動：MapPage \`/map\` 確認原本的 day tabs（無 sticky modifier）視覺不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)