### PR TITLE
fix(add-to-trip): trip dropdown empty + form align mockup B1

### DIFF
--- a/functions/api/my-trips.ts
+++ b/functions/api/my-trips.ts
@@ -1,10 +1,25 @@
 /**
- * GET /api/my-trips — 回傳使用者有權限的 tripId 列表
+ * GET /api/my-trips — 回傳使用者有權限的 trip 摘要（id / name / title / totalDays）
+ *
+ * v2.22.1: 加 name / title / totalDays 給 AddPoiFavoriteToTripPage dropdown 顯示
+ *   trip 名稱用（之前只回 tripId，dropdown 看到「選擇行程…」之後 options 空白）。
+ *   totalDays 從 trip_days COUNT subquery 算。Backwards-compatible：既有 callers
+ *   只 read tripId 仍 work。
  */
 
 import { AppError } from './_errors';
 import { json, getAuth } from './_utils';
 import type { Env } from './_types';
+
+const SELECT_BASE = `
+  SELECT DISTINCT
+    p.trip_id AS tripId,
+    t.name AS name,
+    t.title AS title,
+    COALESCE((SELECT COUNT(*) FROM trip_days td WHERE td.trip_id = t.id), 0) AS totalDays
+  FROM trip_permissions p
+  INNER JOIN trips t ON t.id = p.trip_id
+`;
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   const { env } = context;
@@ -17,20 +32,13 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   let results;
   if (auth.isAdmin) {
     const { results: rows } = await env.DB
-      .prepare(`SELECT DISTINCT p.trip_id AS tripId
-                FROM trip_permissions p
-                INNER JOIN trips t ON t.id = p.trip_id
-                ORDER BY p.trip_id`)
+      .prepare(`${SELECT_BASE} ORDER BY p.trip_id`)
       .all();
     results = rows;
   } else {
     if (!auth.userId) return json([]);
     const { results: rows } = await env.DB
-      .prepare(`SELECT p.trip_id AS tripId
-                FROM trip_permissions p
-                INNER JOIN trips t ON t.id = p.trip_id
-                WHERE p.user_id = ?
-                ORDER BY p.trip_id`)
+      .prepare(`${SELECT_BASE} WHERE p.user_id = ? ORDER BY p.trip_id`)
       .bind(auth.userId)
       .all();
     results = rows;

--- a/src/pages/AddPoiFavoriteToTripPage.tsx
+++ b/src/pages/AddPoiFavoriteToTripPage.tsx
@@ -5,7 +5,10 @@
  * 不再含 position radio / anchorEntryId — server 依 startTime 自動排 sort_order。
  *
  * mockup-driven hard gate aligned (docs/design-sessions/2026-05-04-favorites-redesign.html v4
- * sign-off 2026-05-04)。對齊 DESIGN.md L580-602 規範。
+ * sign-off 2026-05-04，frame B1/B2/B3)。對齊 DESIGN.md L580-602 規範。
+ *
+ * Mockup classes：tp-form-poi-summary / tp-form / tp-form-field / tp-form-label /
+ * tp-form-select / tp-form-input.tabular / tp-form-help / tp-form-actions / tp-action-btn。
  *
  * Hits fast-path POST /api/poi-favorites/:id/add-to-trip — travel_* 由背景 tp-request 之後算。
  */
