### PR TITLE
v2.31.98 follow-up: ChangePoiPage body :has() 撐大

### DIFF
--- a/src/pages/ChangePoiPage.tsx
+++ b/src/pages/ChangePoiPage.tsx
@@ -87,6 +87,15 @@ const SCOPED_STYLES = `
     padding: 16px 24px 96px;
   }
 }
+/* v2.31.98: 自訂 tab 兩段式 layout 需要更寬空間（mockup C 1024px）。
+   :has() 只在 ≥1024px 撐大；其他 tab 仍維持 720px 不變。 */
+@media (min-width: 1024px) {
+  .tp-change-poi-body:has(.tp-custom-poi-form-twopane) {
+    max-width: 1024px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
 .tp-change-poi-subtabs {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
QA 截圖發現 v2.31.98 ChangePoiPage 自訂 tab two-pane 被既有 .tp-change-poi-body max-width: 720px 壓扁。對齊 AddStopPage v2.31.95 同樣 :has() 解法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)