### PR TITLE
chore: remove stale poi-favorites-rename TODOS entry (已 ship in archive batch)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -146,34 +146,6 @@
 
 ---
 
-## poi-favorites-rename — UI mockup-driven redesigns (PoiFavoritesPage + AddPoiFavoriteToTripPage)
-
-**Priority:** P2 — mockup signed-off (`docs/design-sessions/2026-05-04-favorites-redesign.html` v4)，React refactor 留 follow-up
-**Source:** `openspec/changes/poi-favorites-rename/tasks.md` §11.3-§11.10, §12.3-§12.11
-
-**Scope:**
-
-§11 PoiFavoritesPage redesign（mockup-driven hard gate）：
-- region pill row + type filter row 對齊 mockup
-- 8-state matrix（loading / empty-pool / filter-no-results / error / data / optimistic-delete / bulk-action-busy / pagination）
-- batch flow delete-only（不支援 batch add-to-trip — DUC1 user accept）
-- a11y: filter chip `role="group"` + `aria-pressed`（不是 `role="tab"`）/ checkbox `aria-label` per row / optimistic-delete `aria-live`
-- viewport breakpoints: 1024+ 3-col / 640-1023 2-col / <430 1-col / max-width 1040px
-- hierarchy rules: 0 favorites 隱藏 filters / 50 grid 為主 / 200+ sticky search + pagination
-- 8 處 `border: 1px solid var(--color-border)` 違反 H7 一併修（從 master SavedPoisPage 繼承的 pre-existing pattern）
-
-§12 AddPoiFavoriteToTripPage redesign：
-- 4-field 純時間驅動 form（trip / day / startTime / endTime）— 廢除 position radio + anchorEntryId
-- desktop 2-col grid（max-width 720px）/ phone stack 單欄 + button full-width
-- TitleBar title 靠左（flex:1）/ 左側返回 button / 右側無 confirm action
-- 「加入行程」primary button 在 `.tp-form-actions` wrapper 內、置中對齊、放在 4 fields 下方
-- 7-state matrix（loading / empty-no-trip / conflict / error / success / optimistic / partial）
-- trip 切換時 day field skeleton + 提交按鈕 disabled
-
-**建議 flow：** invoke `/tp-claude-design` 對照 mockup 產 React → invoke `/design-review` 視覺稽核 → /tp-code-verify。
-
----
-
 ## Completed
 
 ### v2.30.3 — `.tp-action-btn` family extract (poi-favorites-rename §13 收尾)


### PR DESCRIPTION
## Summary

Discovery：「全部評估 問題仍在的就做」sweep 發現 TODOS.md 的 PoiFavorites redesign item 是 **stale**，redesign 早在 v2.29.x archive batch (\`openspec/changes/archive/2026-05-14-poi-favorites-rename/tasks.md\`) shipped。

## Evidence

**§11.9 PoiFavoritesPage 重構** 🟢 in archive：
- region pill `role="group"` + `aria-pressed` (L494-532)
- 8-state matrix (loading aria-busy / empty / filter-no-results / error role=alert / data / optimistic aria-live / batch-busy / pagination)
- batch flow delete-only (TripPickerPopover only in ExplorePage now)
- 49 unit tests across 8 spec files pass

**§12.9 AddPoiFavoriteToTripPage 重構** 🟢 in archive：
- 4-field 純時間驅動 form (移除 position state + anchorEntryId)
- `.tp-form-grid-2col` desktop 2-col + `.tp-form-row-pair` start+end 並排
- `.tp-form-actions` 置中 primary button
- TitleBar 無 primary action

**「8 處 border 違反 H7」claim 不正確**：
- H7 是 FAB/overlay-specific rule（出處 \`archive/2026-03-23-fab-bottom-panel/review-report.md\`：「H7: 無框線設計」for FAB context），非 universal
- Mockup 本身 9 次使用 `border: 1px solid var(--color-border)`（grep 證實）
- Code 與 mockup 一致 (6 處 hairline border 對齊 mockup intent)

## Test plan

Docs-only PR，無實作改動 → CI 跑 build/typecheck 即驗證 ✅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)