### PR TITLE
v2.24.6 fix(test): drag-flows :73 + :100 atomic scrollIntoView via evaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to Tripline will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.24.6] - 2026-05-07
+
+**fix(test): drag-flows :73 + :100 改用 atomic native `scrollIntoView` via
+`evaluate()`，補足 v2.24.5 over-correction。**
+
+### Fixed
+
+v2.24.5 完全刪 `scrollIntoViewIfNeeded` → off-screen 元素 mobile-chrome :73
+`getBoundingClientRect` 回 0x0 + mobile-safari :100 `focus()` fail（off-screen
+不可 focus）。
+
+修正：用 `firstGrip.evaluate((el) => { el.scrollIntoView(...); ... })` atomic
+scroll + measure。Native `scrollIntoView` 不會經過 Playwright 的 stability 等
+待 → 不踩 React useEffect re-render race（webkit "Element not attached"）；同
+時又能保證元素 in-viewport → `getBoundingClientRect` 正確 + `focus()` 可靠。
+
+### Verified
+
+- 5/5 consecutive mobile-chrome :73 通過
+- 5/5 consecutive mobile-safari :100 通過
+- 完整 mobile-chrome 43/44 + mobile-safari 43/44，0 fail
+
+### Notes
+
+- 純 test 修正，無 src / API / migration 變更
+- v2.24.0 sprint chronic flake hunt 真正最終收尾（v2.24.4 root cause + v2.24.5
+  trade-off + v2.24.6 atomic fix）
+
 ## [2.24.5] - 2026-05-07
 
 **fix(test): drag-flows.spec.js:73 mobile-safari `scrollIntoViewIfNeeded`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripline",
-  "version": "2.24.5",
+  "version": "2.24.6",
   "private": true,
   "scripts": {
     "dev": "concurrently -n vite,api -c cyan,green \"vite\" \"wrangler pages dev dist --local --port 8788\"",

--- a/tests/e2e/drag-flows.spec.js
+++ b/tests/e2e/drag-flows.spec.js
@@ -82,12 +82,12 @@ test.describe('Drag flows — Section 8.2 mobile webkit', () => {
     // Apple HIG 44px tap target，詳見 DESIGN.md Decisions Log + Accessibility
     // section。Webkit (mobile-safari) 對 sticky/transform 容器內 element 的
     // boundingBox() 偶爾回 null，改讀 DOM getBoundingClientRect() 拿 rect。
-    // 2026-05-07 v2.24.5：刪 scrollIntoViewIfNeeded — getBoundingClientRect
-    // 對 off-screen 也 work，scrollIntoView 在 webkit + sticky/transform 容器
-    // 偶爾踩到 React useEffect re-render 導致 "Element not attached" intermittent
-    // fail（master CI 23+ runs chronic flake 之後 sole remaining mobile-safari
-    // flake source）。
+    // 2026-05-07 v2.24.6：scroll + measure 用 single evaluate atomic — 避免
+    // Playwright scrollIntoViewIfNeeded auto-stability 等待跟 React useEffect
+    // re-render race（webkit "Element not attached"）；同時不能完全省 scroll，
+    // off-screen 元素 getBoundingClientRect 偶爾回 0（mobile-chrome）。
     const box = await firstGrip.evaluate((el) => {
+      el.scrollIntoView({ block: 'center', inline: 'center' });
       const r = el.getBoundingClientRect();
       return { width: r.width, height: r.height };
     });
@@ -102,6 +102,8 @@ test.describe('Drag flows — Section 8.3 keyboard a11y', () => {
     await expect(page.getByRole('heading', { name: /2026 沖繩自駕五日遊/ })).toBeVisible();
 
     const firstGrip = page.getByRole('button', { name: /拖拉排序/ }).first();
+    // Mobile-safari off-screen focus 不可靠 — 先 scroll into view 再 focus
+    await firstGrip.evaluate((el) => el.scrollIntoView({ block: 'center' }));
     await firstGrip.focus();
     await expect(firstGrip).toBeFocused();
     // 觸發 Space — dnd-kit KeyboardSensor 接管。runtime 完整位移流程 jsdom/


### PR DESCRIPTION
## Summary

修 v2.24.5 over-correction：完全刪 `scrollIntoViewIfNeeded` 解決 webkit race，但 off-screen 元素 mobile-chrome :73 `getBoundingClientRect` 回 0x0 + mobile-safari :100 `focus()` 對 off-screen 元素失敗。

## Root cause + fix

需要同時：
1. **必須 scroll into view**（off-screen → measurement / focus 失效）
2. **不能用 Playwright `scrollIntoViewIfNeeded`**（auto-stability 等待跟 React useEffect re-render race → webkit "Element not attached"）

解決：browser-side native `scrollIntoView` via `evaluate()` — atomic scroll + measure 在 single round-trip 完成。Native scrollIntoView 是 synchronous DOM 操作，無 Playwright re-check race window。

```js
// :73 — measure dimensions
const box = await firstGrip.evaluate((el) => {
  el.scrollIntoView({ block: 'center', inline: 'center' });
  const r = el.getBoundingClientRect();
  return { width: r.width, height: r.height };
});

// :100 — keyboard focus
await firstGrip.evaluate((el) => el.scrollIntoView({ block: 'center' }));
await firstGrip.focus();
await expect(firstGrip).toBeFocused();
```

## Verify

- 5/5 consecutive mobile-chrome :73 ✓
- 5/5 consecutive mobile-safari :100 ✓
- 完整 mobile-chrome 43/44 ✓ + 1 skip 0 fail
- 完整 mobile-safari 43/44 ✓ + 1 skip 0 fail

## Chronic flake hunt timeline 真正收尾

| Stage | Master CI mobile fails | Status |
|---|---|---|
| Before（PR #480 land 後 23 runs）| 8 specs × 2 browsers = 16 | ❌ chronic |
| v2.24.4 (`will-change` stacking context fix) | 1 mobile-safari `scrollIntoView` race | 🟡 87.5% reduction |
| v2.24.5 (刪 scrollIntoView) | 2 fails (over-correction trade-off) | 🟡 但 chronic 模式破了 |
| v2.24.6 (atomic evaluate scroll + measure) | 0 fails | ✅ green |

純 test 變更，無 src / API / migration / build。

🤖 Generated with [Claude Code](https://claude.com/claude-code)