### PR TITLE
P0 fix(migration): 0047 backup-restore pattern + CI cascade safety gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # 2026-05-04 incident gate: scan for D1 cascade-wipe risk patterns in NEW
+      # migrations (DROP TABLE on cascade-parent without _backup_ pattern).
+      # See scripts/check-migration-safety.sh for the rule + post-incident note.
+      # Block deploy if any new/modified migration is unsafe.
+      - name: D1 migration safety check
+        run: bash scripts/check-migration-safety.sh --since=origin/master~1
+
       - name: Apply pending migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/migrations/0047_owner_user_id_cutover_phase2.sql
+++ b/migrations/0047_owner_user_id_cutover_phase2.sql
@@ -1,6 +1,23 @@
 -- Migration 0047: V2 owner cutover Phase 2 — DROP email columns + UNIQUE 改 user_id
 --
--- Phase 2 (irreversible cutover). Phase 1 = migration 0046 (ADD COLUMN + backfill).
+-- ## ⚠️ POST-INCIDENT FIX (2026-05-04)
+--
+-- 原版本用 `PRAGMA foreign_keys = OFF` + `DROP TABLE trips` + RENAME swap idiom
+-- (SQLite 標準 recipe). 在 D1 環境失效 — D1 每個 SQL statement 跑在獨立 connection
+-- 上下文，PRAGMA 不持久跨 statement。`DROP TABLE trips` 觸發 ON DELETE CASCADE，
+-- 砍光所有 children: trip_days, trip_entries, trip_pois, trip_destinations,
+-- trip_docs, trip_doc_entries, trip_invitations。Prod 資料全失。
+--
+-- 修法 — 顯式 backup → swap → restore pattern：
+--   1. 把所有 trips children rows 複製到 _backup_* temp tables
+--   2. 做 trips swap (DROP TABLE trips → CASCADE 砍 children — 已 backup,不影響)
+--   3. INSERT children back from backups
+--   4. DROP backup tables
+--
+-- 不依賴 PRAGMA 行為。Self-evident 的 backup-restore，D1 安全。
+--
+-- ## Phase 2 of 2 (phase 1 = migration 0046)
+--
 -- D6=A approved Big Bang，但 phase 2 仍應由 runbook 強制 manual gate（E-M5）：
 --
 --   1. 確認 commit 1-6 已 deploy 到 prod（code 100% 走 user_id-based auth dual-read）
@@ -15,16 +32,22 @@
 -- user_id IS NULL row → 違反 NOT NULL → 整個 transaction ABORT，不會半 cutover。
 -- 這是 SQLite 內建的 assertion 機制，比手寫 SELECT COUNT 更穩。
 
-PRAGMA foreign_keys = OFF;
-
--- 若上次 phase 2 中途 fail，*_new 表可能殘留 — 先清理確保 idempotent re-run。
+-- 若上次 phase 2 中途 fail，*_new 與 _backup_* 表可能殘留 — 先清理確保 idempotent re-run。
 DROP TABLE IF EXISTS saved_pois_new;
 DROP TABLE IF EXISTS trip_permissions_new;
 DROP TABLE IF EXISTS trips_new;
+DROP TABLE IF EXISTS _backup_trip_days;
+DROP TABLE IF EXISTS _backup_trip_entries;
+DROP TABLE IF EXISTS _backup_trip_pois;
+DROP TABLE IF EXISTS _backup_trip_destinations;
+DROP TABLE IF EXISTS _backup_trip_docs;
+DROP TABLE IF EXISTS _backup_trip_doc_entries;
+DROP TABLE IF EXISTS _backup_trip_invitations;
 
 -- =============================================
 -- 1. saved_pois: drop email, UNIQUE 改 (user_id, poi_id), user_id NOT NULL
 -- =============================================
