### PR TITLE
docs(openspec): retroactive archive v2.33.16-22 + Okinawa offline tile proposal

### DIFF
--- a/openspec/changes/archive/2026-05-22-input-system-overhaul-v2.33.16-22/proposal.md
+++ b/openspec/changes/archive/2026-05-22-input-system-overhaul-v2.33.16-22/proposal.md
@@ -1,0 +1,124 @@
+# Input System Overhaul — Terracotta Calendar / Select / Time (v2.33.16-22)
+
+**Retroactive archive** — 7 個 PR 已 ship 才補 OpenSpec（CLAUDE.md hard rule
+「Post-ship retroactive OpenSpec archive if PR didn't propose first」）。
+
+PR：#692 #693 #694 #695 #696 #697 #698（v2.33.16-22）。
+
+## Why
+
+v2.31.81 #3 把 native `<select>` 用 `appearance: none + background-image:
+data:image/svg... chevron` 美化成 site-style pill，但這只解決 trigger 視
+覺。**彈出層 (popup) 仍是 OS chrome**：
+
+- iOS Safari `<input type="date">` 跳出 wheel drum / `<input type="time">`
+  跳出 rotating drum
+- macOS Safari `<select>` 跳出 native dropdown（rounded corner 不同）
+- Chrome 桌面 `<select>` 跳出 native blue-focus list
+
+跨平台不一致也與 Terracotta design system 衝突。User feedback：「目前
+日曆 跟 select 還是用原生的 要改成網站風格」。
+
+唯一根本解 = 替換成 React 自訂 component（headless library + 自己 popover）。
+
+## What Changes
+
+### v2.33.16 — Input 二系統 (`.tp-input-long` / `.tp-input-short`)
+
+Foundation。把 74 個散落 input 收斂到 2 種 class：
+
+- `.tp-input-long` — 一般文字 (email/password/標題/地址/textarea/長 select)
+  - padding 12 14, border 1.5px, radius lg, bg secondary, font body, left align
+- `.tp-input-short` — 固定格式短值 (time/date/短 number)
+  - 22px bold center, 44px tap target, radius md
+
+Migrated 7 short callsites (date inputs, time inputs, duration number)。長
+inputs 維持靠 `:where()` base layer 視覺等效（v2.33.12）。
+
+### v2.33.17 — TripDatePicker + TripSelect
+
+Calendar + select popup → headless library + terracotta theme：
+
+- `react-day-picker@9` 包裝成 `TripDatePicker`（44px cell, 中文 weekday/month,
+  terracotta accent today/selected）
+- `@headlessui/react@2` Listbox 包裝成 `TripSelect`（44px row,
+  accent-subtle hover, `variant: 'default' | 'pill'`）
+
+Migrated：
+- 3 date callsites: NewTripPage 出發/回程, EditTripPage shift modal
+- 6 select callsites: AddPoiFavoriteToTrip × 2, EditTripPage 顯示語言,
+  EntryActionPage 時段, TripsListPage 排序 (pill), AddEntryPage Day
+
+### v2.33.18 — e2e pickDate helper (regression fix)
+
+v2.33.17 把 `<input type="date">` 換成 button-based TripDatePicker 後，
+Playwright Flow 1 `getByTestId(...).fill('YYYY-MM-DD')` 失敗。新
+`tests/e2e/_helpers/pickDate.js` 點 trigger + navigate month + 點 day。
+
+### v2.33.19 — `.tp-select` class collision fix
+
+Prod QA 截圖發現 TripSelect 上有兩個 chevron — wrapper `<div className="
+tp-select">` 與 v2.31.81 native `<select>` chrome CSS 同名。Fix：刪除
+legacy `.tp-form-row > select` + `.tp-select` 規則（無 callsite 用 native
+select）。
+
+### v2.33.20 — `companion-resolver.test.ts` hookTimeout
+
+CI flaky `Hook timed out in 10000ms` 在 `beforeAll createTestDb`。Fix：
+明確 30s budget。獨立 PR 但同 session 修。
+
+### v2.33.21 — TripTimePicker
+
+完成 calendar + select + time 三件套。`@headlessui/react` Popover + 2-col
+scrolling lists (hour 0-23 + minute 0-55 by `minuteStep` default 5)。
+
+Migrated 5 callsites: AddCustomStop, AddPoiFavoriteToTrip × 2, EditEntry × 2。
+
+### v2.33.22 — page-scoped CSS cleanup
+
+v2.33.16-21 換 Trip* components 後，多支 page 的 page-scoped CSS rules 已
+dead。本次 sweep：
+
+- AddPoiFavoriteToTripPage: `.tp-form-select` / `.tp-form-input` 整批
+- AddEntryPage: `.tp-add-entry-daypicker-select`
+- EditTripPage: `.tp-shift-modal-input`
+- EditEntryPage 抵達/離開: wrapper double-frame 修復 + label tag → div
+
+## Capabilities Added
+
+### Components
+
+- `src/components/TripDatePicker.tsx` + `.styles.ts` — terracotta calendar
+- `src/components/TripSelect.tsx` + `.styles.ts` — terracotta dropdown
+- `src/components/TripTimePicker.tsx` + `.styles.ts` — terracotta time picker
+
+### Tokens
+
+- `css/tokens.css @layer base` 加 `.tp-input-long` + `.tp-input-short` 系統 class
+
+### Test helpers
+
+- `tests/unit/__helpers__/tripSelect.ts` — `pickFromTripSelect(testId, matcher)`
+- `tests/unit/__helpers__/tripTimePicker.ts` — `pickTime(testId, 'HH:MM')`
+- `tests/e2e/_helpers/pickDate.js` — Playwright `pickDate(page, testId, iso)`
+
+## Dependencies Added
+
+- `react-day-picker@9` — calendar grid
+- `date-fns@4` — peer dep
+- `@headlessui/react@2` — Listbox + Popover (accessibility + portal)
+
+## Not in Scope (DEFER)
+
+- 沖繩 7/26 trip offline tile cache (PR3) — 獨立提案（Workbox + map tile
+  caching, big scope）
+- iOS native time picker drum 改成 web 介面但保留觸感 — 不做（current
+  2-col list 已夠用）
+
+## Tests
+
+- vitest 269 files / 2082 tests pass（含 8 個新 TripDatePicker test +
+  6 個 TripSelect test + 8 個 TripTimePicker test）
+- 9 個 affected source-grep / interaction tests 反轉 assertion（時間 input
+  改 click pattern）
+- e2e qa-flows.spec.js Flow 1 改用 pickDate helper（CI pass）

