### PR TITLE
v2.24.5 fix(test): drag-flows mobile-safari scrollIntoView race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Tripline will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.24.5] - 2026-05-07
+
+**fix(test): drag-flows.spec.js:73 mobile-safari `scrollIntoViewIfNeeded`
+intermittent flake — webkit + sticky/transform 容器內 React useEffect
+re-render race condition。**
+
+### Fixed
+
+- `tests/e2e/drag-flows.spec.js:73` 刪掉 `firstGrip.scrollIntoViewIfNeeded()`
+  call。Test 只測 grip dimensions（24x24 tap target），`getBoundingClientRect`
+  對 off-screen 元素也 work，不需要先 scroll into view
+- v2.24.4 (chronic flake fix) 之後 sole remaining mobile-safari flake，5/5
+  consecutive runs 通過 + 完整 mobile-safari/mobile-chrome suite 各 43/44 ✓
+- 刪 scrollIntoView 後 webkit 不再踩 React useEffect re-render 中觸發
+  "Element is not attached to the DOM" intermittent error
+
+### Notes
+
+- 純 test code 變更（4 行刪 + 4 行 comment 增加），無 src / API / migration
+- 這是 v2.24.0 sprint chronic flake hunt 收尾。完整 chronic flake history：
+  - **Before**：23 連續 master CI runs fail，每 run 8 specs × 2 mobile browsers 同樣 fail
+  - **v2.24.4**：root cause `.app-shell-main` 全時 `will-change: transform` 變
+    stacking context → bottom-bar pointer events 被 nav 攔截 → 8→1 fail (87.5%)
+  - **v2.24.5 (this)**：webkit-only `scrollIntoView` race → 1→0 fail
+- 預期之後 master CI 連續綠，retry --failed 不再需要
+
 ## [2.24.4] - 2026-05-07
 
 **fix(shell): 修 22+ master CI runs chronic mobile e2e flake — `.app-shell-main`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripline",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "private": true,
   "scripts": {
     "dev": "concurrently -n vite,api -c cyan,green \"vite\" \"wrangler pages dev dist --local --port 8788\"",

--- a/tests/e2e/drag-flows.spec.js
+++ b/tests/e2e/drag-flows.spec.js
@@ -77,12 +77,16 @@ test.describe('Drag flows — Section 8.2 mobile webkit', () => {
 
     const firstGrip = page.getByRole('button', { name: /拖拉排序/ }).first();
     await expect(firstGrip).toBeVisible();
-    await firstGrip.scrollIntoViewIfNeeded();
-    // 2026-05-02 v2.18.3:grip 從 32x32 改 24x24 對齊 mockup S12 Variant A
+    // 2026-05-02 v2.18.3：grip 從 32x32 改 24x24 對齊 mockup S12 Variant A
     // (terracotta-preview-v2.html .tp-stop-v-grip)。documented exception 對
-    // Apple HIG 44px tap target,詳見 DESIGN.md Decisions Log + Accessibility
+    // Apple HIG 44px tap target，詳見 DESIGN.md Decisions Log + Accessibility
     // section。Webkit (mobile-safari) 對 sticky/transform 容器內 element 的
-    // boundingBox() 偶爾回 null,改讀 DOM getBoundingClientRect() 拿 rect。
+    // boundingBox() 偶爾回 null，改讀 DOM getBoundingClientRect() 拿 rect。
+    // 2026-05-07 v2.24.5：刪 scrollIntoViewIfNeeded — getBoundingClientRect
+    // 對 off-screen 也 work，scrollIntoView 在 webkit + sticky/transform 容器
+    // 偶爾踩到 React useEffect re-render 導致 "Element not attached" intermittent
+    // fail（master CI 23+ runs chronic flake 之後 sole remaining mobile-safari
+    // flake source）。
     const box = await firstGrip.evaluate((el) => {
       const r = el.getBoundingClientRect();
       return { width: r.width, height: r.height };


### PR DESCRIPTION
## Summary

v2.24.4 (chronic flake fix) 之後 master CI 還剩 sole 1 個 mobile-safari only intermittent flake：`drag-flows.spec.js:73` 的 `firstGrip.scrollIntoViewIfNeeded()` 在 webkit + sticky/transform 容器內偶爾踩 React useEffect re-render mid-flight → `Element is not attached to the DOM`。

## Root cause

Test 在 `expect(firstGrip).toBeVisible()` 通過後立刻 `scrollIntoViewIfNeeded()`。Webkit 行為：
- `scrollIntoViewIfNeeded` 會檢查元素是否需要 scroll
- 同時 React useEffect (TimelineRail 內 useTripSegments fetch resolve / 其他 effect) 觸發 re-render
- Webkit 處理這 race 比 Chrome 慢 → 偶爾 element detach 中段

mobile-chrome 不會踩（v2.24.4 後完全綠），desktop 也不會。

## Fix

刪 `await firstGrip.scrollIntoViewIfNeeded()` — test 只驗 24x24 grip dimensions，`getBoundingClientRect` 對 off-screen 元素 work，不需先 scroll into view。

```diff
 const firstGrip = page.getByRole('button', { name: /拖拉排序/ }).first();
 await expect(firstGrip).toBeVisible();
-await firstGrip.scrollIntoViewIfNeeded();
 const box = await firstGrip.evaluate((el) => {
   const r = el.getBoundingClientRect();
   return { width: r.width, height: r.height };
 });
```

## Verify

- 5/5 consecutive mobile-safari runs pass on `drag-flows.spec.js:73`
- 完整 mobile-safari suite：43/44 ✓ + 1 skip 0 fail
- 完整 mobile-chrome suite：43/44 ✓ + 1 skip 0 fail
- desktop chrome：44/44 ✓ (regression check)

## Chronic flake hunt 收尾

| Stage | Master CI mobile fail | Status |
|---|---|---|
| Before fix（PR #480 land 後 23 runs）| 8 specs × 2 browsers per run | ❌ chronic |
| v2.24.4 (`will-change` stacking context fix) | 1 spec × 1 browser per run | 🟡 87.5% reduction |
| v2.24.5 (this — `scrollIntoView` race fix) | 0 fail | ✅ green |

預期之後 master CI 連續綠，`gh run rerun --failed` 不再需要。

## Notes

- 純 test code 變更（4 行刪 + 4 行 comment）；無 src / API / migration / build
- 這是 v2.24.0 sprint chronic flake hunt 的最終收尾 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)