### PR TITLE
fix(tests): unpin developer-apps-page bottomNav regex

### DIFF
--- a/tests/unit/developer-apps-page-bottom-nav.test.ts
+++ b/tests/unit/developer-apps-page-bottom-nav.test.ts
@@ -28,7 +28,9 @@ describe('v2.31.34 DeveloperAppsPage mobile bottomNav', () => {
   });
 
   it('AppShell 傳 bottomNav prop（GlobalBottomNav with authed）', () => {
-    expect(SRC).toMatch(/bottomNav=\{<GlobalBottomNav authed=\{!!user\}\s*\/>\}/);
+    // v2.31.40 update: callsite 從 `!!user` 改 `user !== null`（auth flicker fix），
+    // regex 放寬接受任一 authed expression。
+    expect(SRC).toMatch(/bottomNav=\{<GlobalBottomNav authed=\{[^}]+\}\s*\/>\}/);
   });
 
   it('sidebar prop 維持 DesktopSidebarConnected（regression）', () => {


### PR DESCRIPTION
## Summary

v2.31.40 (#602) sed callsite \`!!user\` → \`user !== null\` 做 auth flicker fix，但 v2.31.34 留下的 \`tests/unit/developer-apps-page-bottom-nav.test.ts\` pin 死 regex 含 \`!!user\` → master CI fail。

## Fix

\`tests/unit/developer-apps-page-bottom-nav.test.ts:31\` regex 改 \`\\\\{[^}]+\\\\}\` 接受任一 authed expression。

## Test plan

- [x] \`npx vitest run\` → 1690/1690 pass
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)