### PR TITLE
feat: /api/my-trips additive 補 trip card meta 富欄位

### DIFF
--- a/functions/api/my-trips.ts
+++ b/functions/api/my-trips.ts
@@ -1,24 +1,55 @@
 /**
- * GET /api/my-trips — 回傳使用者有權限的 trip 摘要（id / name / title / totalDays）
+ * GET /api/my-trips — 回傳使用者有權限的 trip 摘要
  *
  * v2.22.1: 加 name / title / totalDays 給 AddPoiFavoriteToTripPage dropdown 顯示
  *   trip 名稱用（之前只回 tripId，dropdown 看到「選擇行程…」之後 options 空白）。
  *   totalDays 從 trip_days COUNT subquery 算。Backwards-compatible：既有 callers
  *   只 read tripId 仍 work。
+ *
+ * 2026-06: 加 trip card meta 富欄位給 Flutter client 顯示行程卡 / filter / 排序。
+ *   仿 trips.ts baseCols（line ~192）的富欄位 SELECT。全部用 camelCase alias，
+ *   對齊既有 tripId / name / title / totalDays 風格。Additive / backwards-compatible：
+ *   web AddPoiFavoriteToTripPage 只 read tripId / name / title / totalDays，新欄位
+ *   不影響既有 callers。
+ *   新增欄位：
+ *     - owner            （u.email — V2 cutover 後 trips.owner email column 已 drop，
+ *                          LEFT JOIN users 拿 owner email for display）
+ *     - ownerDisplayName （u.display_name — trip card avatar initial / 顯示名）
+ *     - ownerUserId      （t.owner_user_id — canonical owner id）
+ *     - role             （p.role — 當前 user 在此 trip 的權限：owner/admin/member/viewer。
+ *                          admin 分支因 isAdmin 看全部，role 反映該 permission row 實際值）
+ *     - countries        （t.countries — filter / 顯示）
+ *     - startDate        （MIN(trip_days.date) — 行程起日）
+ *     - endDate          （MAX(trip_days.date) — 行程迄日）
+ *     - updatedAt        （t.updated_at — 排序 / 同步用；trips 表確有此欄位 migration 0047）
+ *     - memberCount      （COUNT(DISTINCT trip_permissions.user_id) — 協作人數）
  */
 
 import { requireAuth } from './_auth';
 import { json } from './_utils';
 import type { Env } from './_types';
 
+// LEFT JOIN users u ON u.id = t.owner_user_id：V2 cutover (migration 0047) 後
+// trips.owner email column 已 drop，owner_user_id 為 canonical，需 JOIN users 拿
+// email / display_name 顯示。admin 與 user 兩分支共用此 SELECT_BASE，改一處即可。
 const SELECT_BASE = `
   SELECT DISTINCT
     p.trip_id AS tripId,
     t.name AS name,
     t.title AS title,
-    COALESCE((SELECT COUNT(*) FROM trip_days td WHERE td.trip_id = t.id), 0) AS totalDays
+    u.email AS owner,
+    u.display_name AS ownerDisplayName,
+    t.owner_user_id AS ownerUserId,
+    p.role AS role,
+    t.countries AS countries,
+    t.updated_at AS updatedAt,
+    COALESCE((SELECT COUNT(*) FROM trip_days td WHERE td.trip_id = t.id), 0) AS totalDays,
+    (SELECT MIN(date) FROM trip_days td WHERE td.trip_id = t.id AND date IS NOT NULL) AS startDate,
+    (SELECT MAX(date) FROM trip_days td WHERE td.trip_id = t.id AND date IS NOT NULL) AS endDate,
+    (SELECT COUNT(DISTINCT user_id) FROM trip_permissions mp WHERE mp.trip_id = t.id) AS memberCount
   FROM trip_permissions p
   INNER JOIN trips t ON t.id = p.trip_id
+  LEFT JOIN users u ON u.id = t.owner_user_id
 `;
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {


### PR DESCRIPTION
## 摘要
`GET /api/my-trips` additive 補欄位,供 Flutter client(trip-planner.flutter)顯示行程卡 meta + filter(我的/共編)+ 排序(最新編輯/出發日)。

**Backwards-compatible**:既有 4 欄(`tripId`/`name`/`title`/`totalDays`)不變,web 的 `AddPoiFavoriteToTripPage` 等既有 caller 不受影響。

### 新增欄位(camelCase,仿 `trips.ts` baseCols)
`owner`(u.email)、`ownerDisplayName`、`ownerUserId`、`role`(p.role)、`countries`、`startDate`(MIN trip_days.date)、`endDate`(MAX)、`updatedAt`、`memberCount`。`SELECT_BASE` 加 `LEFT JOIN users u ON u.id = t.owner_user_id`,admin 與 user 兩分支共用。

### 驗證
- `tsc --noEmit -p tsconfig.functions.json` 通過
- `my-trips.integration.test.ts` 3/3 綠
- additive,不破壞 web

> 配對 PR:trip-planner.flutter 的行程卡 meta/filter/排序對接(需本 PR merge + deploy 後生效)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)