### PR TITLE
refactor(titlebar): 全 ghost icon button family — drop borders + 統一 44×44

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,19 +265,22 @@
 
 **Action button (`.tp-titlebar-action`)**
 - 唯一合法 class，禁止自製 ad-hoc class
-- 兩 variant: default outline / `.is-primary` accent filled
-- 桌機: rounded rect (radius-md 8px) + 1px border + icon + 文字 label
-- 手機: square 44×44 + radius-md (rounded corners) + 1px border + icon-only (label hidden via `.tp-titlebar-action-label` @media)
+- **Ghost icon button family**：無 border、透明底、hover 出 `--color-hover` + accent text。對齊 Apple HIG / iOS toolbar 慣例，跟 `.tp-titlebar-back` 同 family。
+- 兩 variant: default ghost / `.is-primary` accent filled (CTA 強調用，Tracerocta 實心)
+- 桌機: rounded rect (radius-md 8px) + icon + 文字 label
+- 手機: square 44×44 + radius-md + icon-only (label hidden via `.tp-titlebar-action-label` @media)
 - 44×44 min tap target
 - 多 action 水平排列, `.tp-titlebar-actions` wrapper, gap 6px
 
 **Button family radius 統一規則**
-所有 TitleBar button (含返回 / icon trigger / action) **一律 radius-md (8px)** — 不用 radius-full pill。對齊 mockup S23 spec + `.tp-embedded-menu-trigger` 既有 36×36 square + radius-md 視覺風格。
+所有 TitleBar button (含返回 / icon trigger / action) **一律 radius-md (8px)** — 不用 radius-full pill。
 
-**例外 button class** (都用 radius-md，差別在 size + border)
-- `.tp-titlebar-back` — 左側返回 button, 44×44 transparent icon-only + radius-md
-- `.tp-titlebar-icon-btn` — OverflowMenu kebab trigger, 44×44 icon-only no border + radius-md
-- `.tp-embedded-menu-trigger` — EmbeddedActionMenu 內部 kebab, 36×36 square + radius-md (smaller size for sub-trigger context)
+**全 TitleBar button class** (都 ghost、無 border、44×44 min tap)
+- `.tp-titlebar-back` — 左側返回 button, 44×44 ghost icon
+- `.tp-titlebar-action` — 右側 action (icon + 文字 / mobile icon-only)，可加 `.is-primary` 變實心 accent CTA
+- `.tp-titlebar-icon-btn` — OverflowMenu kebab trigger, 44×44 icon-only ghost
+- `.tp-titlebar-trip-picker` — Chat/Map「切換行程」 picker, ghost icon + text，radius-full（pill shape 因為 picker 內部 chevron + truncation 視覺需要 — 唯一例外）
+- 漢堡選單 (TripsListPage embedded EmbeddedActionMenu) 直接複用 `.tp-titlebar-action`，不再有獨立 `.tp-embedded-menu-trigger` class
 
 **Sub-content 規則 (TitleBar 下方)**
 - eyebrow + meta: 用 `.tp-page-eyebrow` + `.tp-page-meta` inline 在 TitleBar 下方第一行 (settings/list page 資訊密度需求)

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1330,13 +1330,16 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
  * 手機 (<=760) 縮回 icon-only 圓形 (label hidden via @media)。
  * 用法：<button class="tp-titlebar-action"><Icon /><span class="tp-titlebar-action-label">label</span></button> */
 .tp-titlebar-action {
+  /* Ghost icon button — 跟 .tp-titlebar-back 同 family，無外框、透明底，
+   * hover 出 --color-hover。Apple HIG / iOS toolbar 慣例。Primary CTA 變體
+   * 走下方 .is-primary 用 accent 實心. */
   display: inline-flex;
   align-items: center;
   gap: 6px;
   height: var(--spacing-tap-min);
   padding: 0 14px;
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
+  border: none;
   background: transparent;
   color: var(--color-foreground);
   font: inherit;
@@ -1344,23 +1347,25 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
   font-weight: 600;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background-color 150ms, border-color 150ms, color 150ms;
+  transition: background-color 150ms, color 150ms;
 }
 .tp-titlebar-action:hover {
   background: var(--color-hover);
-  border-color: var(--color-accent);
   color: var(--color-accent);
 }
 .tp-titlebar-action:focus-visible { outline: none; box-shadow: var(--shadow-ring); }
 .tp-titlebar-action .svg-icon { width: 18px; height: 18px; }
