### PR TITLE
v2.24.4 fix(shell): 修 22+ master CI mobile e2e chronic flake — will-change stacking context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to Tripline will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.24.4] - 2026-05-07
+
+**fix(shell): 修 22+ master CI runs chronic mobile e2e flake — `.app-shell-main`
+全時 `will-change: transform` 變 stacking context 害 sibling bottom-nav 蓋過
+form bottom-bar pointer events。**
+
+### Fixed
+
+- `.app-shell-main` 從 base CSS 拿掉 `will-change: transform`，改成只在
+  `[data-pulling="true"]` 時 enable
+- Root cause：`will-change: transform` 永久 enable 讓 main 變 stacking context +
+  containing block for `position: fixed` descendants。內部 `.tp-page-bottom-bar`
+  (z=210) 被 scope 到 main 內部，main 整體 z auto < `.app-shell-bottom-nav`
+  (z=200) → mobile 上 form confirm button 永遠被 nav 蓋掉，pointer events 被
+  攔截
+- Bisect 顯示：PR #480（pull-to-refresh feat 2026-05-05）引入此 regression，
+  之後 22+ master CI runs 連續 mobile-chrome / mobile-safari fail
+  - `add-stop-page.spec.js:73` 自訂 tab 缺 title 點完成 → inline error
+  - `drag-flows.spec.js:73,80,96,102` mobile grip handles touch / keyboard a11y
+  - `qa-flows.spec.js:208,226` Flow 5 編輯行程 bottom button → PUT
+  - `qa-flows.spec.js:264,284` Flow 7 移動景點 cross-day → PATCH
+
+### Verified
+
+- Local full e2e：mobile-chrome 43/44 + mobile-safari 43/44 + chromium 44/44，
+  0 fail（之前 mobile 8 fail × 2 browsers）
+- Pulling 期間 `will-change` 仍 enable（GPU layer hint 不損效能）
+
+### Notes
+
+- 純 CSS 1 行變更（move `will-change` 從 base 到 `[data-pulling="true"]`），無
+  React / API / migration 變更
+- 預期之後 master CI 不再連續 mobile e2e flake fail
+
 ## [2.24.3] - 2026-05-07
 
 **v2.24.0 sprint Phase δ：tp-* skill files 切換到 segments path（recompute-travel endpoint）。**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripline",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "private": true,
   "scripts": {
     "dev": "concurrently -n vite,api -c cyan,green \"vite\" \"wrangler pages dev dist --local --port 8788\"",

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -65,14 +65,21 @@ export const APP_SHELL_STYLES = `
   .app-shell-ptr[data-refreshing="true"] .app-shell-ptr-spinner { animation: none; }
 }
 
-/* main 拉動位移（pull friction）。transform 同時讓 PTR indicator 跟內容一起下拉 */
+/* main 拉動位移（pull friction）。transform 同時讓 PTR indicator 跟內容一起下拉。
+ *
+ * will-change: transform 只在 data-pulling="true" 時 enable。全時 enable 會讓
+ * main 永遠變 stacking context + containing block for position: fixed descendants,
+ * 導致 sibling .app-shell-bottom-nav (z=200) 整個蓋過 main (z auto), 而 main 內
+ * .tp-page-bottom-bar (z=210) 被 scope 到 main 內部 stacking context → mobile
+ * 上 form confirm button 被 bottom-nav 攔截 pointer events (22+ master CI runs
+ * e2e flake root cause)。Pulling 期間才提示瀏覽器把 main 升 GPU layer。 */
 .app-shell-main {
   position: relative;
   transition: transform 200ms ease-out;
-  will-change: transform;
 }
 .app-shell-main[data-pulling="true"] {
   transition: none;
+  will-change: transform;
 }
 
 /* PR-VV 2026-04-27：bottom-nav 改 position: fixed overlay（從 grid row）。


### PR DESCRIPTION
## Summary

修 22+ master CI runs 連續 fail 的 mobile-chrome / mobile-safari Playwright e2e chronic flake。Root cause 是 PR #480 (2026-05-05 pull-to-refresh) 引入的 `.app-shell-main` 全時 `will-change: transform` 創造 stacking context bug。

## Root cause

`.app-shell-main` baseline CSS 加 `will-change: transform` 後：
1. main 永遠是 **stacking context**（即使 transform=none）
2. main 也是 `position: fixed` descendants 的 **containing block**
3. 結果 → `.tp-page-bottom-bar` (z=210) 被 scope 到 main 內部 stacking context
4. main 整體 z=auto < sibling `.app-shell-bottom-nav` (z=200) → nav 蓋過整個 main
5. mobile 上 form confirm button 永遠被 nav 攔截 pointer events

實測 `document.elementFromPoint(buttonCenterX, buttonCenterY)` 在 mobile 上回傳 nav 的 `<a>` element 而非 button — Playwright `.click()` 看到 "subtree intercepts pointer events" timeout fail。

## Fix

```diff
 .app-shell-main {
   position: relative;
   transition: transform 200ms ease-out;
-  will-change: transform;
 }
 .app-shell-main[data-pulling="true"] {
   transition: none;
+  will-change: transform;
 }
```

`will-change` 只在 PTR pulling 期間 enable（GPU layer hint 仍 active 不損效能）。其餘時間 main 不是 stacking context，bar (z=210) 升回 `.app-shell` root 級別正確蓋過 nav (z=200)。

## Affected tests（22+ master CI runs 同樣失敗）

- `add-stop-page.spec.js:73` 自訂 tab 缺 title → inline error
- `drag-flows.spec.js:73,80,96,102` mobile grip handles touch / keyboard a11y
- `qa-flows.spec.js:208,226` Flow 5 bottom edit-trip-submit button → PUT
- `qa-flows.spec.js:264,284` Flow 7 移動景點 cross-day → PATCH `{ day_id }`

## Verify

Local full e2e suite，三個 browser project：

| project | before | after |
|---|---|---|
| chromium | 44/44 ✓ | 44/44 ✓ |
| mobile-chrome | **8 fail** | **43/44 ✓ + 1 skip** |
| mobile-safari | **8 fail** | **43/44 ✓ + 1 skip** |

Diagnostic test (`document.elementFromPoint`) before：`A.tp-global-bottom-nav-btn`；after：`BUTTON.tp-entry-action-btn-primary`。

## Notes

- 純 CSS 1 行 move（base → `[data-pulling="true"]`），無 React / API / migration 變更
- 預期之後 master CI 不再連續 mobile e2e flake fail
- 需要 deploy 到 prod 嗎？是的 — 影響真實 mobile users 的 form bottom button click（雖然手指 tap 的命中區比 Playwright 點擊精確，但 button 確實在 nav 後面，正常 user agent 可能也踩到）

🤖 Generated with [Claude Code](https://claude.com/claude-code)