### PR TITLE
fix(scripts): backfill-poi-addresses.ts use correct D1 binding name

### DIFF
--- a/scripts/backfill-poi-addresses.ts
+++ b/scripts/backfill-poi-addresses.ts
@@ -62,7 +62,7 @@ function queryPois(flags: CliFlags): PoiRow[] {
   const wrangler = buildWranglerArgs(flags);
   // 撈所有有 address 的 row（normalize 是 pure function，過濾無 typo 在 JS 端做）
   const sql = "SELECT id, address FROM pois WHERE address IS NOT NULL AND address != '' ORDER BY id";
-  const out = exec(`bunx wrangler d1 execute trip-planner ${wrangler} --command="${sql}" --json`);
+  const out = exec(`bunx wrangler d1 execute trip-planner-db ${wrangler} --command="${sql}" --json`);
   // wrangler d1 --json: array with one element per statement, each has {results:[]}
   const parsed = JSON.parse(out) as Array<{ results: PoiRow[] }>;
   return parsed[0]?.results ?? [];
@@ -73,7 +73,7 @@ function updateAddress(flags: CliFlags, id: number, newAddress: string): void {
   // single-quote escape: SQLite SQL strings escape '' = single '
   const escaped = newAddress.replace(/'/g, "''");
   const sql = `UPDATE pois SET address = '${escaped}', updated_at = datetime('now') WHERE id = ${id}`;
-  exec(`bunx wrangler d1 execute trip-planner ${wrangler} --command="${sql}"`);
+  exec(`bunx wrangler d1 execute trip-planner-db ${wrangler} --command="${sql}"`);
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary
Small fix — backfill script 之前用 project name 「trip-planner」當 D1 DB name 撞 wrangler 「Couldn't find DB」error。正確 binding name 是「trip-planner-db」（wrangler.toml `database_name`）。

## Test
Verified prod backfill works：
- 194 prod pois rows scanned
- 0 row needs normalize（typo 在 search cache 已自然 expire，pois.address 也已 clean）

## Context
v2.31.36 (PR #596) merge 後 GHA auto-applied migration 0068。再跑 backfill verify：script 因 DB name 拼錯沒跑成功 → 修正 → 0 candidates 確認 clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)