### PR TITLE
v2.24.2 feat: TimelineRail 接 segments → TravelPill tap-switch live (γ.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to Tripline will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.24.2] - 2026-05-07
+
+**v2.24.0 sprint γ.1：TimelineRail 接 segments fetch + pass to TravelPill。**
+γ.0 ship 的 TravelPill tap-switch UI 是 dormant scaffold；本次接線後使用者
+真的看到可點 pill + 開 dialog 切換 mode。
+
+### Added
+
+- `src/hooks/useTripSegments.ts` — fetch GET `/api/trips/:id/segments` 後 build
+  Map indexed by `${fromEntryId}-${toEntryId}` 給 TimelineRail render loop O(1)
+  lookup。Listen `tp-segment-updated` + `tp-entry-updated` event 自動 re-fetch
+  （PATCH 完 / entry sort_order 變動 / recompute-travel 完 → segments fresh）。
+  Empty/null tripId → no fetch，failure → silently 留 empty map（caller graceful
+  degrade，TravelPill 退回 v2.23 唯讀渲染）。
+
+### Changed
+
+- `src/components/trip/TimelineRail.tsx` — 接線 useTripSegments(tripId)，render
+  loop 為每對 (prev, curr) entry 從 segmentMap 取對應 row，並把 `segment +
+  tripId + fromName + toName` props 傳給 TravelPill。Backwards compat：
+  segment 沒對到（migration 沒跑 / 新 entry 還沒 recompute）但 entry.travel
+  legacy 仍存在 → fallback 用 travel obj 唯讀渲染。
+
+### Tests
+
+- `tests/unit/timeline-rail-segments-wiring.test.tsx`（7 tests）— 驗 hook
+  call passes tripId、segmentMap → TravelPill button render、modeSource=user
+  顯示鎖頭、multi-pair lookup、no segment + no travel → no pill、first entry
+  上方無 pill。
+- `tests/unit/timeline-rail-toolbar-pencil.test.tsx` +
+  `tests/unit/timeline-rail-inline-expand.test.tsx` — 加 `vi.mock` 攔
+  useTripSegments 避免 segments fetch 干擾既有 fetchSpy 斷言。
+
+### Notes
+
+- 純 frontend 變更，no API / migration / backend changes
+- v2.24.0 sprint γ phase 完結（α schema + β backend + γ.0 UI scaffold + γ.1 wiring）
+- Phase δ（skill files segments path 更新）+ Phase ε（DROP trip_entries.travel_*）
+  分離 PR 不阻擋本次 ship
+
 ## [2.24.1] - 2026-05-07
 
 **v2.24.0 sprint γ.0：TravelPill tap-switch UI scaffolding（mockup + React component + TDD）。**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripline",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "private": true,
   "scripts": {
     "dev": "concurrently -n vite,api -c cyan,green \"vite\" \"wrangler pages dev dist --local --port 8788\"",

--- a/src/components/trip/TimelineRail.tsx
+++ b/src/components/trip/TimelineRail.tsx
@@ -40,6 +40,7 @@ import TravelPill from './TravelPill';
 import type { TimelineEntryData } from './TimelineEvent';
 import { parseTimeRange, formatDuration, deriveTypeMeta } from '../../lib/timelineUtils';
 import { useDragDrop } from '../../hooks/useDragDrop';
+import { useTripSegments } from '../../hooks/useTripSegments';
 
 const SCOPED_STYLES = `
 .tp-rail-detail {
@@ -717,6 +718,9 @@ const TimelineRail = memo(function TimelineRail({ events, nowIndex = -1, dayId }
   // backend PATCH 完成 + tp-entry-updated 觸發 refetch 再用 fresh data 覆蓋。
   const [orderOverride, setOrderOverride] = useState<number[] | null>(null);
   const tripId = useTripId();
+  // v2.24.0 γ.1：fetch segments → 為每對 entry 提供 segment row 給 TravelPill 啟用
+  // tap-switch dialog。Hook listen tp-segment-updated + tp-entry-updated 自動 re-fetch。
+  const { segmentMap } = useTripSegments(tripId);
 
   // PR-K dnd-kit sensors。pointer 8px activation distance 避免誤觸 (跟 click
   // expand row 衝突)，keyboard 走 sortable coordinate getter。
@@ -809,14 +813,29 @@ const TimelineRail = memo(function TimelineRail({ events, nowIndex = -1, dayId }
           const isLast = i === events.length - 1;
           const expanded = entry.id != null && expandedId === entry.id;
           const travelObj = entry.travel && typeof entry.travel === 'object' ? entry.travel : null;
+          // v2.24.0 γ.1：lookup segment for (prev, curr) pair
+          const prev = i > 0 ? orderedEvents[i - 1] : null;
+          const segment = (prev?.id != null && entry.id != null)
+            ? segmentMap.get(`${prev.id}-${entry.id}`)
+            : undefined;
           return (
             <div key={entry.id ?? i} className="ocean-rail-row-wrap">
-              {i > 0 && travelObj && (
+              {i > 0 && (travelObj || segment) && (
                 <TravelPill
-                  type={travelObj.type ?? null}
-                  desc={travelObj.desc ?? null}
-                  min={travelObj.min ?? null}
-                  distanceM={travelObj.distanceM ?? null}
+                  type={travelObj?.type ?? null}
+                  desc={travelObj?.desc ?? null}
+                  min={travelObj?.min ?? null}
+                  distanceM={travelObj?.distanceM ?? null}
+                  segment={segment ? {
+                    id: segment.id,
+                    mode: segment.mode,
+                    modeSource: segment.modeSource,
+                    min: segment.min,
+                    distanceM: segment.distanceM,
+                  } : undefined}
+                  tripId={tripId}
+                  fromName={prev?.title ?? null}
+                  toName={entry.title ?? null}
                 />
               )}
               <RailRow

--- a/src/hooks/useTripSegments.ts
+++ b/src/hooks/useTripSegments.ts
@@ -1,0 +1,89 @@
+/**
+ * useTripSegments — v2.24.0 Phase γ.1
+ *
+ * Fetch GET /api/trips/:id/segments + 監聽 `tp-segment-updated` event re-fetch。
+ *
+ * Returns `segmentMap` 索引為 `${fromEntryId}-${toEntryId}` → segment row，方便
+ * TimelineRail 在 entry pair render 時 O(1) 查找。
+ *
+ * 也 listen `tp-entry-updated`：entry 增刪 / sort_order 變動會觸發 recompute-travel
+ * → segments 改變 → 需 re-fetch。
+ *
+ * Empty/null tripId → no fetch，回 empty map。Failure → 不 retry，silently 留 empty
+ * map（caller 端 graceful degrade — TravelPill 無 segment props 變 v2.23 唯讀渲染）。
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { apiFetch } from '../lib/apiClient';
+
+export interface TripSegment {
+  id: number;
+  tripId: string;
+  fromEntryId: number;
+  toEntryId: number;
+  mode: 'driving' | 'walking' | 'transit';
+  modeSource: 'auto' | 'user';
+  min: number | null;
+  distanceM: number | null;
+  source: string | null;
+  computedAt: number | null;
+  updatedAt: number | null;
+}
+
+export function useTripSegments(tripId: string | null | undefined) {
+  const [segments, setSegments] = useState<TripSegment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!tripId) {
+      setSegments([]);
+      return;
+    }
+    let cancelled = false;
+    let inFlight = false;
+
+    const fetchSegments = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      setLoading(true);
+      try {
+        const data = await apiFetch<TripSegment[]>(`/trips/${encodeURIComponent(tripId)}/segments`);
+        if (cancelled) return;
+        setSegments(Array.isArray(data) ? data : []);
+      } catch {
+        if (cancelled) return;
+        // 留 empty — caller graceful degrade
+      } finally {
+        inFlight = false;
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void fetchSegments();
+
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { tripId?: string } | null;
+      // 沒帶 tripId → 一律 re-fetch（保守）；帶且不符 → skip
+      if (detail?.tripId && detail.tripId !== tripId) return;
+      void fetchSegments();
+    };
+
+    window.addEventListener('tp-segment-updated', handler);
+    window.addEventListener('tp-entry-updated', handler);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('tp-segment-updated', handler);
+      window.removeEventListener('tp-entry-updated', handler);
+    };
+  }, [tripId]);
+
+  const segmentMap = useMemo(() => {
+    const m = new Map<string, TripSegment>();
+    for (const s of segments) {
+      m.set(`${s.fromEntryId}-${s.toEntryId}`, s);
+    }
+    return m;
+  }, [segments]);
+
+  return { segments, segmentMap, loading };
+}

--- a/tests/unit/timeline-rail-inline-expand.test.tsx
+++ b/tests/unit/timeline-rail-inline-expand.test.tsx
@@ -19,6 +19,12 @@ import { TripIdContext } from '../../src/contexts/TripIdContext';
 import { TripDaysContext } from '../../src/contexts/TripDaysContext';
 import type { DayOption } from '../../src/lib/entryAction';
 
+// γ.1：useTripSegments 會打 GET /api/trips/:id/segments，這個 test 套件 stub 全域
+// fetch 驗 PATCH/DELETE/etc — mock hook 回 empty 避免 segments fetch 干擾 fetchSpy。
+vi.mock('../../src/hooks/useTripSegments', () => ({
+  useTripSegments: () => ({ segments: [], segmentMap: new Map(), loading: false }),
+}));
+
 const TIMELINE_RAIL_SRC = fs.readFileSync(
   path.resolve(__dirname, '../../src/components/trip/TimelineRail.tsx'),
   'utf8',

--- a/tests/unit/timeline-rail-segments-wiring.test.tsx
+++ b/tests/unit/timeline-rail-segments-wiring.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * TimelineRail × useTripSegments wiring (v2.24.0 Phase γ.1)
+ *
+ * 驗證：
+ *   - TimelineRail 用 useTripId() → 給 hook tripId → segmentMap O(1) lookup
+ *   - 每對 (prev, curr) entry 從 segmentMap 取對應 row 給 TravelPill
+ *   - 有 segment + tripId → TravelPill 變 button（v2.24.0 interactive）
+ *   - segment 有 modeSource='user' → TravelPill 顯示鎖頭
+ *   - segment 不存在但 travelObj 在 → fallback 用 travelObj 唯讀渲染
+ *   - 第一個 entry（i=0）→ 上方無 TravelPill
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TimelineRail from '../../src/components/trip/TimelineRail';
+import type { TimelineEntryData } from '../../src/components/trip/TimelineEvent';
+import { TripIdContext } from '../../src/contexts/TripIdContext';
+
+const useTripSegmentsMock = vi.fn();
+vi.mock('../../src/hooks/useTripSegments', () => ({
+  useTripSegments: (tripId: string | null | undefined) => useTripSegmentsMock(tripId),
+}));
+
+beforeEach(() => {
+  useTripSegmentsMock.mockReset();
+});
+
+function entry(id: number, title: string, time = '09:00-10:00'): TimelineEntryData {
+  return { id, time, title, description: null, note: null, googleRating: null };
+}
+
+function renderRail(events: TimelineEntryData[], tripId: string | null = 'trip-okinawa') {
+  return render(
+    <MemoryRouter>
+      <TripIdContext.Provider value={tripId}>
+        <TimelineRail events={events} />
+      </TripIdContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe('TimelineRail × useTripSegments wiring', () => {
+  it('passes tripId from context to useTripSegments hook', () => {
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: new Map(), loading: false });
+    renderRail([entry(1, '那霸機場')], 'trip-okinawa');
+    expect(useTripSegmentsMock).toHaveBeenCalledWith('trip-okinawa');
+  });
+
+  it('segment + tripId → TravelPill renders as interactive button with ▾', () => {
+    const segMap = new Map([
+      ['1-2', {
+        id: 99, tripId: 'trip-okinawa', fromEntryId: 1, toEntryId: 2,
+        mode: 'driving' as const, modeSource: 'auto' as const,
+        min: 25, distanceM: 18000, source: 'google_routes',
+        computedAt: 1, updatedAt: 1,
+      }],
+    ]);
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: segMap, loading: false });
+
+    renderRail([entry(1, '那霸機場'), entry(2, '本部午餐')]);
+
+    const pills = screen.getAllByTestId('travel-pill');
+    expect(pills).toHaveLength(1);
+    expect(pills[0].tagName).toBe('BUTTON');
+    expect(pills[0].textContent).toContain('▾');
+    expect(pills[0].textContent).toContain('25 min');
+  });
+
+  it('segment.modeSource=user → TravelPill 顯示鎖頭（無 ▾）', () => {
+    const segMap = new Map([
+      ['1-2', {
+        id: 99, tripId: 'trip-okinawa', fromEntryId: 1, toEntryId: 2,
+        mode: 'transit' as const, modeSource: 'user' as const,
+        min: 30, distanceM: null, source: null,
+        computedAt: 1, updatedAt: 1,
+      }],
+    ]);
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: segMap, loading: false });
+
+    renderRail([entry(1, '那霸機場'), entry(2, '本部午餐')]);
+
+    expect(screen.getByTestId('travel-pill-lock')).toBeInTheDocument();
+    const pill = screen.getByTestId('travel-pill');
+    expect(pill.textContent).not.toContain('▾');
+  });
+
+  it('multiple entry pairs → multiple TravelPills, each with own segment', () => {
+    const segMap = new Map([
+      ['1-2', {
+        id: 10, tripId: 'trip-okinawa', fromEntryId: 1, toEntryId: 2,
+        mode: 'walking' as const, modeSource: 'auto' as const,
+        min: 8, distanceM: 600, source: 'google_routes',
+        computedAt: 1, updatedAt: 1,
+      }],
+      ['2-3', {
+        id: 11, tripId: 'trip-okinawa', fromEntryId: 2, toEntryId: 3,
+        mode: 'driving' as const, modeSource: 'auto' as const,
+        min: 22, distanceM: 15000, source: 'google_routes',
+        computedAt: 1, updatedAt: 1,
+      }],
+    ]);
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: segMap, loading: false });
+
+    renderRail([
+      entry(1, '那霸機場'),
+      entry(2, '美麗海'),
+      entry(3, '本部午餐'),
+    ]);
+
+    const pills = screen.getAllByTestId('travel-pill');
+    expect(pills).toHaveLength(2);
+    expect(pills[0].textContent).toContain('8 min');
+    expect(pills[1].textContent).toContain('22 min');
+  });
+
+  it('no segment + entry.travel exists → TravelPill 退回 v2.23 唯讀 div', () => {
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: new Map(), loading: false });
+
+    const entryWithTravel: TimelineEntryData = {
+      ...entry(2, '本部午餐'),
+      travel: { type: 'driving', min: 25, distanceM: 18000, desc: null },
+    };
+
+    renderRail([entry(1, '那霸機場'), entryWithTravel]);
+
+    const pill = screen.getByTestId('travel-pill');
+    expect(pill.tagName).toBe('DIV');
+    expect(pill).toHaveAttribute('role', 'presentation');
+    expect(pill.textContent).toContain('25 min');
+  });
+
+  it('no segment + no entry.travel → no TravelPill rendered', () => {
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: new Map(), loading: false });
+
+    renderRail([entry(1, '那霸機場'), entry(2, '本部午餐')]);
+
+    expect(screen.queryByTestId('travel-pill')).toBeNull();
+  });
+
+  it('first entry (i=0) → no TravelPill above it', () => {
+    const segMap = new Map([
+      ['1-2', {
+        id: 99, tripId: 'trip-okinawa', fromEntryId: 1, toEntryId: 2,
+        mode: 'driving' as const, modeSource: 'auto' as const,
+        min: 25, distanceM: 18000, source: 'google_routes',
+        computedAt: 1, updatedAt: 1,
+      }],
+    ]);
+    useTripSegmentsMock.mockReturnValue({ segments: [], segmentMap: segMap, loading: false });
+
+    renderRail([entry(1, '那霸機場'), entry(2, '本部午餐')]);
+
+    // 只該 render 一個 pill（在 entry 2 上方），entry 1 上方無
+    expect(screen.getAllByTestId('travel-pill')).toHaveLength(1);
+  });
+});

--- a/tests/unit/timeline-rail-toolbar-pencil.test.tsx
+++ b/tests/unit/timeline-rail-toolbar-pencil.test.tsx
@@ -15,6 +15,12 @@ import TimelineRail from '../../src/components/trip/TimelineRail';
 import type { TimelineEntryData } from '../../src/components/trip/TimelineEvent';
 import { TripIdContext } from '../../src/contexts/TripIdContext';
 
+// γ.1：useTripSegments 會打 GET /api/trips/:id/segments，這個 test 套件 stub 全域
+// fetch 驗 toolbar fetch 行為 — mock hook 回 empty 避免 segments fetch 干擾 fetchSpy。
+vi.mock('../../src/hooks/useTripSegments', () => ({
+  useTripSegments: () => ({ segments: [], segmentMap: new Map(), loading: false }),
+}));
+
 const ENTRY: TimelineEntryData = {
   id: 42,
   time: '11:30-14:00',


### PR DESCRIPTION
## Summary

- **v2.24.0 sprint γ.1 wiring** — γ.0 ship 的 TravelPill tap-switch UI 是 dormant scaffold；本次接線後使用者真的看到可點 pill + 開 dialog 切換 mode
- 新 hook `useTripSegments(tripId)` fetch GET `/api/trips/:id/segments` 後 build map indexed by `${fromEntryId}-${toEntryId}` 給 TimelineRail render loop O(1) lookup
- TimelineRail render loop 為每對 (prev, curr) entry 從 segmentMap 取 segment，pass `segment + tripId + fromName + toName` props 給 TravelPill
- Hook listen `tp-segment-updated` + `tp-entry-updated` event 自動 re-fetch
- Backwards compat：segment 沒對到（migration 沒跑 / 新 entry 還沒 recompute）但 entry.travel legacy 仍存在 → fallback 用 travel obj 唯讀渲染
- Failure / empty tripId → silent empty map（caller graceful degrade，TravelPill 退回 v2.23 唯讀渲染）

## Why this matters

γ.0 ship 後 production 已有：
- `trip_segments` table + 1km gate API 計算（v2.24.0-β）
- `<TravelPill segment={...} tripId={...} />` interactive component + `<TravelPillDialog>`（v2.24.1 γ.0）

但 TimelineRail 沒接線 → 使用者看不到可點 pill。本次補上後：
- 看 timeline 直接看到 pill 上有 `▾` affordance
- 點 pill 開 dialog → 三選一切換 mode（駕車/步行/大眾運輸）
- 大眾運輸需手動填分鐘（日本沒 Google API 數據的 known gap）
- modeSource='user' 後顯示 🔒 鎖頭，recompute-travel 不再覆蓋

## Test plan

- [x] tsc clean (`npx tsc --noEmit`)
- [x] 172/172 test files green / 1429/1429 tests green
- [x] 新增 `tests/unit/timeline-rail-segments-wiring.test.tsx` 7 tests：
  - tripId from context → hook called with right tripId
  - segment + tripId → button render with `▾`
  - segment.modeSource=user → 鎖頭 + 無 `▾`
  - multi-pair → multiple TravelPills with own segment
  - no segment + entry.travel → fallback 唯讀 div
  - no segment + no travel → no pill
  - first entry (i=0) → no pill above it
- [x] 修 `timeline-rail-toolbar-pencil` + `timeline-rail-inline-expand` 加 `vi.mock` 攔 useTripSegments 避免 segments fetch 干擾既有 fetchSpy 斷言
- [ ] Land 後 prod smoke test：開 trip page → 看 pill 是否帶 ▾ → 點開 dialog 切換 mode → 確認 PATCH 寫入 segments table

## Notes

- 純 frontend 變更，no API / migration / backend changes
- v2.24.0 sprint γ phase 完結（α schema + β backend + γ.0 UI scaffold + γ.1 wiring）
- Phase δ（skill files segments path 更新）+ Phase ε（DROP trip_entries.travel_*）分離 PR 不阻擋本次 ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)