### PR TITLE
fix(ios-safari): chat + search input 自動 zoom 破版

### DIFF
--- a/src/pages/AddPoiFavoriteToTripPage.tsx
+++ b/src/pages/AddPoiFavoriteToTripPage.tsx
@@ -67,6 +67,13 @@ const SCOPED_STYLES = `
 .tp-favorites-add-to-trip .tp-form-row input[type='time']:disabled {
   opacity: 0.5; cursor: not-allowed;
 }
+/* iOS Safari 對 input/select font-size < 16px 自動 zoom 破版；mobile 用 16px 防 zoom */
+@media (max-width: 760px) {
+  .tp-favorites-add-to-trip .tp-form-row select,
+  .tp-favorites-add-to-trip .tp-form-row input[type='time'] {
+    font-size: 16px;
+  }
+}
 
 /* startTime + endTime 並排（grid 內 span 2 col + 內部 grid） */
 .tp-favorites-add-to-trip .tp-form-row-pair {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -400,6 +400,11 @@ const SCOPED_STYLES = `
   min-height: 44px; max-height: 160px;
   line-height: 1.5;
 }
+/* iOS Safari 對 input/textarea font-size < 16px 自動 zoom（讓字 16px 可讀），
+   把 viewport 放大造成破版。mobile 一律 16px 防 auto-zoom；desktop 維持 14px 設計感。 */
+@media (max-width: 760px) {
+  .tp-chat-input { font-size: 16px; }
+}
 .tp-chat-input:focus {
   outline: none; border-color: var(--color-accent);
   box-shadow: 0 0 0 2px var(--color-accent-subtle);

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -72,6 +72,10 @@ const SCOPED_STYLES = `
   outline: none;
 }
 .explore-search input::placeholder { color: var(--color-muted); }
+/* iOS Safari 對 input font-size < 16px 自動 zoom 破版；mobile 用 16px 防 zoom，desktop 維持 15px */
+@media (max-width: 760px) {
+  .explore-search input { font-size: 16px; }
+}
 .explore-search button {
   padding: 8px 16px; border-radius: var(--radius-full);
   background: var(--color-accent); color: var(--color-accent-foreground);

--- a/src/pages/PoiFavoritesPage.tsx
+++ b/src/pages/PoiFavoritesPage.tsx
@@ -108,6 +108,10 @@ const SCOPED_STYLES = `
   outline: none;
 }
 .favorites-search input::placeholder { color: var(--color-muted); }
+/* iOS Safari 對 input font-size < 16px 自動 zoom 破版；mobile 用 16px 防 zoom，desktop 維持 15px */
+@media (max-width: 760px) {
+  .favorites-search input { font-size: 16px; }
+}
 
 .favorites-region-row,
 .favorites-type-row {


### PR DESCRIPTION
## Summary

iOS Safari 對 input font-size < 16px 自動 zoom（讓字 16px 可讀），導致 viewport 放大破版。

User 在 mobile 點 ChatPage 輸入框後，畫面被放大 + 切版。

## Fix

mobile (≤760px) 一律 16px 防 auto-zoom；desktop 維持原設計感。

| File | Class | was → mobile |
|---|---|---|
| ChatPage.tsx | .tp-chat-input | 14px → 16px |
| PoiFavoritesPage.tsx | .favorites-search input | 15px → 16px |
| AddPoiFavoriteToTripPage.tsx | .tp-form-row select/input[type='time'] | 15px → 16px |
| ExplorePage.tsx | .explore-search input | 15px → 16px |

AddStopPage 的 search input 已是 callout=16px，OK 不需修。

## Test plan
- [x] tsc pass
- [x] build pass (76 precache entries)
- [ ] mobile real device 重整 ChatPage 點 input 不再 zoom
- [ ] /explore 搜尋 input 同上
- [ ] /favorites 搜尋 input 同上
- [ ] /favorites/:id/add-to-trip 時間 input 同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)