### PR TITLE
chore: centralize tp-* event names into src/lib/events.ts

### DIFF
--- a/src/components/trip/TimelineRail.tsx
+++ b/src/components/trip/TimelineRail.tsx
@@ -26,6 +26,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useTripId } from '../../contexts/TripIdContext';
 import { useTripDays } from '../../contexts/TripDaysContext';
 import { apiFetchRaw } from '../../lib/apiClient';
+import { EVENT } from '../../lib/events';
 import { TP_DRAG_ACCESSIBILITY } from '../../lib/drag-announcements';
 import Icon from '../shared/Icon';
 import { showToast } from '../shared/Toast';
@@ -402,7 +403,7 @@ const RailRow = memo(function RailRow({ entry, index, expanded, onToggle, isPast
       });
       if (!res.ok) throw new Error('儲存失敗');
       setEditingNote(false);
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', {
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, {
         detail: { tripId, entryId: entryIdNum },
       }));
     } catch (err) {
@@ -435,7 +436,7 @@ const RailRow = memo(function RailRow({ entry, index, expanded, onToggle, isPast
         credentials: 'same-origin',
       });
       if (!res.ok) throw new Error('刪除失敗');
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', {
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, {
         detail: { tripId, entryId: entryIdNum },
       }));
       setShowDeleteConfirm(false);
