### PR TITLE
hotfix(test): stub setZIndexOffset to fix master CI

### DIFF
--- a/tests/unit/ocean-map-imperative-effects.test.tsx
+++ b/tests/unit/ocean-map-imperative-effects.test.tsx
@@ -45,7 +45,7 @@ vi.mock('../../src/hooks/useRoute', () => ({
 vi.mock('leaflet', async (importOriginal) => {
   const orig = await importOriginal<typeof import('leaflet')>();
   const fakeLayer = { addTo: vi.fn().mockReturnThis(), remove: vi.fn(), clearLayers: vi.fn() };
-  const fakeMarker = { addTo: vi.fn().mockReturnThis(), on: vi.fn().mockReturnThis(), remove: vi.fn(), setIcon: vi.fn() };
+  const fakeMarker = { addTo: vi.fn().mockReturnThis(), on: vi.fn().mockReturnThis(), remove: vi.fn(), setIcon: vi.fn(), setZIndexOffset: vi.fn() };
   return {
     ...orig,
     default: {


### PR DESCRIPTION
Hotfix master CI red.

PR #476 added marker.setZIndexOffset(N) but unit test fakeMarker missed the stub → 5 tests TypeError.

Single-line fix: fakeMarker += { setZIndexOffset: vi.fn() }.

Local: 5/5 + 1378 unit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)