--- a/openspec/changes/archive/2026-05-22-input-system-overhaul-v2.33.16-22/tasks.md
+++ b/openspec/changes/archive/2026-05-22-input-system-overhaul-v2.33.16-22/tasks.md
@@ -1,0 +1,64 @@
+# Tasks (retroactive — shipped 2026-05-22)
+
+## v2.33.16 — Input 二系統 (PR #692)
+
+- [x] `css/tokens.css @layer base` 加 `.tp-input-long` + `.tp-input-short`
+- [x] Migrate 7 short callsites (NewTrip dates × 2, EditTrip shift date,
+      AddPoiFavoriteToTrip times × 2, AddCustomStop time + duration,
+      AddStopPage 預估停留, TravelPillDialog transit min, EditEntryPage transit min)
+- [x] sign-off mockup: `docs/design-sessions/2026-05-21-input-full-inventory/two-styles-proposal.html`
+
+## v2.33.17 — TripDatePicker + TripSelect (PR #693)
+
+- [x] Install `react-day-picker@9` + `date-fns@4` + `@headlessui/react@2`
+- [x] Build `src/components/TripDatePicker.tsx` + `.styles.ts`
+- [x] Build `src/components/TripSelect.tsx` + `.styles.ts` (含 `variant: pill`)
+- [x] Migrate 3 date callsites: NewTrip dates × 2, EditTrip shift modal
+- [x] Migrate 6 select callsites: AddPoiFavoriteToTrip × 2, EditTripPage 顯示語言,
+      EntryActionPage 時段, TripsListPage 排序 (pill), AddEntryPage Day
+- [x] Helper `tests/unit/__helpers__/tripSelect.ts`
+- [x] 12 unit tests (6 each); 9 affected tests refactored (`fireEvent.change` → click pattern)
+- [x] `tests/setup-jest-dom.js` 加 ResizeObserver stub (@headlessui 需要)
+- [x] sign-off mockup: `docs/design-sessions/2026-05-22-calendar-select-mockup/` Variant B Spacious
+
+## v2.33.18 — e2e pickDate helper (PR #694)
+
+- [x] `tests/e2e/_helpers/pickDate.js` — click trigger + navigate month + click day
+- [x] Update `tests/e2e/qa-flows.spec.js` Flow 1 to use helper
+
+## v2.33.19 — `.tp-select` class collision fix (PR #695)
+
+- [x] Prod QA 截圖發現 dual chevron on 5 TripSelect callsites
+- [x] Remove `.tp-form-row > select` + `.tp-select` legacy CSS (v2.31.81)
+      from `css/tokens.css` (3 blocks)
+- [x] Verify 5 callsites still render correctly (1 chevron only)
+
+## v2.33.20 — companion-resolver hookTimeout (PR #696)
+
+- [x] `tests/unit/companion-resolver.test.ts` `beforeAll(..., 30_000)`
+- [x] Push v2.33.19 prod QA 5/5 verify 截圖到 docs/design-sessions
+
+## v2.33.21 — TripTimePicker (PR #697)
+
+- [x] Build `src/components/TripTimePicker.tsx` + `.styles.ts`
+      (Popover + 2-col scrolling lists, minuteStep prop, scrollIntoView center)
+- [x] Migrate 5 time callsites: AddCustomStop, AddPoiFavoriteToTrip × 2, EditEntry × 2
+- [x] Helper `tests/unit/__helpers__/tripTimePicker.ts`
+- [x] 8 unit tests; 7 affected tests refactored
+
+## v2.33.22 — page-scoped CSS cleanup (PR #698)
+
+- [x] Remove dead `.tp-favorites-add-to-trip .tp-form-select` / `.tp-form-input`
+- [x] Remove dead `.tp-add-entry-daypicker-select`
+- [x] Remove dead `.tp-shift-modal-input`
+- [x] EditEntry 抵達/離開 wrapper: `<label>` → `<div>`, 拔 border/padding 避免 double frame
+- [x] AddCustomStop 標題 input: `.tp-custom-stop-input` → `.tp-input-long`
+- [x] Update `edit-entry-time-row-overflow.test.ts` assertion 反轉
+
+## QA (prod verify)
+
+- [x] 7 個 callsite 截圖 (qa-1 to qa-7)
+- [x] dual-chevron fix verify (qa-2/4a/4b/5/6/7 post-v2.33.19)
+- [x] 5/5 TripSelect callsites only 1 chevron
+- [x] 3/3 TripDatePicker callsites terracotta calendar
+- [x] 5/5 TripTimePicker callsites terracotta time picker