+-- saved_pois 沒 children FK 依賴，標準 swap 安全。
 
 CREATE TABLE saved_pois_new (
   id        INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -49,6 +72,7 @@ CREATE INDEX idx_saved_pois_poi ON saved_pois(poi_id);
 --    ⚠️ 例外：email='*' wildcard public-read 不 cutover（無 user_id 對應）
 --    → 此 PR 範圍內保留為「歷史遺留」，未來另開 PR 用 dedicated public_trips column
 -- =============================================
+-- trip_permissions 也沒 children FK 依賴，標準 swap 安全。
 
 CREATE TABLE trip_permissions_new (
   id      INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -69,8 +93,19 @@ ALTER TABLE trip_permissions_new RENAME TO trip_permissions;
 
 -- =============================================
 -- 3. trips: drop owner (email column), owner_user_id NOT NULL
+--    ⚠️ trips 有大量 CASCADE children — 必 backup 再 swap 再 restore.
 -- =============================================
 
+-- Step 3a: backup all trips children (data 不依賴 FK，純 SELECT * 複製)
+CREATE TABLE _backup_trip_days        AS SELECT * FROM trip_days;
+CREATE TABLE _backup_trip_entries     AS SELECT * FROM trip_entries;
+CREATE TABLE _backup_trip_pois        AS SELECT * FROM trip_pois;
+CREATE TABLE _backup_trip_destinations AS SELECT * FROM trip_destinations;
+CREATE TABLE _backup_trip_docs        AS SELECT * FROM trip_docs;
+CREATE TABLE _backup_trip_doc_entries AS SELECT * FROM trip_doc_entries;
+CREATE TABLE _backup_trip_invitations AS SELECT * FROM trip_invitations;
+
+-- Step 3b: trips swap. DROP TABLE trips 會 CASCADE 砍 children — 已 backup,不影響.
 CREATE TABLE trips_new (
   id                    TEXT PRIMARY KEY,
   name                  TEXT NOT NULL,
@@ -100,9 +135,29 @@ DROP TABLE trips;
 ALTER TABLE trips_new RENAME TO trips;
 CREATE INDEX idx_trips_owner_user_id ON trips(owner_user_id);
 
-PRAGMA foreign_keys = ON;
+-- Step 3c: restore children from backups. 此時 trips 已重建 (same id values),
+-- FK references match by VALUE,re-INSERT 合法。
+INSERT INTO trip_days        SELECT * FROM _backup_trip_days;
+INSERT INTO trip_entries     SELECT * FROM _backup_trip_entries;
+INSERT INTO trip_pois        SELECT * FROM _backup_trip_pois;
+INSERT INTO trip_destinations SELECT * FROM _backup_trip_destinations;
+INSERT INTO trip_docs        SELECT * FROM _backup_trip_docs;
+INSERT INTO trip_doc_entries SELECT * FROM _backup_trip_doc_entries;
+INSERT INTO trip_invitations SELECT * FROM _backup_trip_invitations;
+
+-- Step 3d: cleanup backups
+DROP TABLE _backup_trip_days;
+DROP TABLE _backup_trip_entries;
+DROP TABLE _backup_trip_pois;
+DROP TABLE _backup_trip_destinations;
+DROP TABLE _backup_trip_docs;
+DROP TABLE _backup_trip_doc_entries;
+DROP TABLE _backup_trip_invitations;
 
 -- 重新整 query planner stats — 表 swap 後 sqlite_stat1 過期會誤選 index
 ANALYZE saved_pois;
 ANALYZE trip_permissions;
 ANALYZE trips;
+ANALYZE trip_days;
+ANALYZE trip_entries;
+ANALYZE trip_pois;

--- a/scripts/check-migration-safety.sh
+++ b/scripts/check-migration-safety.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/check-migration-safety.sh — pre-deploy gate against D1 cascade wipeout
+#
+# 2026-05-04 incident: migration 0047 用 PRAGMA foreign_keys = OFF + DROP TABLE trips
+# 預期會抑制 ON DELETE CASCADE，但 D1 不 honor cross-statement PRAGMA → CASCADE 觸發
+# → 全 prod trip_days/entries/pois/destinations/docs 砍光。
+#
+# 此 script 掃描 migrations/ 找「DROP TABLE <parent>」+ children 用「REFERENCES <parent>」
+# 的危險 pattern，要求 migration 必含 `_backup_` 字樣（backup-restore pattern 標記）。
+#
+# Usage:
+#   bash scripts/check-migration-safety.sh                  # check ALL (informational)
+#   bash scripts/check-migration-safety.sh --since=origin/master  # CI gate (block on NEW)
+#
+# 退出 1 = 不安全 NEW migration；CI 用此 exit code block deploy。
+# 已 applied 歷史 migrations 只 WARN，不 fail（已是既定事實）。
+
+set -euo pipefail
+
+MIGRATIONS_DIR="migrations"
+SINCE_REF=""
+EXIT_CODE=0
+
+# Parse args
+for arg in "$@"; do
+  case "$arg" in
+    --since=*) SINCE_REF="${arg#--since=}" ;;
+    --dir=*)   MIGRATIONS_DIR="${arg#--dir=}" ;;
+    *)         echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+echo "🛡️  D1 migration safety check — scanning $MIGRATIONS_DIR/"
+[ -n "$SINCE_REF" ] && echo "   Gate mode: NEW migrations vs $SINCE_REF"
+echo ""
+
+# Build NEW migration filenames (newline-separated, bash 3 friendly)
+NEW_FILES=""
+if [ -n "$SINCE_REF" ]; then
+  NEW_FILES=$(git diff --name-only --diff-filter=AM "$SINCE_REF"...HEAD -- "$MIGRATIONS_DIR/" 2>/dev/null | grep '\.sql$' | xargs -n1 basename 2>/dev/null || true)
+  COUNT=$(echo "$NEW_FILES" | grep -c '\.sql$' || echo 0)
+  echo "📋 NEW/modified migrations vs $SINCE_REF: $COUNT"
+  [ -n "$NEW_FILES" ] && echo "$NEW_FILES" | sed 's/^/   - /'
+  echo ""
+fi
+
+# is_new() helper — checks if basename in NEW_FILES list
+is_new() {
+  [ -z "$SINCE_REF" ] && return 0  # no gate mode → treat all as new (errors only when no --since)
+  echo "$NEW_FILES" | grep -qx "$1"
+}
+
+# Build list of parents that have CASCADE children (across ALL migrations)
+declare -a CASCADE_PARENTS=()
+while IFS= read -r line; do
+  parent=$(echo "$line" | grep -oE 'REFERENCES[[:space:]]+[a-z_]+' | awk '{print $2}' | head -1)
+  if [ -n "$parent" ]; then
+    if [[ ! " ${CASCADE_PARENTS[*]:-} " =~ " ${parent} " ]]; then
+      CASCADE_PARENTS+=("$parent")
+    fi
+  fi
+done < <(grep -hE 'REFERENCES[[:space:]]+[a-z_]+.*ON[[:space:]]+DELETE[[:space:]]+CASCADE' "$MIGRATIONS_DIR"/*.sql 2>/dev/null || true)
+
+if [ ${#CASCADE_PARENTS[@]} -eq 0 ]; then
+  echo "ℹ️  No CASCADE FK relationships detected in schema — skip check."
+  exit 0
+fi
+
+echo "📋 Tables with CASCADE children (DROP risk):"
+for p in "${CASCADE_PARENTS[@]}"; do
+  echo "   - $p"
+done
+echo ""
+
+UNSAFE_NEW=0
+UNSAFE_HISTORICAL=0
+
+# Scan each migration for DROP TABLE on cascade-parent
+for migration in "$MIGRATIONS_DIR"/*.sql; do
+  [ -f "$migration" ] || continue
+  base=$(basename "$migration")
+
+  for parent in "${CASCADE_PARENTS[@]}"; do
+    if grep -qE "DROP[[:space:]]+TABLE[[:space:]]+(IF[[:space:]]+EXISTS[[:space:]]+)?${parent}([[:space:]]*;|[[:space:]]+RENAME)" "$migration"; then
+      if ! grep -qE "_backup_${parent}|_backup_trip_" "$migration"; then
+        if [ -n "$SINCE_REF" ] && ! is_new "$base"; then
+          # Historical applied migration — WARN only
+          echo "⚠️  HISTORICAL UNSAFE: $base"
+          echo "   - DROP TABLE \`$parent\` without backup-restore"
+          echo "   - Already applied to prod; cannot retroactively fix"
+          echo ""
+          UNSAFE_HISTORICAL=$((UNSAFE_HISTORICAL + 1))
+        else
+          # NEW migration or no gate mode — ERROR
+          echo "❌ UNSAFE NEW: $base"
+          echo "   - DROP TABLE \`$parent\` 觸發 ON DELETE CASCADE 砍光所有 children"
+          echo "   - 缺少 _backup_* pattern — D1 不 honor PRAGMA foreign_keys = OFF"
+          echo "   - 修法：先 CREATE TABLE _backup_<children> AS SELECT * FROM <children>;"
+          echo "          做 swap 後 INSERT children back from backup; DROP backup;"
+          echo "   - Reference: 2026-05-04 prod incident, see 0047 fixed version"
+          echo ""
+          UNSAFE_NEW=$((UNSAFE_NEW + 1))
+          EXIT_CODE=1
+        fi
+      else
+        echo "✅ SAFE: $base (DROP TABLE $parent + uses _backup_ pattern)"
+      fi
+    fi
+  done
+done
+
+echo ""
+echo "════════════════════════════════════"
+echo "Summary: NEW unsafe=$UNSAFE_NEW, historical unsafe=$UNSAFE_HISTORICAL"
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "✅ PASS — no NEW migration risks D1 CASCADE wipe."
+else
+  echo "❌ FAIL — at least one NEW migration risks D1 CASCADE wipe. Block deploy."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## P0 Prod Incident: All trip_days / entries / pois wiped

### Root cause

Migration 0047 (`v2.20.0`) used SQLite standard idiom:
\`\`\`sql
PRAGMA foreign_keys = OFF;
DROP TABLE trips;  -- 預期不觸發 CASCADE
ALTER TABLE trips_new RENAME TO trips;
PRAGMA foreign_keys = ON;
\`\`\`

**This idiom fails in D1.** D1 runs each SQL statement in independent connection contexts. PRAGMA settings don't persist across statements. So `DROP TABLE trips` ran with `foreign_keys = ON` → CASCADE fired → all children wiped:

| Table | Before | After 0047 |
|-------|--------|------------|
| trips | 3 | 3 ✓ (recreated) |
| saved_pois | 2 | 2 ✓ (migration recreated) |
| trip_permissions | 10 | 10 ✓ (migration recreated) |
| **trip_days** | many | **0 ❌** |
| **trip_entries** | many | **0 ❌** |
| **trip_pois** | many | **0 ❌** |
| **trip_destinations** | many | **0 ❌** |
| **trip_docs** | many | **0 ❌** |
| **trip_doc_entries** | many | **0 ❌** |
| **trip_invitations** | many | **0 ❌** |

User-facing symptom: 所有 prod 行程的景點都是空的（trip 顯示但 day list 全空）。

### Fix

**1. `migrations/0047_owner_user_id_cutover_phase2.sql` rewrite**: backup-restore pattern around trips swap. 不依賴 PRAGMA。
\`\`\`sql
CREATE TABLE _backup_trip_days AS SELECT * FROM trip_days;
-- ... backup all children
DROP TABLE trips;  -- CASCADE wipes children — 已 backup,沒事
CREATE TABLE trips_new (...);
ALTER TABLE trips_new RENAME TO trips;
INSERT INTO trip_days SELECT * FROM _backup_trip_days;
-- ... restore all children
DROP TABLE _backup_*;
\`\`\`

**2. `scripts/check-migration-safety.sh`** (NEW): 掃描 migrations/ 找「DROP TABLE on cascade-parent without _backup_ pattern」，exit 1 block deploy。
- `--since=origin/master` mode：only ERROR on NEW migrations，歷史已 applied 的只 WARN
- 偵測 trips/users/pois 等所有有 CASCADE children 的 parent

**3. `.github/workflows/deploy.yml`**: 跑 safety check before `wrangler d1 migrations apply`. Block deploy on unsafe NEW migration.

### Verification

\`\`\`
sqlite3 test:
  PRE:  days=2, entries=2
  POST DROP TABLE trips:  days=0, entries=0  ← cascade fired (bug confirmed)
  POST backup-restore:    days=2, entries=2  ← fix recovered all
\`\`\`

Local D1 partial 0047 re-run test: children survived (backup-restore worked even on partial fail).

### Recovery plan (USER-GATED, after PR merge)

\`\`\`bash
# Step 1: Restore prod D1 to pre-incident snapshot (13 min before migration applied)
wrangler d1 time-travel restore trip-planner-db \\
  --bookmark=00000c7f-00000006-00005060-4b47ad02bf73d7ddb68d7e7ff530624b

# Step 2: Verify trip_days repopulated
wrangler d1 execute trip-planner-db --remote \\
  --command "SELECT COUNT(*) FROM trip_days"

# Step 3: Push to master → CI auto-applies fixed 0046+0047 → safe migration → no wipe
\`\`\`

After restore, d1_migrations table reverts to pre-0046 state. Next master push triggers CI auto-migration with FIXED 0047 → schema migrates safely → trip data preserved.

### Lost data window
Restore bookmark = 2026-05-03 18:00 UTC. Migration applied 18:13 UTC. Loss = 13 min of pre-incident changes (likely none — usage low pre-deploy).

## Test plan
- [x] sqlite3 CLI test confirms backup-restore pattern recovers from cascade
- [x] Migration safety script blocks unsafe new migrations
- [x] Migration safety script informational mode catches historical unsafe migrations (0015/0016 noted)
- [ ] Post-merge: `wrangler d1 time-travel restore` (manual)
- [ ] Post-restore: verify `SELECT COUNT(*) FROM trip_days` > 0
- [ ] CI deploy: confirm fixed 0047 runs cleanly
- [ ] Post-deploy: verify prod \`/api/trips/.../days\` returns populated arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)