@@ -26,8 +29,9 @@ import type { PoiFavorite } from '../types/api';
 
 interface TripBrief {
   tripId: string;
-  name: string;
-  totalDays: number;
+  name?: string;
+  title?: string | null;
+  totalDays?: number;
 }
 
 interface DayBrief {
@@ -36,62 +40,111 @@ interface DayBrief {
   label: string | null;
 }
 
-const SCOPED_STYLES = `
-.tp-favorites-add-to-trip { display: flex; flex-direction: column; gap: 16px; }
+const POI_TYPE_LABEL: Record<string, string> = {
+  restaurant: '餐廳',
+  attraction: '景點',
+  shopping: '購物',
+  hotel: '飯店',
+  parking: '停車',
+  transport: '交通',
+  activity: '活動',
+  other: '其他',
+};
 
+/** trip dropdown 顯示文字：name 優先，其次 title，fallback tripId */
+function tripDisplayName(t: TripBrief): string {
+  return t.name?.trim() || t.title?.trim() || t.tripId;
+}
+
+const SCOPED_STYLES = `
+.tp-favorites-add-to-trip {
+  display: flex; flex-direction: column; gap: 16px;
+  max-width: 720px; width: 100%; margin: 0 auto;
+  padding: 16px;
+}
+@media (max-width: 760px) {
+  .tp-favorites-add-to-trip { padding: 12px; gap: 14px; }
+}
+
+/* POI summary block — accent-subtle bg + border-left accent (mockup B1) */
+.tp-favorites-add-to-trip .tp-form-poi-summary {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 14px 16px;
+  background: var(--color-accent-subtle);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-md);
+}
+.tp-favorites-add-to-trip .tp-form-poi-summary-eyebrow {
+  font-size: var(--font-size-eyebrow); font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--color-accent-deep);
+}
+.tp-favorites-add-to-trip .tp-form-poi-summary-title {
+  font-size: var(--font-size-callout); font-weight: 700;
+  color: var(--color-foreground);
+}
+.tp-favorites-add-to-trip .tp-form-poi-summary-meta {
+  font-size: var(--font-size-footnote);
+  color: var(--color-muted);
+}
+
+/* Form */
+.tp-favorites-add-to-trip .tp-form {
+  display: flex; flex-direction: column; gap: 16px;
+}
 .tp-favorites-add-to-trip .tp-form-grid-2col {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 14px 16px;
-  max-width: 720px;
-  width: 100%;
-  margin: 0 auto;
 }
 @media (max-width: 760px) {
   .tp-favorites-add-to-trip .tp-form-grid-2col { grid-template-columns: 1fr; gap: 12px; }
 }
 