--- a/openspec/changes/okinawa-offline-tile-cache-pr3/proposal.md
+++ b/openspec/changes/okinawa-offline-tile-cache-pr3/proposal.md
@@ -1,0 +1,152 @@
+# Okinawa Offline Tile Cache (PR3)
+
+**Status**: 🟡 Proposal — user sign-off pending（mockup + scope clarification needed before build）
+
+**Driver**: Ray 7/26-8/1 Okinawa trip。沖繩部分區域（北部山區 / 海邊死角）4G/5G
+signal 不穩，user reports「地圖白塊」+ 漫遊流量上限焦慮。
+
+## Why
+
+Current state：v2.23.0 Google Maps JS API 完全 server-side tile fetch。
+無 cache，每次開地圖都重新 download tiles。離線 = white tiles。
+
+User pain (memory `project_okinawa_network_offline`)：
+- 沖繩 7/26-8/1 trip 7 天行程，地圖是主要 navigation
+- 部分區域死角 (北部 / 海邊) 跑網路無 signal
+- 漫遊流量 cap 後續日子可能耗光
+- 行程資料已 download (D1 → IndexedDB cache via React Query) 但地圖 tile
+  沒 offline path
+
+PR3 = trip-planner v2 roadmap 第 3 個必做 PR for 7/26 trip ship。
+
+## What Changes
+
+### Phase 1: tile caching strategy（必選 1）
+
+**A. Service Worker + Cache API tile interception（推薦）**
+
+- 在 `public/sw.js` 註冊 service worker，攔截 `maps.googleapis.com/...tile...`
+  request
+- Cache strategy: `staleWhileRevalidate`（先回 cache，背景更新）
+- Cache key: tile URL (含 zoom/x/y/styles)
+- Quota: ~50MB IndexedDB（沖繩主要區域 zoom 12-16 ~3000 tiles × 15KB
+  ~45MB）
+- Eviction: LRU when quota reach
+
+**B. Pre-download trip area on planner**
+
+- New page `/trip/:id/offline` 「下載離線地圖」UI
+- User 按下 → 算 trip bbox（所有 entries + destinations 含 padding）
+- 跨 zoom 12-16 列舉 tiles + sequentially fetch & cache
+- Progress UI (X/Y tiles, MB used)
+- Settings → 看 quota / 清 cache
+
+**C. Hybrid（A + B）**
+
+- 平常瀏覽 → service worker 自動 cache（A）
+- 預先 cache → user 主動 trigger（B）
+- 同一個 Cache Storage entry
+
+**選 C 推薦** — A 給日常瀏覽自動省流量，B 給離線前手動預載。
+
+### Phase 2: 落地 fallback（必選 1）
+
+**D. White-tile 偵測 + 通知**
+
+- `map.tilesloaded` event 觸發 → check viewport tile 是否全 cache hit
+- 沒 cache hit + 網路 fail → 顯示「地圖載入失敗 — 已離線」banner
+- 此 banner 引導 user 進 `/trip/:id/offline` pre-download
+
+**E. Static map 後備**
+
+- Pre-render 每 day 的 static map image (Google Static Maps API)
+- 存 D1 `trip_days.static_map_url` (signed URL OR base64 in IndexedDB)
+- Network fail → fallback 顯 static png（無 pan/zoom，只看位置）
+
+**選 D 推薦** — E 流量更省但 UX 差（不能互動）。
+
+### Phase 3: tile attribution + ToS（必做）
+
+Google Maps Platform ToS 第 3.2.4.b：「You will not pre-fetch, cache, or
+store any Content」— **明顯禁止 pre-download tiles**。
+
+Workaround：
+- **F1. 改用 OpenStreetMap tile server (Carto / Stadia)** for offline mode only
+- **F2. 跟 Google 簽 Premium plan** — Premium 允許某些 cache 形式
+- **F3. 用 MapTiler / Mapbox Vector tiles** with offline SDK
+- **F4. Self-host raster tiles** — own server tiles, ToS 自由
+
+**選 F3 推薦** — Mapbox / MapTiler 有正式 offline SDK，每月 free tier
+50K tile downloads。沖繩主要區域 ~3000 tiles 一次性 cache 足夠。
+
+### Phase 4: implementation surface
+
+1. `public/sw.js` — service worker（A path）
+2. `src/lib/offlineMap.ts` — Cache Storage helper + tile bbox enumeration
+3. `src/pages/TripOfflinePage.tsx` — `/trip/:id/offline` UI（B path）
+4. `src/components/trip/OfflineBanner.tsx` — D path UX
+5. `src/hooks/useGoogleMap.ts` 改造或 `src/hooks/useMapTilerMap.ts` 新 hook（F3 path）
+6. `migrations/00XX_trip_days_static_map_url.sql`（E fallback if 用）
+7. `functions/api/admin/static-map-prerender.ts`（E fallback if 用）
+
+## Open Questions
+
+1. **Maps provider 切換**：v2.23.0 已 Google Maps，要換 Mapbox/MapTiler 嗎？
+   切換成本 ~3-5 天（OceanMap / LocationPickerMap / GlobalMap rewrite）。
+   或：留 Google for 線上 + Mapbox vector for offline only（2 lib coexist
+   多 300KB bundle）。
+
+2. **User UI 觸發 pre-download 多複雜**：
+   - 最簡：trip detail page 加「下載離線地圖」按鈕 → 全行程一次 cache
+   - 進階：per-day download / cancel / quota meter / map zoom selector
+
+3. **Quota 上限**：50MB 對沖繩 7 天主要區域夠。要支援更大行程
+   (台灣環島 14 天) 嗎？目前 IndexedDB 通常上限 ~50%/100MB per origin。
+
+4. **Offline detection**：用 `navigator.onLine` (false positive 高) 還是
+   tile fetch fail rate (準但延遲)？
+
+5. **Service worker version 管理**：第一次 ship 後升級 sw.js 要怎麼處理
+   既有 cache invalidate？(cache key 含 version?)
+
+## Risks
+
+- **Google ToS 違反**：若沿用 Google Maps + cache → ToS violation。必須換
+  provider。
+- **Mapbox/MapTiler vendor lock-in**：style 不同，需重做 marker / polyline
+  styling。
+- **Quota exceeded**：iOS Safari quota 嚴格 (~50MB)，user 行程 cache 一半被踢
+  → 沒提示就壞掉。要加 quota meter UI。
+- **Service worker debugging**：dev 環境 SW 不啟，prod 才測得到。增 QA 成本。
+
+## Tests
+
+- Unit: `lib/offlineMap.ts` bbox enumeration + cache key derivation
+- Integration: service worker fetch intercept + cache hit/miss
+- E2E (playwright): pre-download trip → toggle offline → 地圖仍 render
+- Manual QA: 沖繩出發前真機測試（iPhone Safari + Android Chrome）
+
+## Effort Estimate
+
+- Phase 1 + 3 (provider 切 + service worker)：3-5 天
+- Phase 2 (pre-download UI)：2-3 天
+- Phase 4 (banner + fallback)：1-2 天
+- E2E + manual QA：1-2 天
+
+Total: **8-12 工作天**（依 maps provider 切換決策）。
+
+## Out of Scope
+
+- Offline POI search（用既有 D1 cache，無 search index）
+- Offline routing（Google Routes 無 offline，留 online-only）
+- 多 trip 同時 offline（先做 single active trip）
+
+## Next Steps
+
+1. ⏸ User sign-off on key decisions:
+   - (a) Maps provider strategy (留 Google 線上 + Mapbox offline, or 整套換)
+   - (b) UI complexity (一鍵下載 / per-day / progress meter)
+   - (c) Effort budget vs 7/26 deadline (剩 ~2 個月)
+2. `/tp-claude-design` mockup（offline page + banner UX）
+3. /office-hours 確認 scope
+4. Build phases incrementally（first vertical slice: trigger + cache + view）

