### PR TITLE
fix(sticky): solid bg + 錨點精準（拿掉半透明、CSS specificity 衝突）

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -626,13 +626,9 @@ body.dark {
     .ocean-side-card-title { font-size: var(--font-size-caption2); font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-muted); }
 
     /* Day section wrapper.
-     * scroll-margin-top must apply to the element that owns id="day{N}" —
-     * that's .ocean-hero (DaySection.tsx renders <div class="ocean-hero" id="day{N}"…>).
-     * Putting it on .ocean-day (the outer section) silently no-ops.
-     *
-     * Value covers stacked sticky chrome: TitleBar (64) + day-strip (~80)
-     * + breathing room (~16) + headroom = 200px. */
-    .ocean-day > .ocean-hero { scroll-margin-top: 200px; }
+     * scroll-margin-top 統一在 .ocean-hero 主規則 (line ~421) 設 110px desktop /
+     * 100px compact (TitleBar 64/56 + DayNav strip 37 + 9px breathing)。
+     * 不在這邊覆寫 — 之前用 200px 過頭近 100px 留白，現用實測精確值。 */
     .ocean-day + .ocean-day { margin-top: 24px; }
 
     /* Embedded TripPage inside TripsListPage's right sheet (desktop).
@@ -1062,9 +1058,7 @@ body.dark {
 /* ===== MapDayTab — bottom underline tab (V2 Terracotta Map page) ===== */
 .tp-map-day-tabs {
   flex-shrink: 0;
-  background: color-mix(in srgb, var(--color-background) 92%, transparent);
-  backdrop-filter: blur(var(--blur-glass, 14px));
-  -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+  background: var(--color-background);
   border-top: 1px solid var(--color-border);
   display: flex;
   gap: 2px;
@@ -1263,9 +1257,7 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
     justify-content: space-between;
     gap: 12px;
     border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-background) 94%, transparent);
-    backdrop-filter: blur(var(--blur-glass, 14px));
-    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+    background: var(--color-background);
   }
   .tp-titlebar-title {
     /* mockup-parity-qa-fixes: mockup .tp-page-titlebar-title:4060 規範 desktop 20/28/700 (was 24px) */
@@ -1296,9 +1288,7 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
     justify-content: space-between;
     gap: 12px;
     border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-background) 94%, transparent);
-    backdrop-filter: blur(var(--blur-glass, 14px));
-    -webkit-backdrop-filter: blur(var(--blur-glass, 14px));
+    background: var(--color-background);
   }
   .tp-titlebar-title {
     font-size: 18px; /* mockup compact 18px (was 22px) */


### PR DESCRIPTION
## Summary

User QA on prod 兩件事 + 真機 browse 實測修。

## Issues

### 1. 半透明背景 → solid

\`.tp-titlebar\` + \`.tp-map-day-tabs\` 之前用 \`color-mix(in srgb, var(--color-background) 94%, transparent) + backdrop-filter: blur(14px)\` 做毛玻璃。User 不要這個效果。

**Fix**: 都改 \`background: var(--color-background)\` solid，移除 backdrop-filter。

### 2. 錨點位置不準（CSS specificity 衝突）

實測 (browse on local dev with mock auth):
- 真實 sticky chrome = 64 (TitleBar) + 37 (DayNav strip) = **101px**
- 但 hero anchor 落在 **200.09px**（97px 多餘留白）

**Root cause**: tokens.css 同時有兩條 scroll-margin-top:
- L421 \`.ocean-hero { scroll-margin-top: 110px }\` (PR #455 新加)
- L635 \`.ocean-day > .ocean-hero { scroll-margin-top: 200px }\` (舊規則,假設 day-strip 80px 估錯)

L635 selector 更 specific (compound) → 蓋掉 L421。

**Fix**: 刪 L635 過頭 200px 規則，L421 的 110px 生效。

## Verification (browse on local dev with mock auth cookie)

| 操作 | hero.top | TitleBar.top |
|---|---|---|
| Land #day1 | 101.09px (initial) | 0 ✓ |
| Click DAY 02 | **110.09px** ✓ | 0 ✓ |
| Click DAY 03 | **110.18px** ✓ | 0 ✓ |
| Click DAY 05 | **110.37px** ✓ | 0 ✓ |
| scrollTop = 2000 | (out of view) | **0 ✓** (sticky 永遠 top) |
| TitleBar bg | — | rgb(255, 251, 245) solid ✓ |
| DayNav bg | — | rgb(255, 251, 245) solid ✓ |

Screenshot: \`.gstack/visual-checks/sticky-anchor-fixed.png\`

## Test plan
- [x] tsc clean
- [x] 1291 tests pass
- [x] browse 實測 anchor + sticky 正確 (above table)
- [x] visual screenshot 確認 solid bg + chrome 緊貼 + 9px breathing

🤖 Generated with [Claude Code](https://claude.com/claude-code)