+/* Icon-only modifier — 強制 44×44 square (desktop + mobile)，給沒文字 label 的
+ * trigger (例：EmbeddedActionMenu 漢堡) 用。 */
+.tp-titlebar-action--icon-only {
+  width: var(--spacing-tap-min);
+  padding: 0;
+  justify-content: center;
+}
 @media (max-width: 760px) {
   .tp-titlebar-action {
     width: var(--spacing-tap-min);
     padding: 0;
-    /* mobile icon-only：保留 border + radius，跟桌機 + .tp-embedded-menu-trigger
-     * 同視覺 family (rounded rectangle)。 */
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
     justify-content: center;
   }
   .tp-titlebar-action-label { display: none; }
@@ -1371,11 +1376,9 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
 .tp-titlebar-action.is-primary {
   background: var(--color-accent);
   color: var(--color-accent-foreground);
-  border-color: var(--color-accent);
 }
 .tp-titlebar-action.is-primary:hover {
   background: var(--color-accent-deep);
-  border-color: var(--color-accent-deep);
   color: var(--color-accent-foreground);
   filter: brightness(0.95);
 }
@@ -1414,10 +1417,11 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
  * 規範:桌機(>=761) icon + trip name + chevron;手機(<=760) icon-only。 */
 .tp-titlebar-trip-menu { position: relative; }
 .tp-titlebar-trip-picker {
+  /* Ghost icon button — 同 .tp-titlebar-action family，無框透明底，hover 出 --color-hover */
   display: inline-flex; align-items: center; gap: 6px;
   height: var(--spacing-tap-min);
   padding: 0 14px;
-  border: 1px solid var(--color-border);
+  border: none;
   border-radius: var(--radius-full);
   background: transparent;
   color: var(--color-foreground);
@@ -1427,11 +1431,10 @@ body.print-mode .tp-map-day-tabs--sticky { display: none; }
   cursor: pointer;
   flex-shrink: 0;
   max-width: 240px;
-  transition: background-color 150ms, border-color 150ms, color 150ms;
+  transition: background-color 150ms, color 150ms;
 }
 .tp-titlebar-trip-picker:hover {
   background: var(--color-hover);
-  border-color: var(--color-accent);
   color: var(--color-accent);
 }
 .tp-titlebar-trip-picker:focus-visible { outline: none; box-shadow: var(--shadow-ring); }

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -76,28 +76,6 @@ const SCOPED_STYLES = `
   display: block;
   min-height: 100%;
 }
-.tp-embedded-menu-trigger {
-  width: 36px; height: 36px;
-  border-radius: var(--radius-md);
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  color: var(--color-foreground);
-  display: grid; place-items: center;
-  cursor: pointer;
-  font: inherit;
-  flex-shrink: 0;
-  transition: border-color 120ms, color 120ms, background 120ms;
-}
-.tp-embedded-menu-trigger:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-subtle);
-}
-.tp-embedded-menu-trigger:focus-visible {
-  outline: 2px solid var(--color-accent); outline-offset: 2px;
-}
-.tp-embedded-menu-trigger .svg-icon { width: 18px; height: 18px; }
-
 .tp-embedded-menu {
   position: fixed;
   min-width: 200px;
@@ -686,7 +664,7 @@ function EmbeddedActionMenu({ tripId, tripPageRef, onCollab }: EmbeddedActionMen
       <button
         ref={triggerRef}
         type="button"
-        className="tp-embedded-menu-trigger"
+        className="tp-titlebar-action tp-titlebar-action--icon-only"
         onClick={() => setOpen((v) => !v)}
         aria-label="行程動作"
         aria-haspopup="menu"


### PR DESCRIPTION
## Summary

User QA on prod 回報「title bar 右側功能外框大小不一致」。討論四方案後選 **D 全 ghost** — 所有 titlebar action button 改 ghost icon button family（無 border、透明底，hover 出 \`--color-hover\`），對齊 Apple HIG / iOS toolbar 慣例，跟既有 \`.tp-titlebar-back\` 同 family。

## Findings (browse measurement on local dev)

| Button | Class (Before) | Size | Style |
|---|---|---|---|
| ← back | \`.tp-titlebar-back\` | 44×44 | ghost (無框) |
| + 加景點 | \`.tp-titlebar-action\` | 96×44 | outlined pill |
| ⋮ 漢堡 | \`.tp-embedded-menu-trigger\` | **36×36** | outlined square (有實底) |

問題：三家 button 三種樣式。Mobile 加景點變 44 vs 漢堡 36 更不齊。

## Changes

### CSS (\`css/tokens.css\`)
- \`.tp-titlebar-action\`: drop \`border: 1px solid var(--color-border)\`，hover 拿掉 border-color
- \`.tp-titlebar-action.is-primary\`: drop border-color override（base 已無 border）
- 新 modifier \`.tp-titlebar-action--icon-only { width: 44; padding: 0; justify-content: center }\` — desktop 也強制 44×44 square 給沒 label 的 trigger 用
- \`.tp-titlebar-trip-picker\` (chat / map 切換行程): 同步去 border
- 刪 \`.tp-embedded-menu-trigger\` (30 LOC dead CSS)

### TripsListPage
- 漢堡 button className 從 \`tp-embedded-menu-trigger\` 改 \`tp-titlebar-action tp-titlebar-action--icon-only\`

### DESIGN.md
- TitleBar action button section 收緊：明確 ghost icon button family + 列出全 button class（back / action / icon-btn / trip-picker）+ 漢堡複用 .tp-titlebar-action

## Verification (browse on local dev, both viewports)

| Page | Desktop | Mobile |
|---|---|---|
| /trips embedded | back 44 + 加景點 94 + 漢堡 44，全 ghost ✓ | back/加景點/漢堡 全 44×44 ghost square ✓ |
| /trips list | 新增行程 108×44 ghost ✓ | — |
| /chat | 切換行程 214×44 ghost ✓ | — |
| /map | 切換行程 214×44 ghost ✓ | — |
| /explore | 我的收藏 108×44 ghost ✓ | — |

全 5 頁 button \`border\` 全 \`0px none\`、bg \`rgba(0, 0, 0, 0)\`、44px 高。截圖收在 \`.gstack/visual-checks/ghost-*.png\`。

## Test plan
- [x] tsc clean
- [x] 1291 tests pass
- [x] browse 5 頁 desktop + trips embedded mobile 視覺驗證
- [ ] 手動：所有 hover state（出 \`--color-hover\` 底）、focus state（box-shadow ring）正常
- [ ] 手動：\`is-primary\` accent solid CTA（form 頁的「儲存 / 完成 / 建立」）視覺仍突出

🤖 Generated with [Claude Code](https://claude.com/claude-code)