### PR TITLE
chore(timeline): 實際移除 dead formatPillLabel（補 #1064 誤失）

### DIFF
--- a/src/components/trip/DayNav.tsx
+++ b/src/components/trip/DayNav.tsx
@@ -18,13 +18,6 @@ import MapDayTab from './MapDayTab';
 
 const WEEKDAYS = '日一二三四五六';
 
-/** Exposed for unit test only; not part of the public component API. */
-export function formatPillLabel(day: DaySummary): string {
-  const d = parseLocalDate(day.date);
-  if (!d) return String(day.dayNum);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
-
 function buildAriaLabel(day: DaySummary): string {
   const parts: string[] = [`Day ${day.dayNum}`];
   const d = parseLocalDate(day.date);


### PR DESCRIPTION
## 背景
#1064 CHANGELOG 寫「移除 dead formatPillLabel」，但當時 `git add src/.../DayNav.tsx tests/unit/day-nav-format.test.ts` 因 test 已被 `git rm` → 整條 add 中止，只有 test 刪除進 commit，**function 本體遺留在 master**（dead + 無測試）。

## 修正
移除 `formatPillLabel`（去日期副標後無生產端 caller；其專屬 `day-nav-format.test.ts` 已於 #1064 刪除）。`parseLocalDate` 仍由 `buildAriaLabel` 使用，保留。使實況與 #1064 CHANGELOG 一致。

## 測試
tsc ✓ · day-nav 相關測試 ✓（純 dead-code 移除，無行為變更 → 不 bump 版本）

🤖 Generated with [Claude Code](https://claude.com/claude-code)