@@ -909,7 +910,7 @@ const TimelineRail = memo(function TimelineRail({ events, nowIndex = -1, dayId }
         .catch(() => {
           showToast('順序已儲存，但車程時間更新失敗，重新整理後再試', 'info');
         });
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', {
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, {
         detail: { tripId, entryId: active.id, reordered: true, travelRecomputeRequested: true },
       }));
     } catch {
@@ -934,7 +935,7 @@ const TimelineRail = memo(function TimelineRail({ events, nowIndex = -1, dayId }
       .then((res) => {
         if (!res.ok) throw new Error(`recompute-travel ${res.status}`);
         showToast('車程已重新計算', 'info');
-        window.dispatchEvent(new CustomEvent('tp-entry-updated', {
+        window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, {
           detail: { tripId, travelRecomputeRequested: true },
         }));
       })

--- a/src/components/trip/TravelPillDialog.tsx
+++ b/src/components/trip/TravelPillDialog.tsx
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Icon from '../shared/Icon';
 import { apiFetchRaw } from '../../lib/apiClient';
+import { EVENT } from '../../lib/events';
 
 const SCOPED_STYLES = `
 .tp-travel-overlay {
@@ -309,7 +310,7 @@ export default function TravelPillDialog({
         min: selectedMode === 'transit' ? transitMinNumber : (currentMin ?? null),
         modeSource: 'user',
       });
-      window.dispatchEvent(new CustomEvent('tp-segment-updated', { detail: { tripId, segmentId } }));
+      window.dispatchEvent(new CustomEvent(EVENT.segmentUpdated, { detail: { tripId, segmentId } }));
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : '儲存失敗');

--- a/src/hooks/useTripSegments.ts
+++ b/src/hooks/useTripSegments.ts
@@ -14,6 +14,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import { apiFetch } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 
 export interface TripSegment {
   id: number;
@@ -67,13 +68,13 @@ export function useTripSegments(tripId: string | null | undefined) {
       void fetchSegments();
     };
 
-    window.addEventListener('tp-segment-updated', handler);
-    window.addEventListener('tp-entry-updated', handler);
+    window.addEventListener(EVENT.segmentUpdated, handler);
+    window.addEventListener(EVENT.entryUpdated, handler);
 
     return () => {
       cancelled = true;
-      window.removeEventListener('tp-segment-updated', handler);
-      window.removeEventListener('tp-entry-updated', handler);
+      window.removeEventListener(EVENT.segmentUpdated, handler);
+      window.removeEventListener(EVENT.entryUpdated, handler);
     };
   }, [tripId]);
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,24 @@
+/**
+ * Centralized window CustomEvent names — dispatch / listen sites share one source.
+ *
+ * Why: ~37 dispatch / listener sites previously used string literals, with no
+ * compile-time check that a typo on the dispatcher matches the listener.
+ *
+ * Each entry below names the event + payload contract observed in dispatch sites.
+ * Listeners read `(event as CustomEvent).detail` per the contract.
+ */
+
+export const EVENT = {
+  /** dispatch detail: `{ tripId, entryId?, dayNum?, segmentId? }` — entry created, edited, deleted, moved, or master/alts changed. */
+  entryUpdated: 'tp-entry-updated',
+  /** dispatch detail: `{ tripId, segmentId? }` — travel segment mode / min / source changed. */
+  segmentUpdated: 'tp-segment-updated',
+  /** dispatch detail: `{ tripId }` — trip metadata edit (PUT /trips/:id). */
+  tripUpdated: 'tp-trip-updated',
+  /** dispatch detail: `{ tripId }` — trip just created (NewTripPage success). */
+  tripCreated: 'tp-trip-created',
+  /** no detail — developer console app just created (DeveloperAppNewPage success). */
+  developerAppCreated: 'tp-developer-app-created',
+} as const;
+
+export type EventName = typeof EVENT[keyof typeof EVENT];

--- a/src/pages/AddStopPage.tsx
+++ b/src/pages/AddStopPage.tsx
@@ -34,6 +34,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { routes } from '../lib/routes';
 import { apiFetch, apiFetchRaw } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
@@ -768,7 +769,7 @@ export default function AddStopPage() {
         method: 'POST',
         credentials: 'same-origin',
       }).catch(() => undefined);
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', { detail: { tripId, dayNum } }));
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, { detail: { tripId, dayNum } }));
       showToast(`已加入 ${payloads.length} 個景點`, 'success');
       handleBack();
     } catch (err) {

--- a/src/pages/ChangePoiPage.tsx
+++ b/src/pages/ChangePoiPage.tsx
@@ -21,6 +21,7 @@ import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { usePoiSearch } from '../hooks/usePoiSearch';
 import { apiFetch, apiFetchRaw } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import { regionToApiParam } from '../lib/maps/region';
 import { mapNominatimCategory } from '../lib/poiCategory';
 import type { PoiFavorite } from '../types/api';
@@ -623,7 +624,7 @@ export default function ChangePoiPage() {
           const text = await res.text();
           throw new Error(`加備選失敗 (${res.status}): ${text.slice(0, 200)}`);
         }
-        window.dispatchEvent(new CustomEvent('tp-entry-updated', { detail: { tripId } }));
+        window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, { detail: { tripId } }));
         navigate(`/trip/${encodeURIComponent(tripId)}/stop/${entryId}/edit`, { replace: true });
         return;
       }
@@ -644,7 +645,7 @@ export default function ChangePoiPage() {
       void apiFetchRaw(`/trips/${encodeURIComponent(tripId)}/recompute-travel`, {
         method: 'POST',
       }).catch(() => undefined);
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', { detail: { tripId } }));
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, { detail: { tripId } }));
       navigate(`/trips?selected=${encodeURIComponent(tripId)}`, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : '置換景點失敗');

--- a/src/pages/DeveloperAppNewPage.tsx
+++ b/src/pages/DeveloperAppNewPage.tsx
@@ -22,6 +22,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { routes } from '../lib/routes';
+import { EVENT } from '../lib/events';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import TitleBar from '../components/shell/TitleBar';
@@ -271,7 +272,7 @@ export default function DeveloperAppNewPage() {
     // Notify DeveloperAppsPage to refetch — listener 跑 GET /api/dev/apps 拿
     // 真實 server row。不傳 detail (PR #452 client-side fabricate row 有 race +
     // 假造 created_at 不可靠，改 always refetch)。
-    window.dispatchEvent(new CustomEvent('tp-developer-app-created'));
+    window.dispatchEvent(new CustomEvent(EVENT.developerAppCreated));
     navigate(routes.developerApps());
   }
 

--- a/src/pages/DeveloperAppsPage.tsx
+++ b/src/pages/DeveloperAppsPage.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRequireAuth } from '../hooks/useRequireAuth';
+import { EVENT } from '../lib/events';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import TitleBar from '../components/shell/TitleBar';
@@ -151,8 +152,8 @@ export default function DeveloperAppsPage() {
   // 一次 GET 換正確性。
   useEffect(() => {
     function handleAppCreated() { void loadApps(); }
-    window.addEventListener('tp-developer-app-created', handleAppCreated);
-    return () => window.removeEventListener('tp-developer-app-created', handleAppCreated);
+    window.addEventListener(EVENT.developerAppCreated, handleAppCreated);
+    return () => window.removeEventListener(EVENT.developerAppCreated, handleAppCreated);
   }, []);
 
   return (

--- a/src/pages/EditEntryPage.tsx
+++ b/src/pages/EditEntryPage.tsx
@@ -40,6 +40,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useTripSegments, type TripSegment } from '../hooks/useTripSegments';
 import { apiFetch, apiFetchRaw } from '../lib/apiClient';
 import { ApiError } from '../lib/errors';
+import { EVENT } from '../lib/events';
 import { haversineMeters, avgLatLng, CROSS_REGION_THRESHOLD_M, type LatLng } from '../lib/geo';
 
 const SCOPED_STYLES = `
@@ -908,9 +909,9 @@ export default function EditEntryPage() {
       const failures = results.filter((r) => !r.ok);
       if (failures.length === 0) {
         // 通知 timeline + segments 重新 fetch
-        window.dispatchEvent(new CustomEvent('tp-entry-updated', { detail: { tripId, entryId } }));
+        window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, { detail: { tripId, entryId } }));
         if (dirty.segmentDirty) {
-          window.dispatchEvent(new CustomEvent('tp-segment-updated', { detail: { tripId, segmentId: segment?.id } }));
+          window.dispatchEvent(new CustomEvent(EVENT.segmentUpdated, { detail: { tripId, segmentId: segment?.id } }));
         }
         showToast('已儲存', 'success');
         navigate(goBackHref, { replace: true });
@@ -1043,7 +1044,7 @@ export default function EditEntryPage() {
       setAltSwapConfirm(null);
       // round 5 fix: dispatch tp-segment-updated so useTripSegments refetches the now-stale
       // adjacent segments (backend marked computed_at=NULL in the setMaster batch).
-      window.dispatchEvent(new CustomEvent('tp-segment-updated', { detail: { tripId } }));
+      window.dispatchEvent(new CustomEvent(EVENT.segmentUpdated, { detail: { tripId } }));
       await refreshEntryPois();
       showToast(`已將「${alt.name}」設為正選`, 'success');
     } catch (err) {

--- a/src/pages/EditTripPage.tsx
+++ b/src/pages/EditTripPage.tsx
@@ -35,6 +35,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { routes } from '../lib/routes';
 import { apiFetchRaw } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
@@ -542,7 +543,7 @@ export default function EditTripPage() {
       }
       showToast('行程已更新', 'success');
       // 廣播更新事件給 listening pages (ActiveTrip / TripsList)
-      window.dispatchEvent(new CustomEvent('tp-trip-updated', { detail: { tripId } }));
+      window.dispatchEvent(new CustomEvent(EVENT.tripUpdated, { detail: { tripId } }));
       navigate(routes.tripsSelected(tripId));
     } catch (err) {
       setError(err instanceof Error ? err.message : '儲存變更失敗');

--- a/src/pages/EntryActionPage.tsx
+++ b/src/pages/EntryActionPage.tsx
@@ -40,6 +40,7 @@ import { useNavigateBack } from '../hooks/useNavigateBack';
 import { routes } from '../lib/routes';
 import { apiFetch, apiFetchRaw } from '../lib/apiClient';
 import { dayColor } from '../lib/dayPalette';
+import { EVENT } from '../lib/events';
 import {
   ENTRY_ACTION_TIME_SLOTS,
   shortenDateLabel,
@@ -312,7 +313,7 @@ export default function EntryActionPage({ action }: EntryActionPageProps) {
         } catch { /* not JSON */ }
         throw new Error(message);
       }
-      window.dispatchEvent(new CustomEvent('tp-entry-updated', {
+      window.dispatchEvent(new CustomEvent(EVENT.entryUpdated, {
         detail: { tripId, entryId: entryIdNum },
       }));
       showToast(action === 'copy' ? '景點已複製' : '景點已移動', 'success');

--- a/src/pages/NewTripPage.tsx
+++ b/src/pages/NewTripPage.tsx
@@ -39,6 +39,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { routes } from '../lib/routes';
 import { apiFetchRaw } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import { lsGet, lsSet } from '../lib/localStorage';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
@@ -603,7 +604,7 @@ export default function NewTripPage() {
       }
       const data = (await res.json()) as { tripId: string };
       // 廣播 tp-trip-created event 讓 TripsListPage refresh list
-      window.dispatchEvent(new CustomEvent('tp-trip-created', { detail: { tripId: data.tripId } }));
+      window.dispatchEvent(new CustomEvent(EVENT.tripCreated, { detail: { tripId: data.tripId } }));
       navigate(`/trips?selected=${encodeURIComponent(data.tripId)}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : '建立行程失敗。');

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
 import { useOfflineToast } from '../hooks/useOfflineToast';
 import { apiFetch } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import { mapRow } from '../lib/mapRow';
 import { lsGet, lsSet, lsRemove, lsRenewAll, LS_KEY_TRIP_PREF } from '../lib/localStorage';
 import { useActiveTrip } from '../contexts/ActiveTripContext';
@@ -240,8 +241,8 @@ function TripPageInner(
         refetchCurrentDayRef.current?.();
       }
     }
-    window.addEventListener('tp-entry-updated', onEntryUpdated);
-    return () => window.removeEventListener('tp-entry-updated', onEntryUpdated);
+    window.addEventListener(EVENT.entryUpdated, onEntryUpdated);
+    return () => window.removeEventListener(EVENT.entryUpdated, onEntryUpdated);
   }, []);
 
   /* --- Dark mode + Print mode (#2: coordinated via shared state) --- */

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -27,6 +27,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useNewTrip } from '../contexts/NewTripContext';
 import { apiFetchRaw } from '../lib/apiClient';
+import { EVENT } from '../lib/events';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
@@ -736,11 +737,11 @@ export default function TripsListPage() {
 
   useEffect(() => {
     function onTripCreated() { void loadTrips(); }
-    window.addEventListener('tp-trip-created', onTripCreated);
-    window.addEventListener('tp-trip-updated', onTripCreated);
+    window.addEventListener(EVENT.tripCreated, onTripCreated);
+    window.addEventListener(EVENT.tripUpdated, onTripCreated);
     return () => {
-      window.removeEventListener('tp-trip-created', onTripCreated);
-      window.removeEventListener('tp-trip-updated', onTripCreated);
+      window.removeEventListener(EVENT.tripCreated, onTripCreated);
+      window.removeEventListener(EVENT.tripUpdated, onTripCreated);
     };
   }, [loadTrips]);
 

--- a/tests/unit/timeline-rail-inline-expand.test.tsx
+++ b/tests/unit/timeline-rail-inline-expand.test.tsx
@@ -292,7 +292,7 @@ describe('TimelineRail — drag reorder contract', () => {
   });
 
   it('broadcasts tp-entry-updated after successful reorder and reverts override on failure', () => {
-    expect(TIMELINE_RAIL_SRC).toContain("new CustomEvent('tp-entry-updated'");
+    expect(TIMELINE_RAIL_SRC).toContain('new CustomEvent(EVENT.entryUpdated');
     expect(TIMELINE_RAIL_SRC).toContain('reordered: true');
     expect(TIMELINE_RAIL_SRC).toContain('setOrderOverride(null)');
   });


### PR DESCRIPTION
## Summary

TODOS.md P3 tech debt — 5 個 CustomEvent 名（`tp-entry-updated` / `tp-segment-updated` / `tp-trip-updated` / `tp-trip-created` / `tp-developer-app-created`）散在 35 個 dispatch / listen sites 用字串 literal，typo 不會被 compile 期抓到。

- 新 `src/lib/events.ts` 定義 `EVENT` const + `EventName` type
- 13 個 src/ 檔案 import `EVENT` 替換 literal
- Test files 保留 raw strings 當 contract assertion（防 events.ts 改 literal 但 listener 漏改）；唯一例外 `timeline-rail-inline-expand.test` 因為它讀 source 內容字串檢查，更新成 expect `'EVENT.entryUpdated'`

無行為變更，pure refactor。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/` — 1532/1532 pass
- [x] `grep -rn "'tp-..." src/` outside events.ts → empty
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)