--- a/openspec/changes/okinawa-offline-tile-cache-pr3/tasks.md
+++ b/openspec/changes/okinawa-offline-tile-cache-pr3/tasks.md
@@ -1,0 +1,42 @@
+# Tasks (NOT STARTED — pending user sign-off)
+
+## Pre-build (BLOCKED)
+
+- [ ] User answers Open Questions 1-5 in proposal.md
+- [ ] Office-hours brainstorm on Maps provider strategy
+- [ ] `/tp-claude-design` mockup for `/trip/:id/offline` page + offline banner
+- [ ] User sign-off mockup
+
+## Phase 1 — Tile caching (3-5 days)
+
+- [ ] Decide provider strategy (Google + Mapbox dual / pure Mapbox switch)
+- [ ] If switch: rewrite `src/hooks/useGoogleMap.ts` → new `useMapTilerMap.ts`
+- [ ] `public/sw.js` service worker registration + tile fetch interception
+- [ ] `src/lib/offlineMap.ts` — Cache Storage helper + tile bbox enumeration
+- [ ] `src/lib/serviceWorker.ts` — register / unregister / version mgmt
+- [ ] Tests: unit (bbox + cache key) + integration (fetch intercept)
+
+## Phase 2 — Pre-download UI (2-3 days)
+
+- [ ] `src/pages/TripOfflinePage.tsx` — new route `/trip/:id/offline`
+- [ ] UI: bbox preview, download button, progress meter (X/Y tiles, MB used)
+- [ ] Settings: quota viewer + clear-cache button
+- [ ] `src/main.tsx` route table 加 `/trip/:id/offline`
+
+## Phase 3 — Offline banner + fallback (1-2 days)
+
+- [ ] `src/components/trip/OfflineBanner.tsx` — appear on tile fail
+- [ ] Link to `/trip/:id/offline` for pre-download
+- [ ] Optional: static map fallback for fully offline scenarios
+
+## Phase 4 — Tests + QA (1-2 days)
+
+- [ ] Playwright E2E: trip detail → 離線 page → download → toggle offline → 地圖 render
+- [ ] Manual QA: iPhone Safari + Android Chrome 模擬 offline
+- [ ] **REAL device QA before 7/26 Okinawa trip departure**
+
+## Phase 5 — Ship + release notes
+
+- [ ] CHANGELOG entry
+- [ ] PR with mockup + reviews
+- [ ] /ship → /land-and-deploy → /canary monitor


### PR DESCRIPTION
## Summary

Retroactive OpenSpec archive per CLAUDE.md hard rule（7 個 PR #692-698 沒先 propose）+ 沖繩 7/26 trip 離線地圖 active proposal（5 個 open question 待 user 拍板）。

## Test plan

- [x] 純 docs，no code
- [ ] User read \`openspec/changes/okinawa-offline-tile-cache-pr3/proposal.md\` 5 個 open questions 拍板

🤖 Generated with [Claude Code](https://claude.com/claude-code)