### PR TITLE
fix: wire entryPoisVersion OCC token in ChangePoiPage

### DIFF
--- a/src/pages/ChangePoiPage.tsx
+++ b/src/pages/ChangePoiPage.tsx
@@ -519,6 +519,15 @@ function poiMeta(address: string | null | undefined, category: string | null | u
   return primary || category || '景點';
 }
 
+function parseErrorCode(text: string): string | null {
+  try {
+    const parsed = JSON.parse(text) as { error?: { code?: string } };
+    return parsed.error?.code ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export default function ChangePoiPage() {
   const { tripId, entryId: entryIdParam } = useParams<{ tripId: string; entryId: string }>();
   const entryId = Number(entryIdParam);
@@ -545,6 +554,10 @@ export default function ChangePoiPage() {
   const [favorites, setFavorites] = useState<PoiFavorite[] | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // v2.27.0 OCC token: GET on mount, attach to PUT /poi-id + POST /alternates body so
+  // concurrent multi-POI mutation (other tab swap / EditEntryPage) flips us to 409
+  // STALE_ENTRY instead of silently overwriting.
+  const [entryPoisVersion, setEntryPoisVersion] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const { results: searchResults, searching } = usePoiSearch({
@@ -602,15 +615,33 @@ export default function ChangePoiPage() {
     return () => { cancelled = true; };
   }, [tab, favorites]);
 
+  useEffect(() => {
+    if (!tripId || !Number.isInteger(entryId)) return;
+    let cancelled = false;
+    apiFetch<{ entryPoisVersion?: string | number | null }>(
+      `/trips/${encodeURIComponent(tripId)}/entries/${entryId}`,
+    )
+      .then((data) => {
+        if (cancelled) return;
+        if (data.entryPoisVersion != null) setEntryPoisVersion(String(data.entryPoisVersion));
+      })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [tripId, entryId]);
+
   const handleSubmit = useCallback(async () => {
     if (!selected || !tripId || !Number.isInteger(entryId) || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
+      const occ = entryPoisVersion != null ? { entryPoisVersion } : {};
       if (mode === 'alternate') {
-        const body = selected.source === 'favorite' && selected.poiId
-          ? { poiId: selected.poiId }
-          : buildSearchPoiBody(selected);
+        const body = {
+          ...(selected.source === 'favorite' && selected.poiId
+            ? { poiId: selected.poiId }
+            : buildSearchPoiBody(selected)),
+          ...occ,
+        };
         const res = await apiFetchRaw(
           `/trips/${encodeURIComponent(tripId)}/entries/${entryId}/alternates`,
           {
@@ -621,6 +652,11 @@ export default function ChangePoiPage() {
         );
         if (!res.ok) {
           const text = await res.text();
+          if (res.status === 409) {
+            const code = parseErrorCode(text);
+            if (code === 'DUPLICATE_POI') throw new Error('此景點已存在於 stop 中');
+            throw new Error('資料已被其他操作更新，請重新整理');
+          }
           throw new Error(`加備選失敗 (${res.status}): ${text.slice(0, 200)}`);
         }
         window.dispatchEvent(new CustomEvent('tp-entry-updated', { detail: { tripId } }));
@@ -629,15 +665,21 @@ export default function ChangePoiPage() {
       }
 
       // master 模式（既有 PUT /poi-id 流程）
-      const body = selected.source === 'favorite' && selected.poiId
-        ? { poiId: selected.poiId }
-        : buildSearchPoiBody(selected);
+      const body = {
+        ...(selected.source === 'favorite' && selected.poiId
+          ? { poiId: selected.poiId }
+          : buildSearchPoiBody(selected)),
+        ...occ,
+      };
       const res = await apiFetchRaw(`/trips/${encodeURIComponent(tripId)}/entries/${entryId}/poi-id`, {
         method: 'PUT',
         body: JSON.stringify(body),
       });
       if (!res.ok) {
         const text = await res.text();
+        if (res.status === 409) {
+          throw new Error('資料已被其他操作更新，請重新整理');
+        }
         throw new Error(`PUT 失敗 (${res.status}): ${text.slice(0, 200)}`);
       }
       // fire-and-forget recompute current day（user 換 POI 後 distance/min 應更新）
@@ -650,7 +692,7 @@ export default function ChangePoiPage() {
       setError(err instanceof Error ? err.message : '置換景點失敗');
       setSubmitting(false);
     }
-  }, [selected, tripId, entryId, submitting, navigate, mode, buildSearchPoiBody]);
+  }, [selected, tripId, entryId, submitting, navigate, mode, buildSearchPoiBody, entryPoisVersion]);
 
   const titleBarActions = useMemo(() => (
     <TitleBarPrimaryAction

--- a/tests/unit/change-poi-page.test.tsx
+++ b/tests/unit/change-poi-page.test.tsx
@@ -178,6 +178,112 @@ describe('ChangePoiPage — alternate mode', () => {
   });
 });
 
+describe('ChangePoiPage — entryPoisVersion OCC token', () => {
+  it('GET /entries/:eid on mount → entryPoisVersion attached to POST /alternates body', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url === '/trips/okinawa-2026/entries/42') {
+        return Promise.resolve({ entryPoisVersion: '7' });
+      }
+      return Promise.resolve([]);
+    });
+    mockPoiSearch.results = [{
+      place_id: 'ChIJ-occ',
+      name: 'OCC 餐廳',
+      address: '沖繩',
+      lat: 26.1,
+      lng: 127.6,
+      category: 'restaurant',
+      country: 'JP',
+      rating: 4.0,
+    }];
+    renderPage();
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/trips/okinawa-2026/entries/42');
+    });
+
+    fireEvent.click(screen.getByTestId('change-poi-search-item-ChIJ-occ'));
+    fireEvent.click(screen.getByTestId('change-poi-submit'));
+
+    await waitFor(() => {
+      expect(apiFetchRaw).toHaveBeenCalled();
+    });
+    const call = (apiFetchRaw as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.entryPoisVersion).toBe('7');
+  });
+
+  it('alternate mode POST 409 DUPLICATE_POI → 「此景點已存在」error', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url === '/trips/okinawa-2026/entries/42') {
+        return Promise.resolve({ entryPoisVersion: '5' });
+      }
+      return Promise.resolve([]);
+    });
+    (apiFetchRaw as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: () => Promise.resolve('{"error":{"code":"DUPLICATE_POI","message":"此景點已存在於 stop 中"}}'),
+    } as unknown as Response);
+    mockPoiSearch.results = [{
+      place_id: 'ChIJ-dup',
+      name: 'Dup',
+      address: '沖繩',
+      lat: 26.1,
+      lng: 127.6,
+      category: 'restaurant',
+      country: 'JP',
+      rating: 4.0,
+    }];
+    renderPage();
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/trips/okinawa-2026/entries/42'));
+
+    fireEvent.click(screen.getByTestId('change-poi-search-item-ChIJ-dup'));
+    fireEvent.click(screen.getByTestId('change-poi-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText('此景點已存在於 stop 中')).toBeTruthy();
+    });
+  });
+
+  it('master mode PUT /poi-id 409 → user-friendly STALE_ENTRY error', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url === '/trips/okinawa-2026/entries/42') {
+        return Promise.resolve({ entryPoisVersion: '3' });
+      }
+      return Promise.resolve([]);
+    });
+    (apiFetchRaw as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: () => Promise.resolve('{"error":"STALE_ENTRY"}'),
+    } as unknown as Response);
+    mockPoiSearch.results = [{
+      place_id: 'ChIJ-stale',
+      name: 'Stale',
+      address: '沖繩',
+      lat: 26.1,
+      lng: 127.6,
+      category: 'restaurant',
+      country: 'JP',
+      rating: 4.0,
+    }];
+    renderPage('/trip/okinawa-2026/stop/42/change-poi');
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/trips/okinawa-2026/entries/42');
+    });
+
+    fireEvent.click(screen.getByTestId('change-poi-search-item-ChIJ-stale'));
+    fireEvent.click(screen.getByTestId('change-poi-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText('資料已被其他操作更新，請重新整理')).toBeTruthy();
+    });
+  });
+});
+
 describe('ChangePoiPage — master search mode', () => {
   it('normalises wrapped /api/poi-search results and keeps the search input editable', () => {
     renderPage('/trip/okinawa-2026/stop/42/change-poi');


### PR DESCRIPTION
## Summary

TODOS.md v2.27.x P2 — `PUT /poi-id` / `POST /alternates` backend 接受 OCC token `entryPoisVersion` 但 ChangePoiPage 沒 fetch / 帶上，cross-tab swap 仍可能 lost update（user 在 EditEntryPage 改 master 後再到 ChangePoiPage 換另一 POI，第二次的 PUT 會 silently 蓋掉前一次的更動）。

- mount-time `GET /trips/:id/entries/:eid` 取 `entryPoisVersion`
- submit body spread `{ entryPoisVersion }` 進兩個 mode (`alternate` POST + `master` PUT)
- 409 response 解析 `error.code`，區分 `STALE_ENTRY` 與 `DUPLICATE_POI` 給 user-friendly 訊息（取代 raw `PUT 失敗 (409): ...`）

無 backend / migration / contract 變更 — pure frontend wire-up，舊版仍向後相容（沒帶 OCC token 走 UNIQUE constraint catch path）。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/change-poi-page.test.tsx` — 8/8 (+3 new)
- [ ] CI green
- [ ] Manual: 兩 tab 各操作一次 entry，第二次 submit 看到 409 訊息

🤖 Generated with [Claude Code](https://claude.com/claude-code)