### PR TITLE
fix(daynav): #dayN anchor scroll-margin + 移除側邊漸層 + sticky chrome 緊貼

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -326,7 +326,9 @@ Trip detail 與 Map page 共用同一個 underline tab primitive — `<MapDayTab
 
 **Strip container (`.tp-map-day-tabs`)**
 - 共用 wrapper：horizontal scroll + scrollbar hidden + glass blur 14px
-- Trip detail 加 modifier `.tp-map-day-tabs--sticky`：position: sticky, top: 64px (desktop) / 56px (compact)，緊接 TitleBar 形成 sticky chrome group，加底邊 hairline + 右側 mask 漸層 fade（暗示水平可捲）
+- Trip detail 加 modifier `.tp-map-day-tabs--sticky`：position: sticky, top: 64px (desktop) / 56px (compact)，緊接 TitleBar 形成 sticky chrome group，僅加底邊 hairline（不加水平 mask 漸層 — 視覺干擾）
+- 錨點 #dayN 跳轉：`.ocean-hero { scroll-margin-top: 110px (desktop) / 100px (compact) }`，避免目標被 sticky chrome 蓋住
+- TripPage 的 `.ocean-page` 桌機 top padding = 0（讓 sticky day strip 緊貼 TitleBar 無空隙）；mobile 已是 0
 - MapPage 不用 modifier：top border 當作底部 card-rail 上邊界，自然 stack 在頁面 flex column
 - TripPage 內 `<TitleBar>` 已 sticky top:0，`<DayNav>` 設 top:64/56px → 兩者凍結頂部成 sticky chrome group
 

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -404,10 +404,13 @@ body.dark {
 @layer base {
     .ocean-shell { min-height: 100dvh; background: var(--color-background); color: var(--color-foreground); }
 
-    /* Page */
-    .ocean-page { padding: 28px 40px 48px; max-width: 1440px; margin: 0 auto; }
+    /* Page — top padding 0 讓 sticky day nav strip 緊貼 TitleBar 下方無空隙
+     * (.ocean-page 只有 TripPage 用)。Hero 自帶 padding，content 不會貼太緊。 */
+    .ocean-page { padding: 0 40px 48px; max-width: 1440px; margin: 0 auto; }
 
-    /* Hero card inside each day — Airbnb editorial white card */
+    /* Hero card inside each day — Airbnb editorial white card。
+     * scroll-margin-top: 110px desktop / 100px compact 讓 #dayN 錨點跳轉時
+     * 落在 sticky chrome (TitleBar 64/56 + DayNav strip ~37) 下方，避免被蓋。 */
     .ocean-hero {
         background: var(--color-accent);
         color: var(--color-accent-foreground);
@@ -415,6 +418,7 @@ body.dark {
         border: 0;
         padding: 20px 24px; margin-bottom: 20px;
         overflow: hidden;
+        scroll-margin-top: 110px;
     }
     .ocean-hero-chips {
         display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap;
@@ -640,16 +644,11 @@ body.dark {
     .app-shell-sheet { overscroll-behavior: contain; }
     .app-shell-sheet .ocean-shell { min-height: 0; }
     .app-shell-sheet .ocean-page { padding: 0 24px 24px; }
-    .app-shell-sheet .ocean-day-strip {
-      top: 0;
-      margin: 0 -24px 16px;
-      padding: 8px 24px;
-    }
     .app-shell-sheet .ocean-day > .ocean-hero { scroll-margin-top: 96px; }
 
     /* Breakpoints */
     @media (max-width: 1200px) {
-        .ocean-page { padding: 24px 28px 40px; }
+        .ocean-page { padding: 0 28px 40px; }
     }
     @media (max-width: 960px) {
         .ocean-hero-title { font-size: 24px; } /* mockup .tp-detail-hero-title compact:1877 (was 28px) */
@@ -663,9 +662,9 @@ body.dark {
         .ocean-page { padding: 0 16px calc(80px + env(safe-area-inset-bottom)); }
         .ocean-hero { padding: 22px 20px; border-radius: var(--radius-md); }
         .ocean-hero-title { font-size: 24px; } /* F003: DESIGN.md mobile hero title = 24px */
-        /* Mobile sticky day-strip is the only top chrome (topbar hidden).
-         * Pill row 60-80 high + breathing 16-20 → land day title clear. */
-        .ocean-day > .ocean-hero { scroll-margin-top: 96px; }
+        /* Mobile sticky chrome = TitleBar 56 + DayNav strip ~37 = ~93px
+         * + 7px breathing = 100px。 */
+        .ocean-day > .ocean-hero { scroll-margin-top: 100px; }
     }
 
     /* Mobile bottom tab bar (只在 ≤760px 顯示) */
@@ -1124,8 +1123,8 @@ body.dark {
   color: var(--color-accent);
 }
 
-/* Sticky chrome variant — trip detail page 把同一條 strip 黏在 TitleBar 下方，
- * border 從 top 翻到 bottom + 加右側 mask 漸層暗示「還有更多 day 可水平捲」。
+/* Sticky chrome variant — trip detail page 把同一條 strip 黏在 TitleBar 下方。
+ * border 從 top 翻到 bottom (sticky chrome group 底邊)。
  * MapPage 不用此 modifier (它的 tabs 是 bottom card-rail 的上邊界)。 */
 .tp-map-day-tabs--sticky {
   position: sticky;
@@ -1133,10 +1132,8 @@ body.dark {
   z-index: calc(var(--z-sticky-nav, 200) - 1);
   border-top: none;
   border-bottom: 1px solid var(--color-border);
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
-  mask-image: linear-gradient(to right, black calc(100% - 32px), transparent 100%);
 }
-@media (max-width: 1100px) {
+@media (max-width: 760px) {
   .tp-map-day-tabs--sticky { top: 56px; }
 }
 body.print-mode .tp-map-day-tabs--sticky { display: none; }


### PR DESCRIPTION
## Summary

PR #454 deploy 後 user QA 在 \`/trips?selected=okinawa-trip-2026-HuiYun#day2\` 截圖回報 4 個視覺/互動 bug，這 PR 全修。

## Findings & Fixes

| # | Bug | Root cause | Fix |
|---|-----|-----------|-----|
| 1 | 錨點 \`#day2\` 切換位置不對，hero 被 sticky chrome 蓋掉 | desktop 沒 \`scroll-margin-top\`（只 mobile ≤760px 有 96px） | \`.ocean-hero { scroll-margin-top: 110px }\` desktop, 100px compact (對應 TitleBar 64/56 + DayNav strip ~37) |
| 2 | 左右漸層干擾視覺 | \`.tp-map-day-tabs--sticky\` 加了 \`mask-image: linear-gradient(...)\` | 移除 mask-image |
| 3 | Sticky chrome 上方留空太高 | \`.ocean-page\` 桌機 \`padding-top: 28px\` 撐開 day strip 與 TitleBar 之間 | desktop padding-top 28→0（mobile 已是 0） |
| 4 | (順手) dead CSS | \`.app-shell-sheet .ocean-day-strip\` PR #454 後 class 改名失效 | 刪除 |

## TitleBar 凍結確認（沒改 code，純驗證）

User 提到「所有 title bar 應該都要凍結」— 已 audit：
- \`.tp-titlebar\` 兩個 viewport (≥761 / ≤760) 都有 \`position: sticky; top: 0\`
- \`.app-shell-main\` 是 scroll container（\`overflow-y: auto\`, \`height: 100dvh\`）
- \`.tp-embedded-trip\` grid auto/1fr 不破壞 sticky 鏈
- 沒任何 page wrapper 用 \`overflow: hidden\` 截斷 sticky 鏈
- 結論：TitleBar sticky 鏈完整,user 之前看到「沒凍結」其實是 anchor 跳轉後 hero 被覆蓋的視覺錯覺（fix #1 解）

## Files

- \`css/tokens.css\` — 4 處改動（scroll-margin / mask 移除 / page padding / dead rule 清理）
- \`DESIGN.md\` — Day Nav section 同步：說明錨點 offset 規範 + mask 已移除 + .ocean-page top:0 規範

## Test plan

- [x] tsc clean
- [x] 1291 tests pass
- [x] build OK
- [ ] 手動：\`/trips?selected=<tripId>#day2\` 確認 hero 跳轉後完全可見、不被 sticky chrome 蓋
- [ ] 手動：sticky day strip 左右無漸層
- [ ] 手動：TitleBar 與 day strip 緊貼，無空隙
- [ ] 手動：所有頁面 TitleBar 滾動時都凍結頂部（chat / map / explore / account / trips）

🤖 Generated with [Claude Code](https://claude.com/claude-code)