### PR TITLE
test: fix trip notes mobile checks

### DIFF
--- a/tests/e2e/trip-notes.spec.js
+++ b/tests/e2e/trip-notes.spec.js
@@ -5,7 +5,7 @@
  * Verify:
  *   - /trip/:id/notes renders 5 sections with TitleBar + trip name
  *   - Each section has correct meta count
- *   - AI button present on pretrip + emergency only
+ *   - AI button present on expanded pretrip + emergency only
  *   - Click section head → expand/collapse
  *   - Empty trip → empty hero with 5 dot progress
  */
@@ -13,6 +13,15 @@ import { test, expect } from '@playwright/test';
 const { setupApiMocks } = require('./api-mocks');
 
 const TRIP_ID = 'okinawa-trip-2026-Ray';
+
+async function ensureSectionOpen(page, key) {
+  const head = page.getByTestId(`trip-notes-section-head-${key}`);
+  await expect(head).toBeVisible();
+  if ((await head.getAttribute('aria-expanded')) !== 'true') {
+    await head.click();
+    await expect(head).toHaveAttribute('aria-expanded', 'true');
+  }
+}
 
 const NOTES_FIXTURE = {
   flights: [
@@ -67,9 +76,11 @@ test.describe('TripNotesPage E2E happy path', () => {
     await expect(page.getByTestId('trip-notes-section-emergency')).toContainText('2 個聯絡人');
   });
 
-  test('AI button 只在 pretrip + emergency', async ({ page }) => {
+  test('AI button 只在展開的 pretrip + emergency', async ({ page }) => {
     await page.goto(`/trip/${TRIP_ID}/notes`);
     await expect(page.getByTestId('trip-notes-page')).toBeVisible({ timeout: 10000 });
+    await ensureSectionOpen(page, 'pretrip');
+    await ensureSectionOpen(page, 'emergency');
     await expect(page.getByTestId('trip-notes-ai-btn-pretrip')).toBeVisible();
     await expect(page.getByTestId('trip-notes-ai-btn-emergency')).toBeVisible();
     await expect(page.getByTestId('trip-notes-ai-btn-flights')).not.toBeVisible();

--- a/tests/setup-dom.js
+++ b/tests/setup-dom.js
@@ -4,9 +4,15 @@
  */
 import '@testing-library/jest-dom';
 
-// Node.js 25 內建 localStorage 但缺少 .clear()/.key()/.length — jsdom 也無法正確覆蓋
-// 用完整的 Map-backed polyfill 替代
-if (typeof globalThis.localStorage !== 'undefined' && typeof globalThis.localStorage.clear !== 'function') {
+// Node.js 25 內建 localStorage accessor；讀取它會噴 `--localstorage-file`
+// warning。用 descriptor 偵測後直接覆蓋，避免觸發 getter。
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+if (
+  !localStorageDescriptor ||
+  typeof localStorageDescriptor.get === 'function' ||
+  !localStorageDescriptor.value ||
+  typeof localStorageDescriptor.value.clear !== 'function'
+) {
   const store = new Map();
   const ls = {
     getItem: (k) => store.has(k) ? store.get(k) : null,
@@ -17,6 +23,9 @@ if (typeof globalThis.localStorage !== 'undefined' && typeof globalThis.localSto
     get length() { return store.size; },
   };
   Object.defineProperty(globalThis, 'localStorage', { value: ls, writable: true, configurable: true });
+  if (typeof globalThis.window !== 'undefined') {
+    Object.defineProperty(globalThis.window, 'localStorage', { value: ls, writable: true, configurable: true });
+  }
 }
 
 // jsdom 不提供 ResizeObserver — @headlessui Listbox 內部 element-movement


### PR DESCRIPTION
## Summary
- Update TripNotes E2E to open collapsed mobile accordion sections before asserting pretrip/emergency AI buttons.
- Avoid Node 25 native `localStorage` getter access in Vitest DOM setup so `--localstorage-file` warnings disappear.

## Test plan
- [x] `npm test` — 398 files / 3446 tests passed, no `--localstorage-file` warning after fix
- [x] `npx playwright test` — 153 tests passed
- [x] `npm run typecheck`
- [x] `npm run typecheck:functions`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `node scripts/verify-sw.js`
- [x] `bash scripts/bundle-size-check.sh`
- [ ] `npm run test:api` — interrupted locally; CI will run it on PR

## Notes
- Target branch is `master` (repo default branch), not `main`.
