### PR TITLE
fix(layout): TitleBar sticky 被推走 — .tp-embedded-trip grid → block

### DIFF
--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -67,13 +67,13 @@ const SCOPED_STYLES = `
   margin-top: 24px;
 }
 
-/* grid template rows (chrome auto + main 1fr) 取代 flex column —
- * flex 的 default flex-shrink:1 會讓 TitleBar 在 main 內容很長時被擠壓。 */
+/* Block stacking — TitleBar (sticky) + TripPage 自然 stack。
+ * 不能用 grid + height: 100% — 那會把 TitleBar 的 sticky containing block
+ * 限制在 row 1 (64px) 內，捲動超過 viewport 高度 TitleBar 就被擠出。
+ * 需要 containing block 跟 .ocean-shell 一樣長,sticky 才能整段 viewport 黏住。 */
 .tp-embedded-trip {
   position: relative;
-  display: grid;
-  grid-template-rows: auto 1fr;
-  height: 100%;
+  display: block;
   min-height: 100%;
 }
 .tp-embedded-menu-trigger {


### PR DESCRIPTION
## Summary

User QA 在 prod 回報「捲動到 day 2 之後 title bar 會被推走」。Root cause: CSS sticky 的元素**不能離開自己的 containing block**。

## Root Cause

PR #455 把 \`.ocean-page\` top padding 設 0 讓 sticky chrome 緊貼，但沒解決底層 layout bug：

\`\`\`css
.tp-embedded-trip {
  display: grid;
  grid-template-rows: auto 1fr;   /* row 1: TitleBar 64px, row 2: rest */
  height: 100%;                    /* = .app-shell-main 100dvh */
}
\`\`\`

TitleBar 是 grid item（row 1）。Sticky containing block = grid。Grid 高 = viewport 高 (100dvh)。Sticky 元素的 sticky range = `[0, containingBlockHeight - elementHeight] = [0, 100dvh - 64px]`。

捲動 > 100dvh - 64 (≈ 636px on 700px viewport) 之後，TitleBar 已到 sticky range 上限 → 開始被推出 viewport 頂端。

從第二個 day section 之後 (#day2 onward 通常已超過第一個 viewport)，TitleBar 必然被推走。

## Fix

\`\`\`css
.tp-embedded-trip {
  display: block;          /* 從 grid */
  min-height: 100%;        /* 移除 height: 100% */
}
\`\`\`

- TitleBar containing block 變 \`.tp-embedded-trip\` 整個 block
- Block 高度 = TitleBar 64 + TripPage \`.ocean-shell\` (\`min-height: 100dvh\`) ≥ 100dvh + 64
- Sticky range 涵蓋整個 scroll 範圍 → TitleBar 永遠黏在頂端
- 不再依賴 grid 1fr 撐高 row 2 (\`.ocean-shell min-height: 100dvh\` 已足夠)
- 短內容 trip 仍透過 \`min-height: 100%\` 填滿 viewport

## Test plan

- [x] tsc clean
- [x] 1291 tests pass
- [x] build OK
- [ ] 手動：\`/trips?selected=<tripId>\` 捲到底部 → TitleBar + DayNav 永遠凍結頂端
- [ ] 手動：\`#day2\` / \`#day3\` 跳轉後 sticky chrome 不消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)