-.tp-favorites-add-to-trip .tp-form-row { display: flex; flex-direction: column; gap: 6px; }
-.tp-favorites-add-to-trip .tp-form-row label {
+.tp-favorites-add-to-trip .tp-form-field {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.tp-favorites-add-to-trip .tp-form-label {
   font-size: var(--font-size-footnote); font-weight: 600;
   color: var(--color-foreground);
 }
-.tp-favorites-add-to-trip .tp-form-row select,
-.tp-favorites-add-to-trip .tp-form-row input[type='time'] {
+.tp-favorites-add-to-trip .tp-form-select,
+.tp-favorites-add-to-trip .tp-form-input {
   padding: 10px 12px; border: 1px solid var(--color-border);
   border-radius: var(--radius-md); background: var(--color-background);
   color: var(--color-foreground); font: inherit; font-size: 15px;
   min-height: var(--spacing-tap-min);
+  width: 100%;
 }
-.tp-favorites-add-to-trip .tp-form-row select:disabled,
-.tp-favorites-add-to-trip .tp-form-row input[type='time']:disabled {
+.tp-favorites-add-to-trip .tp-form-select:focus,
+.tp-favorites-add-to-trip .tp-form-input:focus {
+  outline: none; border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-subtle);
+}
+.tp-favorites-add-to-trip .tp-form-select:disabled,
+.tp-favorites-add-to-trip .tp-form-input:disabled {
   opacity: 0.5; cursor: not-allowed;
 }
+.tp-favorites-add-to-trip .tp-form-input.tabular { font-variant-numeric: tabular-nums; }
 /* iOS Safari 對 input/select font-size < 16px 自動 zoom 破版；mobile 用 16px 防 zoom */
 @media (max-width: 760px) {
-  .tp-favorites-add-to-trip .tp-form-row select,
-  .tp-favorites-add-to-trip .tp-form-row input[type='time'] {
+  .tp-favorites-add-to-trip .tp-form-select,
+  .tp-favorites-add-to-trip .tp-form-input {
     font-size: 16px;
   }
 }
 
-/* startTime + endTime 並排（grid 內 span 2 col + 內部 grid） */
-.tp-favorites-add-to-trip .tp-form-row-pair {
-  grid-column: span 2;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-}
-@media (max-width: 760px) {
-  .tp-favorites-add-to-trip .tp-form-row-pair { grid-template-columns: 1fr; gap: 12px; }
+.tp-favorites-add-to-trip .tp-form-help {
+  font-size: var(--font-size-caption2);
+  color: var(--color-muted);
 }
 
+/* Submit button (mockup .tp-action-btn) */
 .tp-favorites-add-to-trip .tp-form-actions {
   margin-top: 8px;
-  max-width: 720px; width: 100%; margin-left: auto; margin-right: auto;
   display: flex; justify-content: center;
 }
-.tp-favorites-add-to-trip .tp-form-actions .tp-btn--primary {
+.tp-favorites-add-to-trip .tp-action-btn {
   font: inherit; font-weight: 700; font-size: 15px;
   padding: 12px 28px; border-radius: var(--radius-full);
   background: var(--color-accent); color: var(--color-accent-foreground);
@@ -99,15 +152,19 @@ const SCOPED_STYLES = `
   cursor: pointer; min-height: var(--spacing-tap-min);
   min-width: 200px;
 }
-.tp-favorites-add-to-trip .tp-form-actions .tp-btn--primary:disabled {
+.tp-favorites-add-to-trip .tp-action-btn:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+.tp-favorites-add-to-trip .tp-action-btn:disabled {
   opacity: 0.55; cursor: not-allowed;
 }
 @media (max-width: 760px) {
-  .tp-favorites-add-to-trip .tp-form-actions .tp-btn--primary { width: 100%; }
+  .tp-favorites-add-to-trip .tp-action-btn { width: 100%; }
 }
 
+/* Day skeleton */
 .tp-favorites-add-to-trip .tp-skel {
-  background: var(--color-bg-muted, var(--color-tertiary));
+  background: var(--color-tertiary);
   border-radius: var(--radius-md); height: 44px;
   animation: tp-pulse 1.4s ease-in-out infinite;
 }
@@ -116,31 +173,24 @@ const SCOPED_STYLES = `
   .tp-favorites-add-to-trip .tp-skel { animation: none; }
 }
 
+/* Empty no-trip */
 .tp-favorites-add-to-trip .tp-empty-cta {
   text-align: center; padding: 40px 24px; color: var(--color-muted);
   border: 1px dashed var(--color-border); border-radius: var(--radius-lg);
-  max-width: 720px; width: 100%; margin: 0 auto;
 }
 .tp-favorites-add-to-trip .tp-empty-cta a {
   display: inline-block; margin-top: 12px;
   padding: 10px 20px; border-radius: var(--radius-md);
-  background: var(--color-accent); color: var(--color-background);
+  background: var(--color-accent); color: var(--color-accent-foreground);
   text-decoration: none; font-weight: 600;
 }
-.tp-favorites-add-to-trip .tp-poi-summary {
-  padding: 16px; border-radius: var(--radius-md);
-  background: var(--color-bg-muted, var(--color-tertiary));
-  border: 1px solid var(--color-border);
-  max-width: 720px; width: 100%; margin: 0 auto;
-}
-.tp-favorites-add-to-trip .tp-poi-summary h3 { margin: 0 0 4px 0; font-size: 16px; }
-.tp-favorites-add-to-trip .tp-poi-summary p { margin: 0; color: var(--color-muted); font-size: 13px; }
+
+/* Submit error */
 .tp-favorites-add-to-trip .tp-error {
   padding: 12px 16px; border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--color-danger) 12%, transparent);
   color: var(--color-danger); border: 1px solid var(--color-danger);
-  font-size: 14px;
-  max-width: 720px; width: 100%; margin: 0 auto;
+  font-size: var(--font-size-footnote);
 }
 `;
 
@@ -271,6 +321,15 @@ export default function AddPoiFavoriteToTripPage() {
     setConflictPayload(null);
   }, []);
 
+  const onFormSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    void handleSubmit();
+  }, [handleSubmit]);
+
+  // POI summary 對應 mockup B1 — eyebrow + title + meta（type 中文 + 收藏中 / address）
+  const poiTypeLabel = favorite?.poiType ? POI_TYPE_LABEL[favorite.poiType] ?? favorite.poiType : '';
+  const poiEyebrow = poiTypeLabel ? `${poiTypeLabel} · 收藏中` : '收藏中';
+
   // ========== Render ==========
 
   let mainContent: React.ReactElement;
@@ -300,9 +359,12 @@ export default function AddPoiFavoriteToTripPage() {
   } else if (trips.length === 0) {
     mainContent = (
       <div className="tp-favorites-add-to-trip">
-        <div className="tp-poi-summary">
-          <h3>{favorite.poiName ?? '景點'}</h3>
-          {favorite.poiAddress && <p>{favorite.poiAddress}</p>}
+        <div className="tp-form-poi-summary">
+          <span className="tp-form-poi-summary-eyebrow">{poiEyebrow}</span>
+          <span className="tp-form-poi-summary-title">{favorite.poiName ?? '景點'}</span>
+          {favorite.poiAddress && (
+            <span className="tp-form-poi-summary-meta">{favorite.poiAddress}</span>
+          )}
         </div>
         <EmptyState
           title="你還沒有任何行程"
@@ -314,12 +376,18 @@ export default function AddPoiFavoriteToTripPage() {
       </div>
     );
   } else {
+    const selectedDay = days?.find((d) => d.dayNum === dayNum);
     mainContent = (
       <div className="tp-favorites-add-to-trip">
-        <div className="tp-poi-summary">
-          <h3>{favorite.poiName ?? '景點'}</h3>
-          {favorite.poiAddress && <p>{favorite.poiAddress}</p>}
-          {favorite.note && <p>備註：{favorite.note}</p>}
+        <div className="tp-form-poi-summary">
+          <span className="tp-form-poi-summary-eyebrow">{poiEyebrow}</span>
+          <span className="tp-form-poi-summary-title">{favorite.poiName ?? '景點'}</span>
+          {favorite.poiAddress && (
+            <span className="tp-form-poi-summary-meta">{favorite.poiAddress}</span>
+          )}
+          {favorite.note && (
+            <span className="tp-form-poi-summary-meta">備註：{favorite.note}</span>
+          )}
         </div>
 
         {submitError && (
@@ -328,87 +396,105 @@ export default function AddPoiFavoriteToTripPage() {
           </div>
         )}
 
-        <div className="tp-form-grid-2col">
-          <div className="tp-form-row">
-            <label htmlFor="atstr-trip">行程</label>
-            <select
-              id="atstr-trip"
-              value={tripId}
-              onChange={(e) => setTripId(e.target.value)}
-              data-testid="favorites-add-to-trip-trip"
-            >
-              <option value="">選擇行程…</option>
-              {trips.map((t) => (
-                <option key={t.tripId} value={t.tripId}>
-                  {t.name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="tp-form-row">
-            <label htmlFor="atstr-day">第幾天</label>
-            {daysLoading ? (
-              <div className="tp-skel" data-testid="favorites-add-to-trip-day-skeleton" />
-            ) : (
+        <form
+          className="tp-form"
+          aria-label="加入行程表單"
+          onSubmit={onFormSubmit}
+        >
+          <div className="tp-form-grid-2col">
+            <div className="tp-form-field">
+              <label className="tp-form-label" htmlFor="atstr-trip">行程</label>
               <select
-                id="atstr-day"
-                value={String(dayNum)}
-                onChange={(e) => setDayNum(e.target.value === '' ? '' : Number(e.target.value))}
-                disabled={!days || days.length === 0}
-                data-testid="favorites-add-to-trip-day"
+                id="atstr-trip"
+                className="tp-form-select"
+                value={tripId}
+                onChange={(e) => setTripId(e.target.value)}
+                data-testid="favorites-add-to-trip-trip"
               >
-                {days && days.length === 0 && <option value="">該行程沒有天數</option>}
-                {days && days.length > 0 && (
-                  <>
-                    <option value="">選擇天數…</option>
-                    {days.map((d) => (
-                      <option key={d.dayNum} value={d.dayNum}>
-                        Day {d.dayNum}{d.label ? ` · ${d.label}` : ''} ({d.date})
-                      </option>
-                    ))}
-                  </>
-                )}
+                <option value="">選擇行程…</option>
+                {trips.map((t) => (
+                  <option key={t.tripId} value={t.tripId}>
+                    {tripDisplayName(t)}
+                    {t.totalDays ? ` · ${t.totalDays} 天` : ''}
+                  </option>
+                ))}
               </select>
-            )}
-          </div>
+            </div>
 
-          <div className="tp-form-row-pair">
-            <div className="tp-form-row">
-              <label htmlFor="atstr-start">開始時間（可空，依景點類型自動推）</label>
+            <div className="tp-form-field">
+              <label className="tp-form-label" htmlFor="atstr-day">天數</label>
+              {daysLoading ? (
+                <div
+                  className="tp-skel"
+                  data-testid="favorites-add-to-trip-day-skeleton"
+                  aria-busy="true"
+                  aria-live="polite"
+                />
+              ) : (
+                <select
+                  id="atstr-day"
+                  className="tp-form-select"
+                  value={String(dayNum)}
+                  onChange={(e) => setDayNum(e.target.value === '' ? '' : Number(e.target.value))}
+                  disabled={!days || days.length === 0}
+                  data-testid="favorites-add-to-trip-day"
+                >
+                  {days && days.length === 0 && <option value="">該行程沒有天數</option>}
+                  {days && days.length > 0 && (
+                    <>
+                      <option value="">選擇天數…</option>
+                      {days.map((d) => (
+                        <option key={d.dayNum} value={d.dayNum}>
+                          Day {d.dayNum}{d.label ? ` · ${d.label}` : ''} ({d.date})
+                        </option>
+                      ))}
+                    </>
+                  )}
+                </select>
+              )}
+              {selectedDay?.label && (
+                <span className="tp-form-help">{selectedDay.label}</span>
+              )}
+            </div>
+
+            <div className="tp-form-field">
+              <label className="tp-form-label" htmlFor="atstr-start">開始時間</label>
               <input
                 id="atstr-start"
+                className="tp-form-input tabular"
                 type="time"
                 value={startTime}
                 onChange={(e) => setStartTime(e.target.value)}
                 data-testid="favorites-add-to-trip-start"
               />
+              <span className="tp-form-help">可空 — 依景點類型自動推算</span>
             </div>
 
-            <div className="tp-form-row">
-              <label htmlFor="atstr-end">結束時間（可空，依停留時間預估推）</label>
+            <div className="tp-form-field">
+              <label className="tp-form-label" htmlFor="atstr-end">結束時間</label>
               <input
                 id="atstr-end"
+                className="tp-form-input tabular"
                 type="time"
                 value={endTime}
                 onChange={(e) => setEndTime(e.target.value)}
                 data-testid="favorites-add-to-trip-end"
               />
+              <span className="tp-form-help">可空 — 依停留時間預估推</span>
             </div>
           </div>
-        </div>
 
-        <div className="tp-form-actions">
-          <button
-            type="button"
-            className="tp-btn tp-btn--primary"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            data-testid="favorites-add-to-trip-submit"
-          >
-            {submitting ? '加入中…' : '加入行程'}
-          </button>
-        </div>
+          <div className="tp-form-actions">
+            <button
+              type="submit"
+              className="tp-action-btn"
+              disabled={!canSubmit}
+              data-testid="favorites-add-to-trip-submit"
+            >
+              {submitting ? '加入中…' : '加入行程'}
+            </button>
+          </div>
+        </form>
       </div>
     );
   }

--- a/tests/unit/poi-favorite-add-to-trip-layout.test.tsx
+++ b/tests/unit/poi-favorite-add-to-trip-layout.test.tsx
@@ -98,14 +98,16 @@ describe('AddPoiFavoriteToTripPage — 2-col grid layout', () => {
     expect(grid).toBeTruthy();
   });
 
-  it('startTime + endTime 包在同一 .tp-form-row-pair (mockup 規範並排)', async () => {
+  it('startTime + endTime 同在 .tp-form-grid-2col (mockup B1 規範 4-field grid)', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByTestId('favorites-add-to-trip-start')).toBeTruthy());
     const startInput = screen.getByTestId('favorites-add-to-trip-start');
     const endInput = screen.getByTestId('favorites-add-to-trip-end');
-    // 兩 input 共 nearest .tp-form-row-pair ancestor
-    const pair = startInput.closest('.tp-form-row-pair');
-    expect(pair).toBeTruthy();
-    expect(pair?.contains(endInput)).toBe(true);
+    // mockup B1 直接把 4 個 field 放 grid（trip+day row 1，start+end row 2），
+    // 不另用 row-pair wrapper — 兩 input 應 share 同一 .tp-form-grid-2col ancestor
+    const startGrid = startInput.closest('.tp-form-grid-2col');
+    const endGrid = endInput.closest('.tp-form-grid-2col');
+    expect(startGrid).toBeTruthy();
+    expect(startGrid).toBe(endGrid);
   });
 });


### PR DESCRIPTION
## Summary

User 看到 /favorites/:id/add-to-trip 兩個 bug：
1. **行程 dropdown 空白** — only \`選擇行程…\` placeholder + 沒列 trips
2. **form UI/UX 跟 mockup B1 不對齊**

## Fix

### API: \`functions/api/my-trips.ts\`
Trip dropdown 之前 options 空白因為 API 只回 \`{tripId}\`，沒 \`name\`。改 SQL 加 \`t.name / t.title / COUNT(trip_days) AS totalDays\`。Backwards-compatible — 其他 callers 仍 work。

### Page: \`src/pages/AddPoiFavoriteToTripPage.tsx\`
全 rewrite styles + DOM 對齊 mockup B1：
- \`.tp-form-poi-summary\` + eyebrow / title / meta (accent-subtle bg + border-left accent)
- \`.tp-form\` + \`.tp-form-grid-2col\` (4 field 直接放 grid，移除 row-pair wrapper)
- \`.tp-form-field\` / \`.tp-form-label\` / \`.tp-form-select\` / \`.tp-form-input.tabular\` / \`.tp-form-help\`
- \`.tp-action-btn\` (mockup primary button class)
- form 改 \`<form onSubmit>\` + button type=\"submit\" (accessibility)

## Test plan
- [x] §12 unit 18/18
- [x] 全 unit 1378/1378
- [x] tsc + build OK
- [ ] mobile real device: /favorites/:id/add-to-trip dropdown 顯示 trip name + 點擊 form 樣式對齊 mockup B1

🤖 Generated with [Claude Code](https://claude.com/claude-code)