### PR TITLE
v2.25.0 feat(ui): avatar initial 用帳號名稱第一字母 + sidebar 簡化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to Tripline will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [2.25.0] - 2026-05-07
+
+**Sidebar / Trip card / Chat 帳號顯示一致化：avatar initial 改用「帳號名稱」第一字母（不是 email）。**
+
+### Changed
+
+- `src/components/shell/DesktopSidebar.tsx`：
+  - 移除 sidebar 底部 account card 的 email 行（個人資訊保留在 `/account` hero）
+  - 移除 sidebar 底部 ThemeToggle（切換移到 `/account → /settings/appearance`）
+  - 簡化 `.tp-account-body` CSS（單一 child 不需 flex column / gap）
+- `src/pages/TripsListPage.tsx`：trip card avatar initial 自己的 trip 用 `user.displayName.charAt(0)`，他人 trip 仍 fallback email[0]（後端 trips list 沒帶 owner displayName）
+- `src/pages/ChatPage.tsx`：
+  - 自己訊息也 render avatar（先前只 other-user 有），用 `user.displayName.charAt(0)`
+  - 他人訊息 avatar + sender label 用後端 `submittedByDisplayName` (LEFT JOIN users)，fallback email local part
+  - 樂觀 POST 帶 `submittedByDisplayName` 給 optimistic bubble 立即顯示正確 initial
+
+### Backend
+
+- `functions/api/requests.ts` GET：`SELECT r.*, u.display_name AS submitted_by_display_name FROM trip_requests r LEFT JOIN users u ON u.email = r.submitted_by`
+- `functions/api/requests/[id]/index.ts` GET：同樣 LEFT JOIN
+- 影響：chat-messages 列表 + single request 都會帶 sender displayName
+
+### Tests
+
+- `tests/unit/desktop-sidebar.test.tsx`：email 斷言改 `not.toContain`
+- `tests/unit/desktop-sidebar-connected.test.tsx`：email 斷言改 `not.toContain`，displayName fallback test 改 partial match
+
+### Verified
+
+- tsc clean (frontend + functions)
+- 1429/1429 unit tests + 607/607 API tests green
+
 ## [2.24.6] - 2026-05-07
 
 **fix(test): drag-flows :73 + :100 改用 atomic native `scrollIntoView` via

--- a/functions/api/requests.ts
+++ b/functions/api/requests.ts
@@ -46,33 +46,36 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   const isPaginated = limitParam !== null || before !== null || after !== null;
   const limit = Math.min(Math.max(parseInt(limitParam || '10', 10) || 10, 1), 50);
 
-  let sql = 'SELECT * FROM trip_requests';
+  // 2026-05-07：LEFT JOIN users 取 submitted_by → users.display_name 給 chat
+  // avatar / sender label 用「帳號名稱」第一字母（不是 email）。submitted_by
+  // 是 email；users.email 唯一索引；找不到 → display_name=null fallback 到 email。
+  let sql = 'SELECT r.*, u.display_name AS submitted_by_display_name FROM trip_requests r LEFT JOIN users u ON u.email = r.submitted_by';
   const params: (string | number)[] = [];
   const conditions: string[] = [];
 
   if (tripId) {
-    conditions.push('trip_id = ?');
+    conditions.push('r.trip_id = ?');
     params.push(tripId);
   }
   if (status) {
-    conditions.push('status = ?');
+    conditions.push('r.status = ?');
     params.push(status);
   }
   if (before) {
     if (beforeId) {
-      conditions.push('(created_at < ? OR (created_at = ? AND id < ?))');
+      conditions.push('(r.created_at < ? OR (r.created_at = ? AND r.id < ?))');
       params.push(before, before, parseInt(beforeId, 10) || 0);
     } else {
-      conditions.push('created_at < ?');
+      conditions.push('r.created_at < ?');
       params.push(before);
     }
   }
   if (after) {
     if (afterId) {
-      conditions.push('(created_at < ? OR (created_at = ? AND id < ?))');
+      conditions.push('(r.created_at < ? OR (r.created_at = ? AND r.id < ?))');
       params.push(after, after, parseInt(afterId, 10) || 0);
     } else {
-      conditions.push('created_at < ?');
+      conditions.push('r.created_at < ?');
       params.push(after);
     }
   }
