### PR TITLE
fix(recompute-travel): honor auth.isAdmin (was hardcoded false)

### DIFF
--- a/functions/api/trips/[id]/recompute-travel.ts
+++ b/functions/api/trips/[id]/recompute-travel.ts
@@ -62,7 +62,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   if (!tripId) throw new AppError('DATA_VALIDATION', '缺少 tripId');
 
   const db = context.env.DB;
-  if (!await hasWritePermission(db, auth, tripId, false)) {
+  if (!await hasWritePermission(db, auth, tripId, auth.isAdmin)) {
     throw new AppError('PERM_DENIED');
   }
 


### PR DESCRIPTION
1-line fix。Pre-existing bug surfaced post-v2.23 backfill: admin service tokens couldn't call recompute-travel even though every other write handler honors auth.isAdmin. recompute-travel was the outlier with literal `false`. Fix aligns with convention.