@@ -81,9 +84,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   }
 
   if (sort === 'asc') {
-    sql += ' ORDER BY created_at ASC, id ASC';
+    sql += ' ORDER BY r.created_at ASC, r.id ASC';
   } else {
-    sql += ' ORDER BY created_at DESC, id DESC';
+    sql += ' ORDER BY r.created_at DESC, r.id DESC';
   }
   sql += isPaginated ? ` LIMIT ${limit + 1}` : ' LIMIT 50';
 

--- a/functions/api/requests/[id]/index.ts
+++ b/functions/api/requests/[id]/index.ts
@@ -17,7 +17,11 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   if (!auth) throw new AppError('AUTH_REQUIRED');
   const id = params.id as string;
 
-  const row = await env.DB.prepare('SELECT * FROM trip_requests WHERE id = ?').bind(id).first();
+  // 2026-05-07：LEFT JOIN users 取 display_name 給 chat avatar / sender label。
+  const row = await env.DB
+    .prepare('SELECT r.*, u.display_name AS submitted_by_display_name FROM trip_requests r LEFT JOIN users u ON u.email = r.submitted_by WHERE r.id = ?')
+    .bind(id)
+    .first();
   if (!row) throw new AppError('DATA_NOT_FOUND');
 
   const tripId = (row as Record<string, unknown>).trip_id as string;

--- a/functions/api/trips.ts
+++ b/functions/api/trips.ts
@@ -203,8 +203,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
   // V2 cutover (migration 0047): trips.owner email column dropped — owner_user_id
   // is canonical; LEFT JOIN users 拿 owner email for legacy display。
+  // 2026-05-07：加 u.display_name AS owner_display_name 給 trip card avatar
+  // initial 顯示「帳號名稱」第一字母（不是 email[0]）。
   const baseCols = `t.id AS tripId, t.name,
-                    u.email AS owner, t.owner_user_id,
+                    u.email AS owner, u.display_name AS owner_display_name, t.owner_user_id,
                     t.title,
                     t.countries, t.published, t.data_source, t.default_travel_mode, t.lang,
                     (SELECT COUNT(*) FROM trip_days d WHERE d.trip_id = t.id) AS day_count,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripline",
-  "version": "2.24.6",
+  "version": "2.25.0",
   "private": true,
   "scripts": {
     "dev": "concurrently -n vite,api -c cyan,green \"vite\" \"wrangler pages dev dist --local --port 8788\"",

--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -30,7 +30,6 @@ import type { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import clsx from 'clsx';
 import Icon from '../shared/Icon';
-import ThemeToggle from '../shared/ThemeToggle';
 
 interface NavItemConfig {
   key: 'chat' | 'trips' | 'map' | 'favorites' | 'login';
@@ -213,18 +212,11 @@ body.dark .tp-sidebar {
 }
 .tp-account-card .tp-account-body {
   flex: 1; min-width: 0;
-  display: flex; flex-direction: column; gap: 2px;
 }
 .tp-account-card .tp-account-name {
   font-size: 13px; font-weight: 600;
   /* Dark sidebar：name 用 reverse foreground (cream on dark) */
   color: #FFFBF5;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.tp-account-card .tp-account-email {
-  font-size: var(--font-size-caption2);
-  /* Dark sidebar：email 用半透明 cream */
-  color: rgba(255, 251, 245, 0.6);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 `;
@@ -282,8 +274,8 @@ export default function DesktopSidebar({ user, brand }: DesktopSidebarProps) {
         </nav>
 
         <div className="tp-sidebar-cta">
-          <ThemeToggle testId="sidebar-theme" />
-
+          {/* 2026-05-07：移除 sidebar ThemeToggle —— 主題切換在 /account →
+           * /settings/appearance 內，避免 sidebar 底部過於擁擠。 */}
           {user === undefined ? (
             <div
               className="tp-user-chip tp-user-chip-loading"
@@ -309,11 +301,13 @@ export default function DesktopSidebar({ user, brand }: DesktopSidebarProps) {
                 {/* Section 4.1 (terracotta-ui-parity-polish): mockup line 5132
                  * 規定 name.length > 10 → slice(0,10)+'…' JS-level truncation。
                  * Sidebar nav 點 Account card 改 navigate /account（取代既有
-                 * /settings/sessions直連）— Section 2 account-hub-page 對齊。 */}
+                 * /settings/sessions直連）— Section 2 account-hub-page 對齊。
+                 * 2026-05-07：移除 email row（個人資訊保留在 /account hero
+                 * page）。Card parent flex align-items: center 已將 name 跟
+                 * avatar 上下置中對齊。 */}
                 <div className="tp-account-name">
                   {user.name.length > 10 ? `${user.name.slice(0, 10)}…` : user.name}
                 </div>
-                <div className="tp-account-email">{user.email}</div>
               </div>
             </Link>
           ) : (

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -61,6 +61,9 @@ interface ChatMessage {
    * `submittedBy` email 來)。Render bubble meta 時 split email local-part 當
    * displayName(避免歷史訊息全標當前登入者)。 */
   submittedBy?: string | null;
+  /** 2026-05-07：sender 的 users.display_name（後端 LEFT JOIN）給 avatar /
+   *  sender label 顯示「帳號名稱」第一字母。null → fallback email local part。 */
+  submittedByDisplayName?: string | null;
 }
 
 /** Section 4.8: format day-divider header — `2026/04/27（週六）`。 */
@@ -109,6 +112,9 @@ interface RawRequestRow {
   reply?: string | null;
   status: 'open' | 'processing' | 'completed' | 'failed';
   submittedBy?: string | null;
+  /** 2026-05-07：submitter 帳號 display_name（API LEFT JOIN users）給 chat
+   *  avatar/sender label 顯示「帳號名稱」第一字母。null = users 表無對應。 */
+  submittedByDisplayName?: string | null;
   processedBy?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
@@ -154,7 +160,14 @@ function rowToMessages(row: RawRequestRow): ChatMessage[] {
   const userTs = row.createdAt ?? row.updatedAt ?? null;
   const assistantTs = row.updatedAt ?? row.createdAt ?? null;
   if (row.message) {
-    out.push({ id: baseId, role: 'user', text: row.message, createdAt: userTs, submittedBy: row.submittedBy ?? null });
+    out.push({
+      id: baseId,
+      role: 'user',
+      text: row.message,
+      createdAt: userTs,
+      submittedBy: row.submittedBy ?? null,
+      submittedByDisplayName: row.submittedByDisplayName ?? null,
+    });
   }
   if (row.status === 'completed' && row.reply) {
     out.push({ id: baseId + 1, role: 'assistant', text: row.reply, markdown: true, createdAt: assistantTs });
@@ -628,7 +641,7 @@ export default function ChatPage() {
     // `{m.createdAt && ...}` 永不為真)。改用 createdAt + ISO 8601。
     setMessages((prev) => [
       ...prev,
-      { id: now, role: 'user', text, createdAt: new Date(now).toISOString(), submittedBy: user?.email ?? null },
+      { id: now, role: 'user', text, createdAt: new Date(now).toISOString(), submittedBy: user?.email ?? null, submittedByDisplayName: user?.displayName ?? null },
       { id: now + 1, role: 'assistant', text: '思考中…', pendingRequestId: -1 },
     ]);
 
@@ -806,8 +819,15 @@ export default function ChatPage() {
            * Legacy 訊息沒 submittedBy 視為自己(避免老資料全變對方 view)。 */
           const senderLocalPart = m.submittedBy?.split('@')[0];
           const isOtherUser = !isAssistant && !!m.submittedBy && m.submittedBy !== user?.email;
-          const senderDisplay = senderLocalPart || user?.displayName || user?.email?.split('@')[0] || '我';
-          const senderInitial = (senderLocalPart || senderDisplay || '?').charAt(0).toUpperCase();
+          // 2026-05-07：sender label 與 avatar initial 用「帳號名稱」(displayName)
+          // 第一字母 — 不是 email。
+          //   - 自己（is-user）：current user displayName
+          //   - 他人（is-other-user）：API LEFT JOIN users 帶 submittedByDisplayName，
+          //     fallback email local part（users 表查無對應的 legacy 帳號）
+          const otherDisplayName = m.submittedByDisplayName || senderLocalPart || '?';
+          const selfDisplayName = user?.displayName || user?.email?.split('@')[0] || '我';
+          const senderDisplay = isOtherUser ? otherDisplayName : selfDisplayName;
+          const senderInitial = senderDisplay.charAt(0).toUpperCase();
           const rowClass = isAssistant ? 'is-assistant' : isOtherUser ? 'is-other-user' : 'is-user';
           return (
             <Fragment key={m.id}>
@@ -817,6 +837,11 @@ export default function ChatPage() {
                 )}
                 {isOtherUser && (
                   <div className="tp-chat-avatar is-other-user" aria-hidden="true" data-testid={`chat-avatar-other-${m.id}`}>
+                    {senderInitial}
+                  </div>
+                )}
+                {!isAssistant && !isOtherUser && (
+                  <div className="tp-chat-avatar is-user" aria-hidden="true" data-testid={`chat-avatar-self-${m.id}`}>
                     {senderInitial}
                   </div>
                 )}

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -455,6 +455,10 @@ interface TripInfo {
   tripId: string;
   name: string;
   owner?: string;
+  /** 2026-05-07：owner.users.display_name（API LEFT JOIN）給 trip card avatar
+   *  initial 顯示「帳號名稱」第一字母，不是 email[0]。null/undefined →
+   *  fallback email local part 或 email[0]。 */
+  ownerDisplayName?: string | null;
   title?: string | null;
   countries?: string | null;
   published?: number | boolean;
@@ -1042,17 +1046,18 @@ export default function TripsListPage() {
                 const isActive = isDesktop && t.tripId === effectiveSelectedId;
                 const ownerEmail = (t.owner ?? '').trim();
                 const isOwnTrip = ownerEmail.toLowerCase() === userEmail;
-                // 2026-05-07：avatar initial 改用「帳號名稱」第一字母（不是 email）。
-                // 自己的 trip 有 displayName 可用 → 取其第一字母；他人的 trip
-                // 後端只給 email，仍回退 email 第一字母（fix that 需 backend 加
-                // owner displayName 欄位）。
+                // 2026-05-07：avatar initial 一律用「帳號名稱」第一字母（不是 email）。
+                // 自己的 trip 用 current user displayName（API 也帶 ownerDisplayName，
+                // 但 client-side 已知 displayName 較即時）；他人 trip 用後端 LEFT JOIN
+                // 帶來的 ownerDisplayName，fallback email[0]（users 表查無對應）。
+                const ownerName = isOwnTrip
+                  ? (user?.displayName ?? t.ownerDisplayName ?? ownerEmail)
+                  : (t.ownerDisplayName ?? ownerEmail);
                 const ownerInitial = ownerEmail
-                  ? (isOwnTrip
-                      ? (user?.displayName?.charAt(0) ?? ownerEmail.charAt(0)).toUpperCase()
-                      : ownerEmail.charAt(0).toUpperCase())
+                  ? (ownerName.charAt(0) || ownerEmail.charAt(0)).toUpperCase()
                   : '·';
                 const ownerLabel = ownerEmail
-                  ? (isOwnTrip ? '由你建立' : ownerEmail.split('@')[0])
+                  ? (isOwnTrip ? '由你建立' : (t.ownerDisplayName ?? ownerEmail.split('@')[0]))
                   : '';
                 return (
                   <div key={t.tripId} className="tp-trip-card-wrap">

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -1041,9 +1041,18 @@ export default function TripsListPage() {
               {visibleTrips.map((t) => {
                 const isActive = isDesktop && t.tripId === effectiveSelectedId;
                 const ownerEmail = (t.owner ?? '').trim();
-                const ownerInitial = ownerEmail ? ownerEmail.charAt(0).toUpperCase() : '·';
+                const isOwnTrip = ownerEmail.toLowerCase() === userEmail;
+                // 2026-05-07：avatar initial 改用「帳號名稱」第一字母（不是 email）。
+                // 自己的 trip 有 displayName 可用 → 取其第一字母；他人的 trip
+                // 後端只給 email，仍回退 email 第一字母（fix that 需 backend 加
+                // owner displayName 欄位）。
+                const ownerInitial = ownerEmail
+                  ? (isOwnTrip
+                      ? (user?.displayName?.charAt(0) ?? ownerEmail.charAt(0)).toUpperCase()
+                      : ownerEmail.charAt(0).toUpperCase())
+                  : '·';
                 const ownerLabel = ownerEmail
-                  ? (ownerEmail.toLowerCase() === userEmail ? '由你建立' : ownerEmail.split('@')[0])
+                  ? (isOwnTrip ? '由你建立' : ownerEmail.split('@')[0])
                   : '';
                 return (
                   <div key={t.tripId} className="tp-trip-card-wrap">

--- a/tests/unit/desktop-sidebar-connected.test.tsx
+++ b/tests/unit/desktop-sidebar-connected.test.tsx
@@ -45,7 +45,7 @@ describe('DesktopSidebarConnected', () => {
     expect(container.textContent).not.toContain('未登入');
   });
 
-  it('after fetch success renders user displayName + email', async () => {
+  it('after fetch success renders user displayName (email row removed 2026-05-07)', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(
       new Response(JSON.stringify(SAMPLE_USER), { status: 200 }),
     );
@@ -53,7 +53,8 @@ describe('DesktopSidebarConnected', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('My Name');
     });
-    expect(container.textContent).toContain('me@example.com');
+    // 2026-05-07：email 從 sidebar account card 移除（保留在 /account hero）
+    expect(container.textContent).not.toContain('me@example.com');
     expect(container.querySelector('[data-testid="sidebar-user-loading"]')).toBeNull();
   });
 
@@ -62,7 +63,8 @@ describe('DesktopSidebarConnected', () => {
       new Response(JSON.stringify({ ...SAMPLE_USER, displayName: null }), { status: 200 }),
     );
     const { container } = renderConnected();
-    await waitFor(() => expect(container.textContent).toContain('me@example.com'));
+    // displayName=null → name 退回 email；name 仍渲染（slice 10 + ellipsis）
+    await waitFor(() => expect(container.textContent).toContain('me@exampl'));
   });
 
   it('401 response → renders confirmed unauthed sidebar', async () => {
@@ -88,7 +90,8 @@ describe('DesktopSidebarConnected', () => {
         <DesktopSidebarConnected />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(container.textContent).toContain('me@example.com'));
+    // 2026-05-07：sidebar 移除 email 後改驗 displayName 渲染
+    await waitFor(() => expect(container.textContent).toContain('My Name'));
     expect(container.querySelector('[data-testid="desktop-sidebar"]')).toBeTruthy();
     // sidebar 不再有「+ 新增行程」按鈕（入口改在 TripsListPage / GlobalMap empty state）
     expect(container.querySelector('[data-testid="sidebar-new-trip-btn"]')).toBeNull();

--- a/tests/unit/desktop-sidebar.test.tsx
+++ b/tests/unit/desktop-sidebar.test.tsx
@@ -186,14 +186,14 @@ describe('DesktopSidebar — user chip', () => {
     expect(chip?.textContent).toContain('未登入');
   });
 
-  it('已登入：顯示帳號 chip 含 name + email', () => {
+  it('已登入：顯示帳號 chip 含 name（不含 email — 2026-05-07 移除）', () => {
     const { container } = renderSidebar({
       user: { name: 'Ray Chiu', email: 'ray@trip.io' },
     });
     const chip = container.querySelector('[data-testid="sidebar-account-card"]');
     expect(chip).toBeTruthy();
     expect(chip?.textContent).toContain('Ray Chiu');
-    expect(chip?.textContent).toContain('ray@trip.io');
+    expect(chip?.textContent).not.toContain('ray@trip.io');
   });
 
   it('已登入時不顯示「未登入」chip', () => {


### PR DESCRIPTION
## Summary

- Sidebar account card 移除 email row + ThemeToggle（個人資訊 / 主題切換移到 `/account` 內，sidebar 底部更精簡）
- Trip card / Chat avatar initial 改用 displayName 第一字母（不是 email[0]）
- Chat 自己訊息也渲染 avatar（之前只 other-user 有）

## Why

User 反映：
1. Sidebar 底部 email 跟 ThemeToggle 多餘，希望只留 avatar + 名稱
2. Trip card avatar 顯示「L」（Ray 的 email = `lean.lean@gmail.com`）→ 應該是 `R`（displayName=Ray）
3. Chat 也有同樣問題

## Changes

### Sidebar (`DesktopSidebar.tsx`)
- 移除 `<div className="tp-account-email">{user.email}</div>`
- 移除 `<ThemeToggle testId="sidebar-theme" />` + import
- 簡化 `.tp-account-body` CSS（拿掉 flex column / gap，單一 child 不需要）

### Trip card (`TripsListPage.tsx`)
- 自己 trip → `user.displayName.charAt(0)`
- 他人 trip → 仍 fallback `email[0]`（trips list API 沒帶 owner displayName，前端無法 lookup）

### Chat (`ChatPage.tsx`)
- 新增 self avatar render（is-user 行也帶 avatar）
- avatar initial / sender label 都用 displayName-first
- 樂觀 POST 帶 `submittedByDisplayName` 給 optimistic bubble 立即正確
- `RawRequestRow` + `ChatMessage` interface 加 `submittedByDisplayName?: string | null`

### Backend (`functions/api/requests*`)
- `GET /api/requests`：`SELECT r.*, u.display_name AS submitted_by_display_name FROM trip_requests r LEFT JOIN users u ON u.email = r.submitted_by`
- `GET /api/requests/:id`：同樣 LEFT JOIN
- 用戶不在 users 表 → display_name=null → frontend fallback email local part

## Test plan

- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `npx tsc --noEmit -p tsconfig.functions.json` — clean
- [x] `npm test` — 172/172 files / 1429/1429 tests green
- [x] `npm run test:api` — 63/63 files / 607/607 tests green
- [x] `desktop-sidebar*.test.tsx` 49/49 — email assertions 改 `not.toContain`
- [ ] Land 後 prod smoke test：登入 → sidebar 應只有 avatar + name + R initial / trip card 自己的應顯示 R / chat 訊息應有 R avatar 在右側

## Notes

- 純 UI + 1 endpoint backend extension，無 migration、無 schema 變更
- 他人 trip 的 avatar 還是 email[0]（trips list API 沒帶 owner displayName）— 若要進一步修，後端要在 `/api/my-trips` + `/api/trips` 加 owner displayName

🤖 Generated with [Claude Code](https://claude.com/claude-code)