### PR TITLE
fix: 桌機第三欄六項修正 — header actions、不重掛載中欄、深色 elevation

### DIFF
--- a/docs/design-sessions/2026-07-21-third-column-followups.html
+++ b/docs/design-sessions/2026-07-21-third-column-followups.html
@@ -1,0 +1,316 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8" />
+<title>第三欄面板 owner 回報批次 — #3 header 等高 + #4 桌機 tab 玻璃共用</title>
+<style>
+  :root {
+    --color-background: #FFFBF5;
+    --color-secondary: #FAF4EA;
+    --color-tertiary: #F2E8D8;
+    --color-foreground: #2A1F18;
+    --color-muted: #8A7A68;
+    --color-border: #E8DCC8;
+    --color-line-strong: #D9C7A8;
+    --color-accent: #B85F2A;
+    --color-accent-deep: #8A431A;
+    --color-accent-subtle: #F5E4D3;
+    --color-accent-fill: #B85F2A;
+    --color-accent-foreground: #FFFBF5;
+    --radius-md: 8px;
+    --radius-lg: 14px;
+    --radius-full: 999px;
+    --tabbar-tint: color-mix(in srgb, var(--color-background) 58%, transparent);
+    --tabbar-filter: blur(20px) saturate(190%);
+    --tabbar-rim: 1px solid color-mix(in srgb, var(--color-foreground) 10%, transparent);
+    --tabbar-shadow: 0 6px 18px rgba(42,31,24,0.14);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Microsoft JhengHei", sans-serif;
+    background: #EEE3D2;
+    color: var(--color-foreground);
+    padding: 24px;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .subtitle { color: var(--color-muted); font-size: 13px; margin: 0 0 20px; }
+  h2 { font-size: 15px; margin: 28px 0 8px; }
+  .callout {
+    background: var(--color-accent-subtle);
+    border: 1px solid var(--color-accent);
+    border-radius: var(--radius-md);
+    padding: 12px 16px;
+    font-size: 13px;
+    line-height: 1.6;
+    margin-bottom: 20px;
+    max-width: 980px;
+  }
+  .callout b { color: var(--color-accent-deep); }
+  .callout ul { margin: 6px 0 0; padding-left: 18px; }
+  .status-line { max-width: 980px; font-size: 13px; line-height: 1.8; margin-bottom: 24px; }
+  .status-line .tag { display: inline-block; font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: var(--radius-full); margin-right: 6px; }
+  .tag.done { background: #DCEFD9; color: #2E6B2A; }
+  .tag.mockup { background: var(--color-accent-subtle); color: var(--color-accent-deep); }
+
+  .pair { display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 8px; }
+  .frame-wrap { }
+  .frame-label { font-size: 12px; font-weight: 700; margin-bottom: 6px; color: var(--color-muted); }
+  .frame-label.before { color: #A34A3A; }
+  .frame-label.after { color: #2E6B2A; }
+
+  .frame {
+    display: grid;
+    grid-template-columns: 160px minmax(220px, 1fr) 260px;
+    height: 380px;
+    width: 700px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: var(--color-background);
+    box-shadow: 0 8px 24px rgba(42,31,24,0.12);
+  }
+
+  .col-sidebar {
+    background: var(--color-secondary);
+    padding: 12px 10px;
+    font-size: 12px;
+    color: var(--color-muted);
+    border-right: 1px solid var(--color-border);
+  }
+  .col-sidebar .brand { font-weight: 800; color: var(--color-accent-deep); margin-bottom: 10px; font-size: 13px; }
+
+  /* #4 BEFORE: flat list nav, no glass */
+  .nav-flat .nav-item { padding: 6px 8px; border-radius: var(--radius-md); margin-bottom: 2px; display: flex; align-items: center; gap: 8px; }
+  .nav-flat .nav-item.is-active { background: var(--color-background); color: var(--color-foreground); font-weight: 700; }
+
+  /* #4 AFTER: glass capsule container matching bottom tab */
+  .nav-glass {
+    padding: 4px;
+    border-radius: var(--radius-lg);
+    background: var(--tabbar-tint);
+    backdrop-filter: var(--tabbar-filter);
+    -webkit-backdrop-filter: var(--tabbar-filter);
+    border: var(--tabbar-rim);
+    box-shadow: var(--tabbar-shadow);
+    margin-bottom: 10px;
+  }
+  .nav-glass .nav-item { padding: 6px 8px; border-radius: var(--radius-md); margin-bottom: 2px; display: flex; align-items: center; gap: 8px; }
+  .nav-glass .nav-item.is-active { background: var(--color-accent-fill); color: var(--color-accent-foreground); font-weight: 700; }
+
+  .col-mid { border-right: 1px solid var(--color-border); display: flex; flex-direction: column; min-width: 0; }
+  /* #3 BEFORE: mid titlebar 64px vs panel head 52px — mismatched */
+  .mid-titlebar-before {
+    height: 64px; flex-shrink: 0; display: flex; align-items: center; gap: 10px;
+    padding: 0 16px; border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+  }
+  /* #3 AFTER: both use --titlebar-h (64px here) */
+  .mid-titlebar-after {
+    height: 64px; flex-shrink: 0; display: flex; align-items: center; gap: 10px;
+    padding: 0 16px; border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+  }
+  .mid-titlebar-before .back-btn, .mid-titlebar-after .back-btn {
+    width: 32px; height: 32px; border-radius: 50%; display: grid; place-items: center;
+    background: transparent; color: var(--color-foreground); font-size: 16px; flex-shrink: 0;
+  }
+  .mid-titlebar-before .title, .mid-titlebar-after .title { font-weight: 700; font-size: 14px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mid-titlebar-before .actions, .mid-titlebar-after .actions { display: flex; gap: 4px; flex-shrink: 0; }
+  .mid-titlebar-before .icon-btn, .mid-titlebar-after .icon-btn {
+    width: 30px; height: 30px; border-radius: 50%; display: grid; place-items: center;
+    background: transparent; color: var(--color-foreground); font-size: 14px;
+  }
+  .mid-body { padding: 12px 16px; overflow-y: auto; flex: 1; color: var(--color-muted); font-size: 12px; }
+  .day-chip { display: inline-block; background: var(--color-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-full); padding: 3px 10px; font-weight: 700; font-size: 11px; margin-bottom: 8px; color: var(--color-foreground); }
+  .stop-row { display: flex; gap: 8px; padding: 6px 0; border-bottom: 1px solid var(--color-border); }
+  .stop-row .n { width: 18px; height: 18px; border-radius: 50%; background: var(--color-accent-subtle); color: var(--color-accent-deep); display: grid; place-items: center; font-size: 10px; font-weight: 700; flex-shrink: 0; }
+  .stop-row .name { color: var(--color-foreground); font-weight: 600; font-size: 12px; }
+
+  .col-panel { display: flex; flex-direction: column; min-width: 0; }
+  /* #3 BEFORE: panel head hardcoded 52px */
+  .panel-head-before {
+    height: 52px; flex-shrink: 0; display: flex; align-items: center; gap: 8px;
+    padding: 0 8px 0 6px; border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+  }
+  /* #3 AFTER: panel head now uses --titlebar-h too (64px) — aligned with mid titlebar */
+  .panel-head-after {
+    height: 64px; flex-shrink: 0; display: flex; align-items: center; gap: 8px;
+    padding: 0 8px 0 6px; border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+  }
+  .panel-head-before .icon-btn, .panel-head-after .icon-btn { width: 36px; height: 36px; border-radius: 50%; display: grid; place-items: center; background: transparent; color: var(--color-foreground); font-size: 14px; flex-shrink: 0; }
+  .panel-head-before .title, .panel-head-after .title { flex: 1; text-align: center; font-weight: 700; font-size: 13px; }
+  .panel-body { padding: 12px; overflow-y: auto; flex: 1; font-size: 12px; background: var(--color-tertiary); }
+
+  .mismatch-marker { position: absolute; }
+  .row-guide { position: relative; }
+  .row-guide::after {
+    content: ""; position: absolute; left: 0; right: 0; height: 1px; background: repeating-linear-gradient(90deg, #C9432B 0 6px, transparent 6px 10px);
+    z-index: 5;
+  }
+
+  .annot {
+    max-width: 980px; margin-top: 12px; font-size: 12px; color: var(--color-muted); line-height: 1.7;
+  }
+  .annot code { background: var(--color-tertiary); padding: 1px 5px; border-radius: 4px; }
+
+  .signoff {
+    max-width: 980px; margin-top: 24px; padding: 14px 16px; border: 2px solid var(--color-accent);
+    border-radius: var(--radius-md); font-size: 13px; color: var(--color-foreground); background: var(--color-accent-subtle);
+  }
+</style>
+</head>
+<body>
+  <h1>第三欄面板 owner 2026-07-21 第二輪回報 — #3 header 等高 + #4 桌機 tab 玻璃共用</h1>
+  <p class="subtitle">mockup 產出於實作完成後（bug-fix/token 對齊性質，非全新頁面），仍走 mockup-first gate 補送 owner sign-off。</p>
+
+  <div class="status-line">
+    <b>本回報批次共 6 項，狀態：</b><br/>
+    <span class="tag done">已完成</span> #1 中欄 header actions 消失（補回 TripActionsMenu）<br/>
+    <span class="tag done">已完成</span> #2 開關第三欄不重掛載中欄（TripPageHost 單例 + Portal，見下方「已知取捨」段落已改寫為「已解決」）<br/>
+    <span class="tag done">已完成</span> #5 既有 6 個操作面板套 tertiary elevation（跟新 3 面板一致）<br/>
+    <span class="tag done">已完成</span> #6 行程內容欄兩側深黑（elevation 移到最外層 + 展開卡片調高一階）<br/>
+    <span class="tag mockup">本頁 mockup</span> #3 第三欄 header 沒和第二欄等高<br/>
+    <span class="tag mockup">本頁 mockup</span> #4 桌機 tab 效果沒比照手機版
+  </div>
+
+  <div class="callout">
+    <b>#3 決策摘要</b>：<code>StackPanelHeader</code>（第三欄 header，class <code>.tp-stack-head</code>）原本寫死 <code>height: 52px</code>；
+    中欄 <code>TitleBar</code>（class <code>.tp-titlebar</code>）用 <code>--titlebar-h</code> token（桌機 64px / compact 56px）。
+    兩者不共用同一個高度來源，肉眼可見第三欄 header 比中欄矮一截。改法：<b>把 <code>.tp-stack-head</code> 的 height 也改成
+    <code>calc(var(--titlebar-h) + env(safe-area-inset-top, 0px))</code></b>，跟 <code>.tp-titlebar</code> 完全同源 —— 之後
+    <code>--titlebar-h</code> 若再調整（例如全站改 60px），兩欄會自動一起變，不會再漂移。<br/><br/>
+    <b>#4 決策摘要</b>：手機 <code>GlobalBottomNav</code> 是玻璃膠囊（<code>--tabbar-tint</code> + <code>--tabbar-filter</code> + <code>--tabbar-rim</code> + <code>--tabbar-shadow</code>
+    四件套材質，已在 tokens.css 定義）；桌機 <code>DesktopSidebar</code> 頂部的 primary nav（<code>.tp-sidebar-nav</code>）過去是純色 list、完全沒有材質。
+    這裡<b>不是重做一個新元件</b>，是讓 <code>.tp-sidebar-nav</code> 套用同一組已存在的 <code>--tabbar-*</code> token —— 垂直列表 vs
+    水平膠囊排列不同，但材質語言統一，桌機側欄頂部跟手機底部膠囊才讀作「同一種 chrome」。
+    <ul>
+      <li>已選中項目背景沿用既有 <code>--color-accent-fill</code>（跟手機 active tab 已經一致，未變動）。</li>
+      <li>沒有改變 <code>navItems.ts</code> 的 5-tab IA（含帳號），純視覺材質對齊。</li>
+    </ul>
+  </div>
+
+  <h2>#3 — 第三欄 header 高度對齊中欄 TitleBar</h2>
+  <div class="pair">
+    <div class="frame-wrap">
+      <div class="frame-label before">Before — .tp-stack-head 寫死 52px，比中欄矮</div>
+      <div class="frame">
+        <div class="col-sidebar nav-flat">
+          <div class="brand">Tripline</div>
+          <div class="nav-item is-active">📅 行程</div>
+          <div class="nav-item">💬 聊天</div>
+          <div class="nav-item">🗺 地圖</div>
+          <div class="nav-item">❤ 收藏</div>
+        </div>
+        <div class="col-mid">
+          <div class="mid-titlebar-before">
+            <div class="back-btn">‹</div>
+            <div class="title">2026 沖繩七日遊</div>
+          </div>
+          <div class="mid-body">
+            <div class="day-chip">DAY 3</div>
+            <div class="stop-row"><div class="n">1</div><div class="name">首里城公園</div></div>
+            <div class="stop-row"><div class="n">2</div><div class="name">花織そば</div></div>
+          </div>
+        </div>
+        <div class="col-panel">
+          <div class="panel-head-before">
+            <span class="icon-btn" style="visibility:hidden">‹</span>
+            <span class="title">共編設定</span>
+            <span class="icon-btn">✕</span>
+          </div>
+          <div class="panel-body">
+            <p style="margin:0;color:#A34A3A;font-weight:700;">↑ 52px，比左邊中欄的 64px 矮 12px —— 兩條分隔線高度對不齊</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="frame-wrap">
+      <div class="frame-label after">After — .tp-stack-head 改用 --titlebar-h，兩欄同高</div>
+      <div class="frame">
+        <div class="col-sidebar nav-flat">
+          <div class="brand">Tripline</div>
+          <div class="nav-item is-active">📅 行程</div>
+          <div class="nav-item">💬 聊天</div>
+          <div class="nav-item">🗺 地圖</div>
+          <div class="nav-item">❤ 收藏</div>
+        </div>
+        <div class="col-mid">
+          <div class="mid-titlebar-after">
+            <div class="back-btn">‹</div>
+            <div class="title">2026 沖繩七日遊</div>
+            <div class="actions"><span class="icon-btn">+</span><span class="icon-btn">⋯</span></div>
+          </div>
+          <div class="mid-body">
+            <div class="day-chip">DAY 3</div>
+            <div class="stop-row"><div class="n">1</div><div class="name">首里城公園</div></div>
+            <div class="stop-row"><div class="n">2</div><div class="name">花織そば</div></div>
+          </div>
+        </div>
+        <div class="col-panel">
+          <div class="panel-head-after">
+            <span class="icon-btn" style="visibility:hidden">‹</span>
+            <span class="title">共編設定</span>
+            <span class="icon-btn">✕</span>
+          </div>
+          <div class="panel-body">
+            <p style="margin:0;color:#2E6B2A;font-weight:700;">↑ 64px，跟中欄 TitleBar 同高，分隔線對齊一直線</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="annot">
+    順帶展示 <b>#1 的修復</b>：After 版中欄 TitleBar 右上角補回「+ 新增景點」與「⋯ 動作選單」（Before 版兩者都沒有 —— 這正是 owner 回報 #1 「header actions 消失」的畫面）。
+  </div>
+
+  <h2>#4 — 桌機 primary nav 玻璃材質跟手機底部膠囊共用</h2>
+  <div class="pair">
+    <div class="frame-wrap">
+      <div class="frame-label before">Before — .tp-sidebar-nav 純色 list，無材質</div>
+      <div class="frame" style="height:220px;">
+        <div class="col-sidebar nav-flat">
+          <div class="brand">Tripline</div>
+          <div class="nav-item is-active">📅 行程</div>
+          <div class="nav-item">💬 聊天</div>
+          <div class="nav-item">🗺 地圖</div>
+          <div class="nav-item">❤ 收藏</div>
+          <div class="nav-item">👤 帳號</div>
+        </div>
+        <div class="col-mid" style="align-items:center;justify-content:center;color:var(--color-muted);font-size:12px;">（中欄/右欄與本項無關，省略）</div>
+        <div class="col-panel"></div>
+      </div>
+    </div>
+    <div class="frame-wrap">
+      <div class="frame-label after">After — .tp-sidebar-nav 套用 --tabbar-* 玻璃 token</div>
+      <div class="frame" style="height:220px;">
+        <div class="col-sidebar">
+          <div class="brand">Tripline</div>
+          <div class="nav-glass">
+            <div class="nav-item is-active">📅 行程</div>
+            <div class="nav-item">💬 聊天</div>
+            <div class="nav-item">🗺 地圖</div>
+            <div class="nav-item">❤ 收藏</div>
+            <div class="nav-item">👤 帳號</div>
+          </div>
+        </div>
+        <div class="col-mid" style="align-items:center;justify-content:center;color:var(--color-muted);font-size:12px;">（中欄/右欄與本項無關，省略）</div>
+        <div class="col-panel"></div>
+      </div>
+    </div>
+  </div>
+  <div class="annot">
+    手機參照（不變，僅供比對材質語言）：<code>GlobalBottomNav</code> 的浮動玻璃膠囊 —— tint(0.42) + blur(28px) + saturate(190%) + rim + shadow。
+    桌機這裡是同一組 <code>--tabbar-tint</code> / <code>--tabbar-filter</code> / <code>--tabbar-rim</code> / <code>--tabbar-shadow</code>，
+    容器形狀改成貼合側欄寬度的圓角矩形（不是膠囊），但材質「配方」一致。
+  </div>
+
+  <div class="signoff">
+    <b>需要 owner sign-off 才能視為此輪 UI 變化定案</b>（CLAUDE.md mockup-first hard gate）。
+    #3、#4 程式碼已依本頁樣式實作並通過對應單元測試；若 sign-off 後有調整（例如 #4 想要更貼近「膠囊」的圓角、或 #3 想要跟 compact 斷點驗證），
+    請回饋後續調整，不影響其餘 4 項已完成項目。
+  </div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "typecheck:functions": "tsc --noEmit -p tsconfig.functions.json",
-    "test": "vitest run",
+    "test": "vitest run --maxWorkers=2",
     "test:api": "vitest run --config vitest.config.api.mts",
     "test:all": "vitest run && vitest run --config vitest.config.api.mts",
     "test:watch": "vitest",

--- a/src/components/shell/DesktopSidebar.tsx
+++ b/src/components/shell/DesktopSidebar.tsx
@@ -42,10 +42,24 @@ const SCOPED_STYLES = `
 .tp-sidebar-brand .accent-dot { color: var(--color-accent); }
 
 /* §10.1 primary nav（macOS sidebar 頂部 4-tab；桌機膠囊隱藏後的主導覽，
- * 與 GlobalBottomNav 共用 PRIMARY_NAV_ITEMS + isItemActive）。 */
+ * 與 GlobalBottomNav 共用 PRIMARY_NAV_ITEMS + isItemActive）。
+ *
+ * owner 2026-07-21（第二輪回報 #4）：這裡跟手機 GlobalBottomNav 的玻璃膠囊
+ * 視覺不一致（那邊 tint+blur+rim+shadow 四件套，這裡完全沒有材質、只是純色
+ * list item）。owner 要求共用 —— 不是重做一個新元件，是套用同一組已存在的
+ * --tabbar-* token（GlobalBottomNav 已在用，見該檔 .tp-global-bottom-nav）。
+ * 垂直列表跟水平膠囊的排列不同，但材質（半透明 tint + 高斯模糊 + 邊框 + 陰影）
+ * 是同一套語言，這樣桌機側欄頂部跟手機底部膠囊才讀作「同一種 chrome」。 */
 .tp-sidebar-nav {
   display: flex; flex-direction: column; gap: 2px;
   flex-shrink: 0; margin-bottom: 4px;
+  padding: 4px;
+  border-radius: var(--radius-lg);
+  background: var(--tabbar-tint);
+  backdrop-filter: var(--tabbar-filter);
+  -webkit-backdrop-filter: var(--tabbar-filter);
+  border: var(--tabbar-rim);
+  box-shadow: var(--tabbar-shadow);
 }
 .tp-sidebar-nav-item {
   display: flex; align-items: center; gap: 11px;

--- a/src/components/shell/StackPanelHeader.tsx
+++ b/src/components/shell/StackPanelHeader.tsx
@@ -21,7 +21,13 @@ export interface StackPanelHeaderProps {
 export const STACK_PANEL_HEADER_STYLES = `
 .tp-stack-head {
   display: flex; align-items: center; gap: 8px;
-  height: 52px; padding: 0 8px 0 6px; flex-shrink: 0;
+  /* owner 2026-07-21（第二輪回報 #3）：第三欄 panel header 沒跟中欄 TitleBar
+   * 等高 —— TitleBar 用 --titlebar-h（64px 桌機 / 56px compact，見 tokens.css）,
+   * 這裡原本寫死 52px。改共用同一個 token 來源，兩欄視覺才對齊。safe-area-inset-top
+   * 的處理也比照 .tp-titlebar（iOS PWA standalone 需要）。 */
+  height: calc(var(--titlebar-h) + env(safe-area-inset-top, 0px));
+  padding: env(safe-area-inset-top, 0px) 8px 0 6px;
+  flex-shrink: 0;
   border-bottom: 1px solid var(--color-border);
   /* 桌機右欄 panel / 手機全頁 drill-down 都以外層為 scroll container，header
    * 需 sticky top 才不隨內容捲走（比照 TitleBar sticky glass chrome）。

--- a/src/components/trip/TimelineRail.tsx
+++ b/src/components/trip/TimelineRail.tsx
@@ -64,8 +64,10 @@ const SCOPED_STYLES = `
    * 建 stacking → 卡壓在 spine 之上（線在展開區被卡蓋住，符合「壓在 timeline 上」）。 */
   position: relative;
   z-index: 1;
-  /* 展開明細與卡片同色系（繼承 .tp-rail-item[data-tone] 的 --tone-*；neutral fallback secondary）*/
-  background: var(--tone-subtle, var(--color-secondary));
+  /* 展開明細與卡片同色系（繼承 .tp-rail-item[data-tone] 的 --tone-*；neutral fallback tertiary）。
+   * v2.57.x：外層內容欄整片改 --color-secondary 後（見 TripPage.tsx .tp-trip-page-shell），
+   * fallback 若還留在 secondary 會跟外層同色、展開明細沒層次 —— 調高一階到 tertiary。 */
+  background: var(--tone-subtle, var(--color-tertiary));
   border: 1px solid var(--tone-bg, var(--color-border));
   border-radius: var(--radius-md);
   display: flex; flex-direction: column; gap: 12px;

--- a/src/components/trip/TripActionsMenu.tsx
+++ b/src/components/trip/TripActionsMenu.tsx
@@ -1,0 +1,261 @@
+/**
+ * TripActionsMenu — 行程動作「⋯」選單（editorial trip 詳情共用）。
+ *
+ * v2.57.x 抽出：原本只有 TripsListPage 的 embedded 詳情（/trips?selected=X）有這個選單
+ * （原名 EmbeddedActionMenu，local function，未 export）。owner 2026-07-21 回報「開了第三欄
+ * 面板後第二欄 header 的操作入口消失」——TripStackLayout（/trip/:id/collab 等 3 欄 host）
+ * 的中欄 TitleBar 從一開始就沒有接這組 actions（見 TripStackLayout.tsx 註解「不重造
+ * switcher/⋯ menu」的 scope cut）。owner 這輪要求補回，抽成共用元件讓 TripsListPage 與
+ * TripStackLayout 兩處中欄都能掛。行為/testid 與原 EmbeddedActionMenu 逐一對應，純搬移。
+ */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
+import Icon from '../shared/Icon';
+import type { TripPageHandle } from '../../pages/TripPage';
+
+const MENU_WIDTH = 200;
+const VIEWPORT_MARGIN = 8;
+/** menu 高度估算（首次 open menuRef 尚未量到時用；~6 項 × 44 + divider + padding）。 */
+const ESTIMATED_MENU_HEIGHT = 300;
+/** 底部保留高度（GlobalBottomNav ~56 + iOS safe-area + margin）— 往下展開不可侵入這區，否則選單被遮。 */
+const BOTTOM_SAFE_AREA = 96;
+
+export const TRIP_ACTIONS_MENU_STYLES = `
+.tp-embedded-menu {
+  position: fixed;
+  min-width: 200px;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: 4px;
+  z-index: var(--z-modal, 9000);
+  display: flex; flex-direction: column;
+  gap: 1px;
+}
+.tp-embedded-menu-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  border: none; background: transparent;
+  font: inherit; font-size: var(--font-size-callout);
+  color: var(--color-foreground);
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  min-height: 40px;
+}
+.tp-embedded-menu-item:hover { background: var(--color-hover); }
+.tp-embedded-menu-item:focus-visible {
+  outline: 2px solid var(--color-accent); outline-offset: -2px;
+}
+.tp-embedded-menu-item .svg-icon { width: 16px; height: 16px; flex-shrink: 0; color: var(--color-muted); }
+.tp-embedded-menu-divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 4px 0;
+}
+.tp-embedded-menu-section-label {
+  font-size: var(--font-size-caption2);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  padding: 6px 12px 2px;
+}
+`;
+
+export interface TripActionsMenuProps {
+  tripId: string;
+  tripPageRef: RefObject<TripPageHandle | null>;
+  onEdit: () => void;
+  onCollab: () => void;
+  onHealthCheck: () => void;
+  onNotes?: () => void;
+  onPrint?: () => void;
+  onShare?: () => void;
+}
+
+export default function TripActionsMenu({ tripId, tripPageRef, onEdit, onCollab, onHealthCheck, onNotes, onPrint, onShare }: TripActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    let rafId: number | null = null;
+    function recompute() {
+      const btn = triggerRef.current;
+      if (!btn) return;
+      const r = btn.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let left = r.right - MENU_WIDTH;
+      if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+      if (left + MENU_WIDTH > vw - VIEWPORT_MARGIN) left = vw - MENU_WIDTH - VIEWPORT_MARGIN;
+      // dropUp：往下展開若會被底部（bottom nav + safe area）遮 → 改往上展開（trigger 上方）。
+      const menuH = menuRef.current?.offsetHeight || ESTIMATED_MENU_HEIGHT;
+      const below = r.bottom + 6;
+      const dropUp = below + menuH > vh - BOTTOM_SAFE_AREA && r.top - menuH - 6 >= VIEWPORT_MARGIN;
+      setPos({ top: dropUp ? r.top - menuH - 6 : below, left });
+    }
+    function scheduleRecompute() {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        recompute();
+      });
+    }
+    recompute();
+    window.addEventListener('resize', scheduleRecompute, { passive: true });
+    window.addEventListener('scroll', scheduleRecompute, { capture: true, passive: true });
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', scheduleRecompute);
+      window.removeEventListener('scroll', scheduleRecompute, { capture: true });
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        triggerRef.current?.focus();
+      }
+    }
+    function onClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (menuRef.current && !menuRef.current.contains(target) && !triggerRef.current?.contains(target)) {
+        close();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onClick);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onClick);
+    };
+  }, [open, close]);
+
+  function runAndClose(fn: () => void) {
+    return () => { fn(); close(); };
+  }
+
+  const dropdown = open && pos ? createPortal((
+    <div
+      ref={menuRef}
+      role="menu"
+      className="tp-embedded-menu"
+      style={{ top: pos.top, left: pos.left }}
+      data-testid={`trip-embedded-menu-${tripId}`}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(onEdit)}
+        data-testid={`trip-embedded-menu-edit-${tripId}`}
+      >
+        <Icon name="edit" />
+        <span>編輯行程</span>
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(onCollab)}
+      >
+        <Icon name="group" />
+        <span>共編設定</span>
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(onHealthCheck)}
+        data-testid={`trip-embedded-menu-health-${tripId}`}
+      >
+        <Icon name="sparkle" />
+        <span>AI 健檢</span>
+      </button>
+      {onNotes && (
+        <button
+          type="button"
+          role="menuitem"
+          className="tp-embedded-menu-item"
+          onClick={runAndClose(onNotes)}
+          data-testid={`trip-embedded-menu-notes-${tripId}`}
+        >
+          <Icon name="file-text" />
+          <span>行程筆記</span>
+        </button>
+      )}
+      <div className="tp-embedded-menu-divider" />
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(() => (onPrint ? onPrint() : tripPageRef.current?.togglePrint()))}
+        data-testid={`trip-embedded-menu-print-${tripId}`}
+      >
+        <Icon name="printer" />
+        <span>列印</span>
+      </button>
+      {onShare && (
+        <button
+          type="button"
+          role="menuitem"
+          className="tp-embedded-menu-item"
+          onClick={runAndClose(onShare)}
+          data-testid={`trip-embedded-menu-share-${tripId}`}
+        >
+          <Icon name="copy" />
+          <span>分享連結</span>
+        </button>
+      )}
+      <div className="tp-embedded-menu-divider" />
+      <span className="tp-embedded-menu-section-label">下載格式</span>
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(() => tripPageRef.current?.triggerDownload('pdf'))}
+      >
+        <Icon name="download" />
+        <span>PDF</span>
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="tp-embedded-menu-item"
+        onClick={runAndClose(() => tripPageRef.current?.triggerDownload('json'))}
+      >
+        <Icon name="code" />
+        <span>JSON</span>
+      </button>
+    </div>
+  ), document.body) : null;
+
+  return (
+    <>
+      <style>{TRIP_ACTIONS_MENU_STYLES}</style>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="tp-titlebar-action tp-titlebar-action--icon-only"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="行程動作"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="trips-embedded-menu-trigger"
+      >
+        <Icon name="ellipsis" />
+      </button>
+      {dropdown}
+    </>
+  );
+}

--- a/src/components/trip/TripPageHost.tsx
+++ b/src/components/trip/TripPageHost.tsx
@@ -1,0 +1,97 @@
+/**
+ * TripPageHost — owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」的
+ * root-cause 修復。
+ *
+ * Root cause：`/trips?selected=X`（TripsListPage embedded 詳情，2-pane）與
+ * `/trip/:tripId/{edit|add-stop|...}`（TripStackLayout 中欄，3-pane）是兩個
+ * 完全獨立的頂層 Route element，過去各自 inline render 自己的 <TripPage>。
+ * 路由在這兩者之間切換時，React 必然 unmount 一份、mount 另一份 —— TripPage
+ * 內部沒有跨 mount 的 cache（無 react-query/SWR），重新 mount = 重新打 API，
+ * 使用者看到中欄短暫 loading（owner 講的「刷新」）。
+ *
+ * 修法：整個 app 只 render 一份 <TripPage>，掛在這裡（main.tsx 裡包住
+ * <Routes>，不是 <Routes> 的子路由）—— 不管 `/trips` 或 `/trip/:tripId/*`
+ * 怎麼切換，這個 host 本身從不 unmount，<TripPage> 也就不會被路由切換牽連著
+ * unmount。用 resolveDesktopMiddleColumnTripId 從目前 location 算出「桌機中欄
+ * 現在該顯示哪個 tripId」，只有 tripId 本身改變（使用者切去另一個行程）時才
+ * 透過 `key={tripId}` 讓它重新 mount（這才是真的該重新抓資料的情況）。
+ *
+ * <TripPage> 渲染結果透過 React Portal 掛進當下 host（TripsListPage 桌機分支 /
+ * TripStackLayout 中欄）留的 placeholder <div>。
+ *
+ * ⚠️ portal target 取得方式（push-based ref callback，非 pull-based 查詢）：
+ * 第一版讓 TripPage 自己 `document.getElementById(id)` + `useEffect` 依
+ * `location.pathname` 重查 —— playwright e2e 實測（非只憑推論）抓到 race：
+ * TripPage 的 effect 觸發時，新 host 的 placeholder 有時還沒 mount（兩者是各自
+ * 獨立的 subtree，沒有 render 順序保證），`getElementById` 撲空後就不會再重試，
+ * 中欄永遠空白。改用 TripMainPortalContext：host 的 placeholder
+ * `<div ref={(el) => setPortalNode(el)}>` 一 mount，React 在同一個 commit 內
+ * 同步呼叫這個 callback —— 不需要猜「另一邊是不是已經好了」。
+ *
+ * 手機不受影響：手機沒有「中欄」概念，各頁走整頁 drill-down、各自 inline
+ * render 自己的 <TripPage>（不消費這個 host，也不透過 TripPageHandleContext）。
+ * resolveDesktopMiddleColumnTripId 只在 isDesktop 時呼叫，手機下 tripId 恆為
+ * null，這裡完全不 render 任何東西。
+ */
+import { Suspense, useMemo, useRef, useState, type ForwardRefExoticComponent, type ReactNode, type RefAttributes } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { TripPageHandleContext } from '../../contexts/TripPageHandleContext';
+import { TripMainPortalContext } from '../../contexts/TripMainPortalContext';
+import { resolveDesktopMiddleColumnTripId } from '../../lib/tripStackRoutes';
+import { lazyWithRetry } from '../../lib/lazyWithRetry';
+import type { TripPageHandle, TripPageProps } from '../../pages/TripPage';
+
+// Lazy-load TripPage's heavy module graph (DndContext, drag-drop, print/export
+// libs …) — TripPageHost itself is always mounted (wraps <Routes> in main.tsx),
+// so a static import here would pull that whole graph into the main entry
+// chunk on every page load (chat/map/favorites/…), even when no trip is being
+// viewed. Matching the existing lazy-route convention keeps the dynamic
+// import() from firing until `tripId` actually resolves truthy below.
+//
+// lazyWithRetry's generic signature (`ComponentType<P>`) doesn't preserve the
+// forwardRef `ref` typing that TripPage's real (eager) consumers rely on —
+// React.lazy's own type only models plain function/class components. Cast
+// back to the actual forwardRef shape so `ref={tripPageRef}` below still
+// typechecks against TripPageHandle instead of a bogus Component instance.
+const TripPage = lazyWithRetry<TripPageProps>(() => import('../../pages/TripPage')) as unknown as
+  ForwardRefExoticComponent<TripPageProps & RefAttributes<TripPageHandle>>;
+
+export interface TripPageHostProps {
+  children: ReactNode;
+}
+
+export default function TripPageHost({ children }: TripPageHostProps) {
+  const location = useLocation();
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+  const tripPageRef = useRef<TripPageHandle>(null);
+  const [portalNode, setPortalNode] = useState<Element | null>(null);
+  // setPortalNode（useState setter）本身在 re-render 之間已保證 identity 穩定，
+  // 這裡用 useMemo 讓整個 context value object 也穩定 —— 否則每次 TripPageHost
+  // re-render（例如每次路由變化）都會產生新 object，讓消費這個 context 的 host
+  // （TripsListPage/TripStackLayout）跟著不必要 re-render。
+  const portalContextValue = useMemo(() => ({ setPortalNode }), [setPortalNode]);
+  const tripId = isDesktop
+    ? resolveDesktopMiddleColumnTripId(location.pathname, location.search)
+    : null;
+
+  return (
+    <TripMainPortalContext.Provider value={portalContextValue}>
+      <TripPageHandleContext.Provider value={tripPageRef}>
+        {children}
+        {tripId && (
+          <Suspense fallback={null}>
+            <TripPage
+              key={tripId}
+              ref={tripPageRef}
+              tripId={tripId}
+              noShell
+              usePortalMain
+              portalNode={portalNode}
+            />
+          </Suspense>
+        )}
+      </TripPageHandleContext.Provider>
+    </TripMainPortalContext.Provider>
+  );
+}

--- a/src/contexts/TripMainPortalContext.tsx
+++ b/src/contexts/TripMainPortalContext.tsx
@@ -1,0 +1,31 @@
+/**
+ * TripMainPortalContext — owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」修復。
+ *
+ * 修法沿革（第一版 v.s. 這版）：第一版讓 TripPage 自己用
+ * `document.getElementById(portalTargetId)` + `useEffect(..., [portalTargetId,
+ * location.pathname])` 去「找」目前的 portal placeholder —— 這是 pull-based
+ * polling，實測（playwright e2e，非只憑推論）發現真實瀏覽器下有 race：
+ * TripPage 的 effect 觸發時，新 host（TripsListPage / TripStackLayout）的
+ * placeholder <div> 有時還沒完成 mount（兩者是各自獨立的 lazy chunk / 獨立
+ * subtree，沒有 render 順序保證），`getElementById` 撲空後就再也不會重試，
+ * 導致內容永遠沒被 portal 進去（中欄整個空白，比「刷新」更嚴重）。
+ *
+ * 改用 push-based 的 callback ref：host 的 placeholder <div ref={setPortalNode}>
+ * 一 mount，React 在同一個 commit 內就同步呼叫這個 ref callback —— 不需要猜
+ * 「另一邊是不是已經好了」，命中率 100%。unmount 時 React 也會同步呼叫
+ * ref callback 帶 null，讓 TripPageHost 知道「目前沒有 host 在顯示」。
+ */
+import { createContext, useContext } from 'react';
+
+export interface TripMainPortalContextValue {
+  /** Host 的 placeholder <div> mount/unmount 時呼叫（React ref callback 語意）。 */
+  setPortalNode: (node: Element | null) => void;
+}
+
+const NOOP: TripMainPortalContextValue = { setPortalNode: () => {} };
+
+export const TripMainPortalContext = createContext<TripMainPortalContextValue>(NOOP);
+
+export function useTripMainPortal(): TripMainPortalContextValue {
+  return useContext(TripMainPortalContext);
+}

--- a/src/contexts/TripPageHandleContext.tsx
+++ b/src/contexts/TripPageHandleContext.tsx
@@ -1,0 +1,24 @@
+/**
+ * TripPageHandleContext — owner 2026-07-21 回報 #2 修復用。
+ *
+ * TripPageHost.tsx 是桌機唯一實際 render <TripPage> 的地方（見該檔），它自己持有
+ * 那份 TripPageHandle ref。TripsListPage（desktop embedded 詳情）與 TripStackLayout
+ * （中欄）不再各自 render <TripPage>，改只留 portal placeholder；但兩處的
+ * TripActionsMenu 仍需要一份 ref 呼叫「列印 / 下載」（見 TripActionsMenu 的
+ * tripPageRef prop）。這個 context 讓它們拿到 TripPageHost 持有的那一份 ref，
+ * 而不是各自建立、永遠不會被實際 <TripPage> attach 到的 dead ref。
+ *
+ * 手機不受影響 —— 手機各頁走整頁 drill-down，各自 inline render 自己的
+ * <TripPage ref={localRef}>，不消費這個 context（沒有 Provider 也安全：
+ * default value 是一個 no-op 的 { current: null }）。
+ */
+import { createContext, useContext, type RefObject } from 'react';
+import type { TripPageHandle } from '../pages/TripPage';
+
+const NOOP_REF: RefObject<TripPageHandle | null> = { current: null };
+
+export const TripPageHandleContext = createContext<RefObject<TripPageHandle | null>>(NOOP_REF);
+
+export function useTripPageHandle(): RefObject<TripPageHandle | null> {
+  return useContext(TripPageHandleContext);
+}

--- a/src/entries/main.tsx
+++ b/src/entries/main.tsx
@@ -35,6 +35,7 @@ import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from '
 import { ErrorBoundary } from '../components/shared/ErrorBoundary';
 import { NewTripProvider } from '../contexts/NewTripContext';
 import { ActiveTripProvider } from '../contexts/ActiveTripContext';
+import TripPageHost from '../components/trip/TripPageHost';
 import { Suspense, StrictMode } from 'react';
 import { useDarkMode } from '../hooks/useDarkMode';
 import { ServerStatusBanner } from '../components/ServerStatusBanner';
@@ -180,6 +181,11 @@ if (el) {
           <ServerStatusBanner />
           <ActiveTripProvider>
           <NewTripProvider>
+          {/* owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」修復：TripPageHost
+              必須是整個 route table 的祖先（不是子路由），路由在 /trips?selected=X ↔
+              /trip/:id/{edit|...} 之間切換時它才不會被牽連著 unmount —— 見
+              src/components/trip/TripPageHost.tsx 檔頭註解。 */}
+          <TripPageHost>
           <Suspense fallback={<div style={FALLBACK_STYLE}>載入中…</div>}>
             <Routes>
               {/* `/` 改指向未登入首頁。改版前落到 path="*" → LegacyRedirect → /trips → /login，
@@ -279,6 +285,7 @@ if (el) {
               <Route path="*" element={<LegacyRedirect />} />
             </Routes>
           </Suspense>
+          </TripPageHost>
           </NewTripProvider>
           </ActiveTripProvider>
         </BrowserRouter>

--- a/src/lib/tripStackRoutes.ts
+++ b/src/lib/tripStackRoutes.ts
@@ -1,0 +1,58 @@
+/**
+ * tripStackRoutes — owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」的
+ * root-cause 修復用：判斷「桌機中欄現在該顯示哪個 tripId」的純函式。
+ *
+ * Context：`/trips?selected=X`（TripsListPage embedded 詳情，2-pane）與
+ * `/trip/:tripId/{edit|add-stop|...}`（TripStackLayout 中欄，3-pane）過去是
+ * 兩個完全獨立的頂層 Route element，各自 inline render 一份 <TripPage>。
+ * 路由切換時 React 必然 unmount 一份、mount 另一份 → TripPage 內部 useTrip
+ * 重新打 API，中欄可見的 loading 閃爍（owner 講的「刷新」）。
+ *
+ * 修法（見 TripPageHost.tsx）：整個 app 只 render 一份 <TripPage>，掛在
+ * <Routes> 之上、不受路由切換影響，用這支函式從目前 location 算出「該顯示
+ * 哪個 tripId」，並把渲染結果 portal 進當下 host 留的 placeholder div。
+ *
+ * 這支函式必須跟 src/entries/main.tsx 的 route 表同步 —— 見
+ * tests/unit/trip-stack-routes.test.ts 對 main.tsx 原始碼做 cross-check，
+ * 避免之後加/刪操作路由時，這裡的清單悄悄跟 route 表脫鉤。
+ */
+
+/**
+ * TripStackLayout 底下「操作面板」的 9 條相對路徑（相對於 /trip/:tripId/）。
+ * 對應 src/entries/main.tsx 的 `<Route element={<TripStackLayout />}>` 區塊。
+ */
+export const TRIP_STACK_OPERATION_PATTERNS: readonly RegExp[] = [
+  /^edit$/,
+  /^add-stop$/,
+  /^add-entry$/,
+  /^collab$/,
+  /^health$/,
+  /^notes$/,
+  /^stop\/[^/]+\/copy$/,
+  /^stop\/[^/]+\/move$/,
+  /^stop\/[^/]+\/change-poi$/,
+  /^stop\/[^/]+\/edit$/,
+] as const;
+
+/** 桌機中欄的 <TripPage> 共用 portal target id（TripsListPage 與 TripStackLayout 共用）。 */
+export const TRIP_MAIN_PORTAL_ID = 'trip-main-portal';
+
+/**
+ * 算出「桌機中欄現在該顯示哪個 tripId」，null = 不該顯示（非 trip 相關頁、
+ * 或該頁面本身就是獨立整頁如 /trip/:id/map、/trip/:id/print，不經過中欄）。
+ *
+ * 只在桌機呼叫 —— 手機沒有「中欄」概念（各頁整頁 drill-down），呼叫端自行
+ * 以 isDesktop 為 gate（見 TripPageHost.tsx），這支函式本身不管 viewport。
+ */
+export function resolveDesktopMiddleColumnTripId(pathname: string, search: string): string | null {
+  if (pathname === '/trips') {
+    return new URLSearchParams(search).get('selected');
+  }
+  const match = pathname.match(/^\/trip\/([^/]+)\/(.+)$/);
+  if (!match) return null;
+  const tripId = match[1];
+  const rest = match[2];
+  if (!tripId || !rest) return null;
+  const isOperationRoute = TRIP_STACK_OPERATION_PATTERNS.some((re) => re.test(rest));
+  return isOperationRoute ? tripId : null;
+}

--- a/src/pages/AddEntryPage.tsx
+++ b/src/pages/AddEntryPage.tsx
@@ -42,6 +42,12 @@ const SCOPED_STYLES = `
   overflow-y: auto;
   display: flex; flex-direction: column;
 }
+/* owner 2026-07-21（第二輪回報 #5）：桌機第三欄面板要跟新遷入的共編/健檢/筆記
+ * 3 頁一樣套 tertiary elevation（見 AppShell.tsx .app-shell-sheet 註解 + CollabPage
+ * 同型 override）。手機整頁 drill-down 不受影響，仍是上面的 --color-background。 */
+.app-shell-sheet .tp-add-entry-shell {
+  background: var(--color-tertiary);
+}
 .tp-add-entry-body {
   flex: 1;
   padding: 24px 20px 96px;

--- a/src/pages/AddStopPage.tsx
+++ b/src/pages/AddStopPage.tsx
@@ -156,6 +156,12 @@ const SCOPED_STYLES = `
   display: flex;
   flex-direction: column;
 }
+/* owner 2026-07-21（第二輪回報 #5）：桌機第三欄面板要跟新遷入的共編/健檢/筆記
+ * 3 頁一樣套 tertiary elevation（見 AppShell.tsx .app-shell-sheet 註解 + CollabPage
+ * 同型 override）。手機整頁 drill-down 不受影響，仍是上面的 --color-background。 */
+.app-shell-sheet .tp-add-stop-page-shell {
+  background: var(--color-tertiary);
+}
 .tp-add-stop-page-day-meta {
   font-size: var(--font-size-footnote);
   color: var(--color-muted);

--- a/src/pages/ChangePoiPage.tsx
+++ b/src/pages/ChangePoiPage.tsx
@@ -55,6 +55,12 @@ const SCOPED_STYLES = `
   flex-direction: column;
   background: var(--color-background);
 }
+/* owner 2026-07-21（第二輪回報 #5）：桌機第三欄面板要跟新遷入的共編/健檢/筆記
+ * 3 頁一樣套 tertiary elevation（見 AppShell.tsx .app-shell-sheet 註解 + CollabPage
+ * 同型 override）。手機整頁 drill-down 不受影響，仍是上面的 --color-background。 */
+.app-shell-sheet .tp-change-poi-page-shell {
+  background: var(--color-tertiary);
+}
 .tp-change-poi-tabs {
   display: flex;
   padding: 0 20px;

--- a/src/pages/EditTripPage.tsx
+++ b/src/pages/EditTripPage.tsx
@@ -139,6 +139,12 @@ const SCOPED_STYLES = `
   height: 100%;
   overflow-y: auto;
 }
+/* owner 2026-07-21（第二輪回報 #5）：桌機第三欄面板要跟新遷入的共編/健檢/筆記
+ * 3 頁一樣套 tertiary elevation（見 AppShell.tsx .app-shell-sheet 註解 + CollabPage
+ * 同型 override）。手機整頁 drill-down 不受影響，仍是上面的 --color-secondary。 */
+.app-shell-sheet .tp-edit-page-shell {
+  background: var(--color-tertiary);
+}
 .tp-edit-page-form {
   max-width: 720px;
   margin: 0 auto;

--- a/src/pages/EntryActionPage.tsx
+++ b/src/pages/EntryActionPage.tsx
@@ -76,6 +76,12 @@ const SCOPED_STYLES = `
   height: 100%;
   overflow-y: auto;
 }
+/* owner 2026-07-21（第二輪回報 #5）：桌機第三欄面板要跟新遷入的共編/健檢/筆記
+ * 3 頁一樣套 tertiary elevation（見 AppShell.tsx .app-shell-sheet 註解 + CollabPage
+ * 同型 override）。手機整頁 drill-down 不受影響，仍是上面的 --color-secondary。 */
+.app-shell-sheet .tp-entry-action-shell {
+  background: var(--color-tertiary);
+}
 .tp-entry-action-content {
   max-width: 720px;
   margin: 0 auto;

--- a/src/pages/TripPage.tsx
+++ b/src/pages/TripPage.tsx
@@ -90,18 +90,25 @@ const SCOPED_STYLES = `
 .day-content-loaded {
   animation: fadeIn 300ms var(--transition-timing-function-apple) both;
 }
-/* 內容欄的表面（owner 2026-07-21：「桌機行程功能黑色太多」）。
+/* 內容欄的表面（owner 2026-07-21：「桌機行程功能黑色太多」，第二輪回報「兩側仍深黑」）。
  *
- * browse 對 prod 深色實測：行程頁有 16,091k px2 的透明面積壓在單一
- * .app-shell 的 #1C1C1E 上 —— 整片內容區沒有自己的表面，於是全糊成一塊近黑。
- * 相對地 /trips 的 .tp-trips-shell 早就用 --color-secondary 抬起來了
- * （實測 #2C2C2E，1093k），所以那頁沒這問題。
+ * v2.57.9 在 .trip-content 補了 --color-secondary，但 .trip-content 只是 .tp-page
+ * （padding 40px + max-width 1440px 置中）內的一個窄框 —— DayNav / offline banner 等
+ * 兄弟元素、以及 .tp-page 自己的左右 padding 區，全都還透出 .app-shell-main 底下
+ * .app-shell 的 base 深色。「中間淺一階、兩側還是深黑」的截圖就是這個窄框造成的。
  *
- * 這裡不是發明新規則，是補上這個 app 自己已有的做法：內容欄抬一階，
- * 與 .app-shell 的 base 之間才讀得出層次。Apple HIG 的深色模式正是靠
- * elevation 分層（#1C1C1E → #2C2C2E → #3A3A3C），不是把亮色反過來。 */
+ * 對照 /trips 的 .tp-trips-shell：那份 elevation 是上在最外層（跟 .tp-shell 同級），
+ * 整片欄寬都著色，所以沒有這個 band 問題。這裡照抄同一個既有 pattern —— 把 elevation
+ * 移到 TripPage 的最外層（見下方 .tp-shell.tp-trip-page-shell），而不是只上在內層窄框。
+ * .trip-content 自己不再重複宣告背景（外層已整片上色，這裡重複同色是 no-op）。 */
 .trip-content {
   min-width: 0;
+}
+/* 疊在全域 .tp-shell（tokens.css，background: var(--color-background)）之上；兩個
+ * class 的組合選擇器特異度大於單一 class，不受 import 順序影響一定覆蓋成功。
+ * TripPage 現在永遠 noShell=true（embedded），這個 outer div 就是中欄/embedded 詳情
+ * 唯一涵蓋整個欄寬的節點，在這裡上色才能讓兩側 padding 區、DayNav 等都被涵蓋到。 */
+.tp-shell.tp-trip-page-shell {
   background: var(--color-secondary);
 }
 
@@ -203,6 +210,23 @@ export interface TripPageProps {
    * skip the AppShell wrapper, sidebar, sheet, bottomNav. The hosting page
    * provides those. */
   noShell?: boolean;
+  /**
+   * owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」修復：桌機由
+   * TripPageHost.tsx render 唯一一份持續存在的 <TripPage>（不受路由切換
+   * unmount），用 React Portal 把 main content 掛進當下 host（TripsListPage
+   * 桌機分支 / TripStackLayout 中欄）留的 placeholder <div>。
+   *
+   * 傳 `usePortalMain: true` 才會進入 portal 模式 —— `portalNode` 由呼叫端
+   * （TripPageHost）透過 TripMainPortalContext 的 callback ref 拿到，可能暫時是
+   * null（host 正在切換、placeholder 還沒 mount）。portal 模式下 null 就先不
+   * render 任何東西（避免內容顯示在錯的地方），等 ref callback 給到實際 node
+   * 才 portal 進去 —— 這是 push-based（React ref callback 在 commit 內同步
+   * 觸發），不是 pull-based 的 document.getElementById 猜測（第一版曾用這招，
+   * playwright e2e 實測抓到 race：找不到就永遠不會重試，中欄整個空白）。
+   * 不傳 usePortalMain → 維持原本 inline render（手機各頁、既有呼叫端不受影響）。
+   */
+  usePortalMain?: boolean;
+  portalNode?: Element | null;
 }
 
 /* PR-SS/UU 2026-04-27：embedded mode 用 ref 從外部 trigger 各 actions。
@@ -217,7 +241,7 @@ export interface TripPageHandle {
 }
 
 function TripPageInner(
-  { tripId: propTripId, noShell = false }: TripPageProps,
+  { tripId: propTripId, noShell = false, usePortalMain = false, portalNode = null }: TripPageProps,
   ref: React.Ref<TripPageHandle>,
 ) {
   const { tripId: urlTripId } = useParams<{ tripId: string }>();
@@ -826,7 +850,7 @@ function TripPageInner(
   ) : undefined;
 
   const mainContent = (
-    <div className="tp-shell">
+    <div className="tp-shell tp-trip-page-shell">
       <style>{SCOPED_STYLES}</style>
 
       {/* v2.17.17:TripPage 永遠透過 TripsListPage embedded mode 渲染(noShell=true)
@@ -952,7 +976,13 @@ function TripPageInner(
   if (noShell) {
     return (
       <>
-        {wrappedMain}
+        {/* owner 2026-07-21 #2：usePortalMain 時把 main content portal 到 host 給的
+         * portalNode（TripPageHost 是唯一呼叫端）；portalNode 暫時是 null（host 正在
+         * 切換、callback ref 還沒 fire）就先不 render 任何東西，等它到位才 portal，
+         * 不會把內容顯示在錯的地方。不傳 usePortalMain 維持原本 inline render
+         * （既有呼叫端，如 TripsListPage 手機分支，完全不受影響）。 */}
+        {!usePortalMain && wrappedMain}
+        {usePortalMain && portalNode ? createPortal(wrappedMain, portalNode) : null}
         {sheetPortalNode && sheetContent && createPortal(sheetContent, sheetPortalNode)}
       </>
     );

--- a/src/pages/TripStackLayout.tsx
+++ b/src/pages/TripStackLayout.tsx
@@ -1,6 +1,6 @@
 /**
  * TripStackLayout — rev2 桌機右欄操作堆疊 host（owner 2026-07-18「一次到位：6 條全接」，
- * 2026-07-21 補中欄 TitleBar）。
+ * 2026-07-21 補中欄 TitleBar，2026-07-21 第二輪補中欄 actions）。
  *
  * pathless layout route，掛在 TripLayout（TripContext provider）底下、包住操作路由
  * （加景點/新增/複製移動/換景點/編輯 entry/編輯行程 + v2.57.x 遷入的共編設定/AI 健檢/行程筆記）。
@@ -15,22 +15,45 @@
  * 中欄 TitleBar（v2.57.x 新增）：owner 2026-07-21「開啟第三欄時第二欄 header 不要消失」——
  * 2026-07-19 原決策「中欄無 titlebar」（見 tokens.css `.tp-stack-mid` 註解）在此補回一個輕量
  * 版本（行程名稱 + 返回）。返回 action 直接用 closeStack（與右欄 ✕ 同語意 —— 兩者都是「離開
- * 這個操作堆疊，回到 /trips?selected=:id 的一般行程檢視」），不重造 TripsListPage 那套完整
- * switcher/⋯ menu（範圍見 docs/design-sessions/2026-07-21-desktop-third-column-panelization.html
- * 「已知取捨」段）。trip 名稱讀 TripLayout 已提供的 TripContext，免多打一次 API。
+ * 這個操作堆疊，回到 /trips?selected=:id 的一般行程檢視」）。
+ *
+ * 中欄 actions（v2.57.x 第二輪，owner 回報 #1「第三欄開啟後第二欄操作入口消失」）：
+ * 第一版刻意只放標題 + 返回、不重造 TripsListPage 的完整 switcher/⋯ menu ——結果就是
+ * 開了任一操作面板（含新遷入的共編/健檢/筆記）之後，使用者原本在 /trips?selected=X
+ * 就有的「新增景點 / 編輯行程 / 共編設定 / AI 健檢 / 行程筆記 / 列印 / 分享連結 / 下載」
+ * 全部不見。這裡把 TripsListPage embedded 詳情用的 TripActionsMenu（v2.57.x 從
+ * TripsListPage 的 EmbeddedActionMenu 抽出共用）接回中欄 TitleBar，行為與 TripsListPage
+ * 那份完全一致（同一元件、同 testid），只是不重做 TripTitleSwitcher（切換行程已有
+ * DesktopSidebar 的「我的行程」清單可用，不重複）。
+ *
+ * trip 名稱讀 TripLayout 已提供的 TripContext，免多打一次 API。
+ *
+ * 中欄 <TripPage>（v2.57.x 第三輪，owner 回報 #2「開關第三欄面板會刷新第二欄」）：
+ * 不再由這裡 inline render —— 那正是路由在 /trips?selected=X ↔
+ * /trip/:id/{edit|...} 之間切換時造成 TripPage unmount/remount（=中欄刷新）的
+ * root cause 之一。改留一個 portal placeholder（callback ref 交給
+ * TripMainPortalContext），main.tsx 的 TripPageHost（唯一持續存在、掛在
+ * <Routes> 之上的 <TripPage> 實例）會把內容 portal 進來。TripActionsMenu 需要的
+ * tripPageRef 也改從 TripPageHandleContext 拿 TripPageHost 持有的那一份
+ * （不再自己建立一個永遠不會被 attach 的 dead ref）。
  */
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { SheetStackProvider } from '../contexts/SheetStackContext';
 import { TripContext } from '../contexts/TripContext';
+import { useTripPageHandle } from '../contexts/TripPageHandleContext';
+import { useTripMainPortal } from '../contexts/TripMainPortalContext';
+import { TRIP_MAIN_PORTAL_ID } from '../lib/tripStackRoutes';
 import { routes } from '../lib/routes';
 import AppShell from '../components/shell/AppShell';
 import DesktopSidebarConnected from '../components/shell/DesktopSidebarConnected';
 import GlobalBottomNav from '../components/shell/GlobalBottomNav';
 import TitleBar from '../components/shell/TitleBar';
-import TripPage from './TripPage';
+import Icon from '../components/shared/Icon';
+import TripActionsMenu from '../components/trip/TripActionsMenu';
+import ShareLinkModal from '../components/share/ShareLinkModal';
 
 export default function TripStackLayout() {
   const { tripId } = useParams<{ tripId: string }>();
@@ -38,6 +61,9 @@ export default function TripStackLayout() {
   const navigate = useNavigate();
   const { user } = useCurrentUser();
   const tripCtx = useContext(TripContext);
+  const tripPageRef = useTripPageHandle();
+  const { setPortalNode } = useTripMainPortal();
+  const [shareTripId, setShareTripId] = useState<string | null>(null);
   const valid = tripId && /^[\w-]+$/.test(tripId) ? tripId : null;
 
   // ✕「整個關閉」回行程詳情（桌機+手機共用）。replace → 關閉後瀏覽器上一頁不會又把
@@ -71,13 +97,44 @@ export default function TripStackLayout() {
         sidebar={<DesktopSidebarConnected />}
         main={valid ? (
           <div className="tp-stack-mid">
-            <TitleBar title={tripTitle} back={closeStack} backLabel="返回行程列表" />
-            <TripPage tripId={valid} noShell />
+            <TitleBar
+              title={tripTitle}
+              back={closeStack}
+              backLabel="返回行程列表"
+              actions={(
+                <>
+                  <button
+                    type="button"
+                    className="tp-titlebar-action tp-titlebar-action--icon-only"
+                    onClick={() => navigate(`/trip/${encodeURIComponent(valid)}/add-entry`)}
+                    aria-label="新增景點"
+                    title="新增景點"
+                    data-testid="trip-add-stop-trigger"
+                  >
+                    <Icon name="plus" />
+                  </button>
+                  <TripActionsMenu
+                    tripId={valid}
+                    tripPageRef={tripPageRef}
+                    onEdit={() => navigate(routes.tripEdit(valid))}
+                    onCollab={() => navigate(routes.tripCollab(valid))}
+                    onHealthCheck={() => navigate(routes.tripHealth(valid))}
+                    onNotes={() => navigate(`/trip/${encodeURIComponent(valid)}/notes`)}
+                    onPrint={() => navigate(`/trip/${encodeURIComponent(valid)}/print`)}
+                    onShare={() => setShareTripId(valid)}
+                  />
+                </>
+              )}
+            />
+            <div ref={setPortalNode} data-testid={TRIP_MAIN_PORTAL_ID} />
           </div>
         ) : null}
         sheet={<Outlet />}
         bottomNav={<GlobalBottomNav authed={user !== null} />}
       />
+      {shareTripId && (
+        <ShareLinkModal tripId={shareTripId} open onClose={() => setShareTripId(null)} />
+      )}
     </SheetStackProvider>
   );
 }

--- a/src/pages/TripsListPage.tsx
+++ b/src/pages/TripsListPage.tsx
@@ -20,8 +20,7 @@
  *     metadata，但那支對一般使用者降級成 published-only，行程改為不公開後
  *     名稱全空 → 卡片顯示 tripId。單一來源即可。
  */
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useCurrentUser } from '../hooks/useCurrentUser';
@@ -40,6 +39,7 @@ import TitleBar from '../components/shell/TitleBar';
 import AccountCircle from '../components/shell/AccountCircle';
 import TripCardMenu from '../components/trip/TripCardMenu';
 import ShareLinkModal from '../components/share/ShareLinkModal';
+import TripActionsMenu from '../components/trip/TripActionsMenu';
 // v2.18.0:CollabSheet → CollabPage(獨立路由),InfoSheet wrapper 移除
 import Icon from '../components/shared/Icon';
 import ToastContainer, { showToast } from '../components/shared/Toast';
@@ -47,6 +47,9 @@ import ConfirmModal from '../components/shared/ConfirmModal';
 import ErrorBanner from '../components/shared/ErrorBanner';
 import { TripSelect } from '../components/TripSelect';
 import TripPage, { type TripPageHandle } from './TripPage';
+import { useTripPageHandle } from '../contexts/TripPageHandleContext';
+import { useTripMainPortal } from '../contexts/TripMainPortalContext';
+import { TRIP_MAIN_PORTAL_ID } from '../lib/tripStackRoutes';
 import { useActiveTrip } from '../contexts/ActiveTripContext';
 
 const SCOPED_STYLES = `
@@ -85,47 +88,8 @@ const SCOPED_STYLES = `
   display: block;
   min-height: 100%;
 }
-.tp-embedded-menu {
-  position: fixed;
-  min-width: 200px;
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
-  padding: 4px;
-  z-index: var(--z-modal, 9000);
-  display: flex; flex-direction: column;
-  gap: 1px;
-}
-.tp-embedded-menu-item {
-  display: flex; align-items: center; gap: 10px;
-  padding: 10px 12px;
-  border: none; background: transparent;
-  font: inherit; font-size: var(--font-size-callout);
-  color: var(--color-foreground);
-  text-align: left;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  min-height: 40px;
-}
-.tp-embedded-menu-item:hover { background: var(--color-hover); }
-.tp-embedded-menu-item:focus-visible {
-  outline: 2px solid var(--color-accent); outline-offset: -2px;
-}
-.tp-embedded-menu-item .svg-icon { width: 16px; height: 16px; flex-shrink: 0; color: var(--color-muted); }
-.tp-embedded-menu-divider {
-  height: 1px;
-  background: var(--color-border);
-  margin: 4px 0;
-}
-.tp-embedded-menu-section-label {
-  font-size: var(--font-size-caption2);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-  padding: 8px 12px 4px;
-}
+/* .tp-embedded-menu* 樣式已抽到 TripActionsMenu.tsx（TRIP_ACTIONS_MENU_STYLES），
+ * 該元件自己 render <style>，這裡不再重複定義。 */
 @media (min-width: 1024px) {
   .tp-trips-grid {
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
@@ -588,210 +552,8 @@ function cardMeta(trip: TripInfo): string {
   return '';
 }
 
-const MENU_WIDTH = 200;
-const VIEWPORT_MARGIN = 8;
-/** menu 高度估算（首次 open menuRef 尚未量到時用；~6 項 × 44 + divider + padding）。 */
-const ESTIMATED_MENU_HEIGHT = 300;
-/** 底部保留高度（GlobalBottomNav ~56 + iOS safe-area + margin）— 往下展開不可侵入這區，否則選單被遮。 */
-const BOTTOM_SAFE_AREA = 96;
-
-interface EmbeddedActionMenuProps {
-  tripId: string;
-  tripPageRef: React.RefObject<TripPageHandle | null>;
-  onEdit: () => void;
-  onCollab: () => void;
-  onHealthCheck: () => void;
-  onNotes?: () => void;
-  onPrint?: () => void;
-  onShare?: () => void;
-}
-
-function EmbeddedActionMenu({ tripId, tripPageRef, onEdit, onCollab, onHealthCheck, onNotes, onPrint, onShare }: EmbeddedActionMenuProps) {
-  const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const close = useCallback(() => setOpen(false), []);
-
-  useLayoutEffect(() => {
-    if (!open) return;
-    let rafId: number | null = null;
-    function recompute() {
-      const btn = triggerRef.current;
-      if (!btn) return;
-      const r = btn.getBoundingClientRect();
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
-      let left = r.right - MENU_WIDTH;
-      if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
-      if (left + MENU_WIDTH > vw - VIEWPORT_MARGIN) left = vw - MENU_WIDTH - VIEWPORT_MARGIN;
-      // dropUp：往下展開若會被底部（bottom nav + safe area）遮 → 改往上展開（trigger 上方）。
-      // 靠列表底部的卡片 menu 原本固定 r.bottom+6 往下、超出可視區被 nav 蓋住（QA 截圖）。
-      const menuH = menuRef.current?.offsetHeight || ESTIMATED_MENU_HEIGHT;
-      const below = r.bottom + 6;
-      const dropUp = below + menuH > vh - BOTTOM_SAFE_AREA && r.top - menuH - 6 >= VIEWPORT_MARGIN;
-      setPos({ top: dropUp ? r.top - menuH - 6 : below, left });
-    }
-    // rAF coalesce — scroll/resize 高頻 fire 時合併到單一 frame，避免 long
-    // timeline scroll 時 getBoundingClientRect + setState 每 ms 跑造成 jank。
-    function scheduleRecompute() {
-      if (rafId !== null) return;
-      rafId = requestAnimationFrame(() => {
-        rafId = null;
-        recompute();
-      });
-    }
-    recompute();
-    window.addEventListener('resize', scheduleRecompute, { passive: true });
-    window.addEventListener('scroll', scheduleRecompute, { capture: true, passive: true });
-    return () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      window.removeEventListener('resize', scheduleRecompute);
-      window.removeEventListener('scroll', scheduleRecompute, { capture: true });
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        close();
-        triggerRef.current?.focus();
-      }
-    }
-    function onClick(e: MouseEvent) {
-      const target = e.target as Node;
-      if (menuRef.current && !menuRef.current.contains(target) && !triggerRef.current?.contains(target)) {
-        close();
-      }
-    }
-    window.addEventListener('keydown', onKey);
-    window.addEventListener('mousedown', onClick);
-    return () => {
-      window.removeEventListener('keydown', onKey);
-      window.removeEventListener('mousedown', onClick);
-    };
-  }, [open, close]);
-
-  function runAndClose(fn: () => void) {
-    return () => { fn(); close(); };
-  }
-
-  const dropdown = open && pos ? createPortal((
-    <div
-      ref={menuRef}
-      role="menu"
-      className="tp-embedded-menu"
-      style={{ top: pos.top, left: pos.left }}
-      data-testid={`trip-embedded-menu-${tripId}`}
-    >
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(onEdit)}
-        data-testid={`trip-embedded-menu-edit-${tripId}`}
-      >
-        <Icon name="edit" />
-        <span>編輯行程</span>
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(onCollab)}
-      >
-        <Icon name="group" />
-        <span>共編設定</span>
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(onHealthCheck)}
-        data-testid={`trip-embedded-menu-health-${tripId}`}
-      >
-        <Icon name="sparkle" />
-        <span>AI 健檢</span>
-      </button>
-      {onNotes && (
-        <button
-          type="button"
-          role="menuitem"
-          className="tp-embedded-menu-item"
-          onClick={runAndClose(onNotes)}
-          data-testid={`trip-embedded-menu-notes-${tripId}`}
-        >
-          <Icon name="file-text" />
-          <span>行程筆記</span>
-        </button>
-      )}
-      <div className="tp-embedded-menu-divider" />
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(() => (onPrint ? onPrint() : tripPageRef.current?.togglePrint()))}
-        data-testid={`trip-embedded-menu-print-${tripId}`}
-      >
-        <Icon name="printer" />
-        <span>列印</span>
-      </button>
-      {onShare && (
-        <button
-          type="button"
-          role="menuitem"
-          className="tp-embedded-menu-item"
-          onClick={runAndClose(onShare)}
-          data-testid={`trip-embedded-menu-share-${tripId}`}
-        >
-          <Icon name="copy" />
-          <span>分享連結</span>
-        </button>
-      )}
-      <div className="tp-embedded-menu-divider" />
-      <span className="tp-embedded-menu-section-label">下載格式</span>
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(() => tripPageRef.current?.triggerDownload('pdf'))}
-      >
-        <Icon name="download" />
-        <span>PDF</span>
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        className="tp-embedded-menu-item"
-        onClick={runAndClose(() => tripPageRef.current?.triggerDownload('json'))}
-      >
-        <Icon name="code" />
-        <span>JSON</span>
-      </button>
-    </div>
-  ), document.body) : null;
-
-  return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="tp-titlebar-action tp-titlebar-action--icon-only"
-        onClick={() => setOpen((v) => !v)}
-        aria-label="行程動作"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        data-testid="trips-embedded-menu-trigger"
-      >
-        <Icon name="ellipsis" />
-      </button>
-      {dropdown}
-    </>
-  );
-}
+// EmbeddedActionMenu（行程動作「⋯」選單）v2.57.x 抽到 ../components/trip/TripActionsMenu
+// 供 TripStackLayout 共用（owner「第三欄開啟後第二欄 header actions 消失」）。
 
 export default function TripsListPage() {
   useRequireAuth();
@@ -970,7 +732,16 @@ export default function TripsListPage() {
     setSearchParams(next, { replace: false });
   }
 
-  const tripPageRef = useRef<TripPageHandle>(null);
+  // owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」修復：桌機不再 inline
+  // render <TripPage>（見下方 embedded main JSX）—— main.tsx 的 TripPageHost 是
+  // 唯一持續存在的實例，其 ref 透過 TripPageHandleContext 往下發，這裡 desktop
+  // 用該 ref；手機仍 inline render 自己的 <TripPage>，繼續用 localTripPageRef。
+  const localTripPageRef = useRef<TripPageHandle>(null);
+  const sharedTripPageRef = useTripPageHandle();
+  const tripPageRef = isDesktop ? sharedTripPageRef : localTripPageRef;
+  // portal placeholder 的 callback ref —— TripPageHost 持有的 <TripPage> 靠這個
+  // 知道「現在該把內容 portal 去哪」（push-based，見 TripMainPortalContext 註解）。
+  const { setPortalNode } = useTripMainPortal();
   const handleMenuCollab = useCallback(
     (tripId: string) => { navigate(`/trip/${encodeURIComponent(tripId)}/collab`); },
     [navigate],
@@ -1330,7 +1101,7 @@ export default function TripsListPage() {
             >
               <Icon name="plus" />
             </button>
-            <EmbeddedActionMenu
+            <TripActionsMenu
               tripId={effectiveSelectedId}
               tripPageRef={tripPageRef}
               onEdit={() => navigate(`/trip/${encodeURIComponent(effectiveSelectedId)}/edit`)}
@@ -1343,7 +1114,17 @@ export default function TripsListPage() {
           </>
         )}
       />
-      <TripPage ref={tripPageRef} tripId={effectiveSelectedId!} noShell />
+      {/* owner 2026-07-21 回報 #2：桌機只留 portal placeholder，main.tsx 的
+          TripPageHost（唯一持續存在的 <TripPage>）會把內容 portal 進來 ——
+          路由切換到 /trip/:id/edit 等操作面板時，這個 placeholder 會跟著
+          TripsListPage 一起 unmount，但 TripPage 本身（掛在 TripPageHost，
+          <Routes> 之上）不受影響，不會重新抓資料。手機沒有這個機制，維持
+          原本 inline render（tripPageRef 此時是 localTripPageRef）。 */}
+      {isDesktop ? (
+        <div ref={setPortalNode} data-testid={TRIP_MAIN_PORTAL_ID} />
+      ) : (
+        <TripPage ref={localTripPageRef} tripId={effectiveSelectedId!} noShell />
+      )}
     </div>
   ) : cardGridMain;
 

--- a/tests/e2e/trip-stack-no-remount.spec.js
+++ b/tests/e2e/trip-stack-no-remount.spec.js
@@ -1,0 +1,86 @@
+// @ts-check
+/**
+ * 桌機第三欄面板 no-remount E2E — owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」。
+ *
+ * Root cause 修復（見 src/components/trip/TripPageHost.tsx）：整個 app 只 render 一份
+ * <TripPage>，掛在 <Routes> 之上，路由在 /trips?selected=X ↔ /trip/:id/{edit|...} 之間
+ * 切換不再讓它 unmount/remount。這支 e2e 從「使用者可觀察的行為」驗證，而非只信任 unit
+ * test 的 mount-count 斷言 —— coordinator 明確要求：用實際畫面/network 驗證，不是只推論。
+ *
+ * 驗證兩件事：
+ *   1. 「關閉操作面板、回到 /trips?selected=X」不會讓中欄重新抓一次行程資料。
+ *      （「開啟」面板那一刻其實還有一個已知、獨立於本次修復的次要行為：
+ *      TripLayout 自己也 useTrip(tripId)，供中欄 TitleBar 的行程名稱使用
+ *      （見 src/pages/TripLayout.tsx，未被本次改動觸及）——每次進入任一
+ *      /trip/:id/* 操作路由都會讓 TripLayout 重新 mount 一次，因此多打一次
+ *      /days（只影響 TitleBar 文字，不影響中欄實際行程內容，而行程內容才是
+ *      owner 回報「刷新」真正在講的東西）。這是預先存在、獨立的次要議題，
+ *      不在本次 #2 修復範圍內，這裡誠實地把驗證焦點放在「關閉不再多打」而非
+ *      「開啟全程只打一次」。）
+ *   2. 深連結（直接打開 /trip/:id/edit）仍正常渲染 —— 這是 param→prop 改造最容易壞掉的地方。
+ */
+import { test, expect } from '@playwright/test';
+const { setupApiMocks } = require('./api-mocks');
+
+const TRIP_ID = 'okinawa-trip-2026-Ray';
+
+test.beforeEach(async ({ page }) => {
+  await setupApiMocks(page);
+});
+
+test.describe('TripPageHost — 開關第三欄面板不重新抓中欄行程資料', () => {
+  test('桌機：/trips?selected=X → 開啟編輯行程面板 → 關閉，關閉這一步不再多打 days API', async ({ page }) => {
+    test.skip(test.info().project.name !== 'chromium', '只需一個桌機 viewport 驗證，避免重複跑');
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    // useTrip() 打 GET /api/trips/:id/days?all=1（見 src/hooks/useTrip.ts）——
+    // remount 時這支會被重新呼叫一次；no-remount 修好後開關面板不該再多打。
+    const daysRequests = [];
+    page.on('request', (req) => {
+      const url = req.url();
+      if (new RegExp(`/api/trips/${TRIP_ID}/days(\\?|$)`).test(url)) {
+        daysRequests.push(url);
+      }
+    });
+
+    await page.goto(`/trips?selected=${TRIP_ID}`);
+    // portal placeholder 本身是空 <div>（無自身尺寸），驗證要看它「有沒有被 portal
+    // 進內容」而不是它自己是否 visible —— 直接斷言中欄行程內容（行程標題）有渲染
+    // 出來，這才是「已經抓過一次資料且成功顯示」的可觀察基準點（同 drag-flows.spec.js
+    // 既有的斷言方式）。
+    await expect(page.getByRole('heading', { name: /2026 沖繩自駕五日遊/ })).toBeVisible({ timeout: 10000 });
+    const countAfterInitialLoad = daysRequests.length;
+    expect(countAfterInitialLoad).toBeGreaterThan(0);
+
+    // 開啟操作面板（編輯行程）— 這是 owner 回報「刷新第二欄」的觸發點。
+    await page.getByTestId('trips-embedded-menu-trigger').click();
+    await page.getByTestId('trip-embedded-menu-edit-' + TRIP_ID).click();
+    await expect(page).toHaveURL(new RegExp(`/trip/${TRIP_ID}/edit`));
+    await expect(page.getByTestId('trip-main-portal')).toBeVisible({ timeout: 10000 });
+    // 面板打開後的呼叫次數當基準（含上面提到、獨立於本次修復的 TripLayout
+    // title-only fetch —— 它是 async fire-and-forget，portal visible 那一刻不保證
+    // 已經送出，等一小段時間讓它穩定下來再當基準）。重點驗證是「關閉」這一步
+    // 不再額外多打，不是「開啟」這一步打幾次。
+    await page.waitForTimeout(500);
+    const countAfterPanelOpen = daysRequests.length;
+
+    // 關閉面板，回到 /trips?selected=X。這是本次修復的核心場景：owner 回報
+    // 「開關」都會刷新，第一版只驗過「開啟」半段，這裡明確驗「關閉」。
+    await page.getByTestId('stack-panel-close').click();
+    await expect(page).toHaveURL(new RegExp(`/trips\\?selected=${TRIP_ID}`));
+    await expect(page.getByTestId('trip-main-portal')).toBeVisible({ timeout: 10000 });
+
+    // 核心斷言：關閉面板回到 /trips?selected=X 不應該再多打一次 —— 多打就代表
+    // TripPage 被 unmount/remount 重新抓過資料（owner 講的「刷新」）。
+    expect(daysRequests.length).toBe(countAfterPanelOpen);
+  });
+
+  test('深連結：直接打開 /trip/:id/edit 仍正常渲染中欄（param→prop 改造沒破壞冷啟）', async ({ page }) => {
+    test.skip(test.info().project.name !== 'chromium', '只需一個桌機 viewport 驗證，避免重複跑');
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    await page.goto(`/trip/${TRIP_ID}/edit`);
+    await expect(page.getByTestId('trip-main-portal')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('stack-panel-header')).toBeVisible();
+  });
+});

--- a/tests/unit/app-shell-sheet-elevation.test.ts
+++ b/tests/unit/app-shell-sheet-elevation.test.ts
@@ -1,5 +1,5 @@
 /**
- * 桌機第三欄 dark-mode elevation — 2026-07-21 追加。
+ * 桌機第三欄 dark-mode elevation — 2026-07-21 追加，2026-07-21 第二輪補齊既有 6 面板。
  *
  * Context: coordinator 用 /browse 對 prod 實測發現 .trip-content（中欄內容）先前沒背景，
  * 透明壓在 .app-shell 的深色底色上（PR #1102 已修）。同型問題也適用第三欄 sheet —
@@ -9,9 +9,15 @@
  * 驗證：
  *   - AppShell.tsx 的 .app-shell-sheet 有 --color-tertiary base（涵蓋所有 sheet 消費者，
  *     含既有 TripSheet 與 TripStackLayout 的 <Outlet/> 面板）。
- *   - 本次遷入 TripStackLayout 的 3 頁（共編/AI 健檢/行程筆記）各自的 shell class
- *     在 .app-shell-sheet 內有 --color-tertiary override（面板自己不透明背景才不會
- *     蓋掉 base；手機整頁模式不受影響，維持原本 --color-background/-secondary）。
+ *   - 2026-07-21 v2.57.10 遷入 TripStackLayout 的 3 頁（共編/AI 健檢/行程筆記）各自的
+ *     shell class 在 .app-shell-sheet 內有 --color-tertiary override。
+ *   - owner 這輪回報 #5：原本「6 條全接」（2026-07-18）的 6 個操作面板
+ *     （編輯行程/加景點/新增景點/複製移動/換景點/編輯 entry）當時沒套這層 override，
+ *     跟新遷入的 3 頁不一致。這裡補齊其中 5 個有自訂 shell 背景的頁面
+ *     （EditEntryPage 的 shellClassName="tp-app" 沒有任何背景規則，本來就會透出
+ *     .app-shell-sheet 的 base tertiary，不需 override，故不在此列）。
+ *     面板自己不透明背景才不會蓋掉 base；手機整頁模式不受影響，維持原本
+ *     --color-background/-secondary。
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -21,6 +27,11 @@ const APP_SHELL = readFileSync(join(__dirname, '../../src/components/shell/AppSh
 const COLLAB = readFileSync(join(__dirname, '../../src/pages/CollabPage.tsx'), 'utf8');
 const HEALTH = readFileSync(join(__dirname, '../../src/pages/TripHealthCheckPage.tsx'), 'utf8');
 const NOTES = readFileSync(join(__dirname, '../../src/pages/TripNotesPage.tsx'), 'utf8');
+const EDIT_TRIP = readFileSync(join(__dirname, '../../src/pages/EditTripPage.tsx'), 'utf8');
+const ADD_STOP = readFileSync(join(__dirname, '../../src/pages/AddStopPage.tsx'), 'utf8');
+const ADD_ENTRY = readFileSync(join(__dirname, '../../src/pages/AddEntryPage.tsx'), 'utf8');
+const ENTRY_ACTION = readFileSync(join(__dirname, '../../src/pages/EntryActionPage.tsx'), 'utf8');
+const CHANGE_POI = readFileSync(join(__dirname, '../../src/pages/ChangePoiPage.tsx'), 'utf8');
 
 describe('桌機第三欄 dark-mode elevation（.app-shell-sheet → --color-tertiary）', () => {
   it('AppShell.tsx: .app-shell-sheet 有 --color-tertiary base（涵蓋所有 sheet 消費者）', () => {
@@ -37,5 +48,27 @@ describe('桌機第三欄 dark-mode elevation（.app-shell-sheet → --color-ter
 
   it('TripNotesPage: .app-shell-sheet .tp-notes-shell override 為 --color-tertiary', () => {
     expect(NOTES).toMatch(/\.app-shell-sheet \.tp-notes-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
+  });
+});
+
+describe('owner 回報 #5：既有 6 個操作面板補齊 tertiary elevation（跟新 3 面板一致）', () => {
+  it('EditTripPage: .app-shell-sheet .tp-edit-page-shell override 為 --color-tertiary', () => {
+    expect(EDIT_TRIP).toMatch(/\.app-shell-sheet \.tp-edit-page-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
+  });
+
+  it('AddStopPage: .app-shell-sheet .tp-add-stop-page-shell override 為 --color-tertiary', () => {
+    expect(ADD_STOP).toMatch(/\.app-shell-sheet \.tp-add-stop-page-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
+  });
+
+  it('AddEntryPage: .app-shell-sheet .tp-add-entry-shell override 為 --color-tertiary', () => {
+    expect(ADD_ENTRY).toMatch(/\.app-shell-sheet \.tp-add-entry-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
+  });
+
+  it('EntryActionPage（複製/移動共用）: .app-shell-sheet .tp-entry-action-shell override 為 --color-tertiary', () => {
+    expect(ENTRY_ACTION).toMatch(/\.app-shell-sheet \.tp-entry-action-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
+  });
+
+  it('ChangePoiPage: .app-shell-sheet .tp-change-poi-page-shell override 為 --color-tertiary', () => {
+    expect(CHANGE_POI).toMatch(/\.app-shell-sheet \.tp-change-poi-page-shell\s*\{\s*background: var\(--color-tertiary\);\s*\}/);
   });
 });

--- a/tests/unit/desktop-sidebar-visual.test.tsx
+++ b/tests/unit/desktop-sidebar-visual.test.tsx
@@ -85,3 +85,23 @@ describe('DesktopSidebar rev2 §10.1 — vibrancy 材質 + 清單視覺 token', 
     expect(style).toMatch(/\.tp-trip-item\s*\{[^}]*font-weight:\s*600/);
   });
 });
+
+// owner 2026-07-21（第二輪回報 #4）：桌機 primary nav（.tp-sidebar-nav）跟手機
+// GlobalBottomNav 的玻璃膠囊視覺不一致，要求共用同一套材質 token
+// （--tabbar-tint / --tabbar-filter / --tabbar-rim / --tabbar-shadow，已在
+// tokens.css 定義，GlobalBottomNav 已在用）。
+describe('DesktopSidebar rev2 owner 回報 #4 — primary nav 玻璃材質跟手機 GlobalBottomNav 共用', () => {
+  it('.tp-sidebar-nav 用 --tabbar-tint + --tabbar-filter（跟 .tp-global-bottom-nav 同一組 token，不是自創的新材質）', () => {
+    const { container } = renderSidebar({ user: null, trips: [] });
+    const style = container.querySelector('style')?.textContent ?? '';
+    expect(style).toMatch(/\.tp-sidebar-nav\s*\{[^}]*background:\s*var\(--tabbar-tint\)/);
+    expect(style).toMatch(/\.tp-sidebar-nav\s*\{[^}]*backdrop-filter:\s*var\(--tabbar-filter\)/);
+  });
+
+  it('.tp-sidebar-nav 也套 --tabbar-rim（邊框）+ --tabbar-shadow（陰影），三個材質變數都跟手機膠囊一致', () => {
+    const { container } = renderSidebar({ user: null, trips: [] });
+    const style = container.querySelector('style')?.textContent ?? '';
+    expect(style).toMatch(/\.tp-sidebar-nav\s*\{[^}]*border:\s*var\(--tabbar-rim\)/);
+    expect(style).toMatch(/\.tp-sidebar-nav\s*\{[^}]*box-shadow:\s*var\(--tabbar-shadow\)/);
+  });
+});

--- a/tests/unit/stack-panel-header.test.tsx
+++ b/tests/unit/stack-panel-header.test.tsx
@@ -45,4 +45,14 @@ describe('StackPanelHeader — rev2 共用堆疊面板 header', () => {
       /\.tp-stack-head-spacer\s*\{[^}]*var\(--spacing-tap-min\)/,
     );
   });
+
+  // owner 2026-07-21（第二輪回報 #3）：第三欄 StackPanelHeader 沒有跟中欄 TitleBar
+  // 等高 —— TitleBar 用 --titlebar-h token（64px 桌機/56px compact），StackPanelHeader
+  // 寫死 52px，兩欄 header 對不齊。改共用同一個 token 來源。
+  it('owner 回報 #3：.tp-stack-head 高度改用 --titlebar-h token（不再寫死 52px），跟 .tp-titlebar 同一個高度來源', () => {
+    expect(STACK_PANEL_HEADER_STYLES).not.toMatch(/\.tp-stack-head\s*\{[^}]*height:\s*52px/);
+    expect(STACK_PANEL_HEADER_STYLES).toMatch(
+      /\.tp-stack-head\s*\{[^}]*height:\s*calc\(var\(--titlebar-h\)/,
+    );
+  });
 });

--- a/tests/unit/trip-content-elevation-full-width.test.ts
+++ b/tests/unit/trip-content-elevation-full-width.test.ts
@@ -1,0 +1,50 @@
+/**
+ * 行程內容欄 dark-mode elevation — 兩側仍深黑（owner 2026-07-21 第二輪回報，附截圖）。
+ *
+ * Context：v2.57.9（PR #1102）在 `.trip-content` 補了 `background: var(--color-secondary)`，
+ * 但 `.trip-content` 只是 `.tp-page`（padding 40px + max-width 1440px 置中）內的一個
+ * 子框，DayNav / offline banner 等其他兄弟元素、以及 `.tp-page` 自己的左右 padding 區，
+ * 全都還是透出 `.app-shell-main` 底下 `.app-shell` 的 base 深色。截圖裡看到的「中間淺一階、
+ * 兩側還是深黑」就是這個窄框造成的。
+ *
+ * 對照組：`/trips`（TripsListPage）用 `.tp-trips-shell` 在最外層（跟 `.tp-shell` 同級）
+ * 整片上色，同一份設計沒有這個 band 問題 —— 這裡照抄同一個 pattern，而不是發明新規則：
+ * 把 elevation 移到 TripPage 的最外層（`.tp-shell` 疊加一個頁面專屬 class），
+ * 讓整欄（不只 .trip-content 那個窄框）都是 --color-secondary，並移除 .trip-content
+ * 自己重複的 background（外層已經上色，內層再上同色是 no-op）。
+ *
+ * 三層 elevation（Apple HIG）：
+ *   .app-shell         #1C1C1E（base）
+ *   內容欄整片          --color-secondary（#2C2C2E，本次移到 outer wrapper）
+ *   展開卡片明細         --color-tertiary（#3A3A3C，本次從 secondary 調高一階，
+ *                        避免跟外層同色、层次消失 —— coordinator 明確提醒的風險）
+ *   第三欄 panel         --color-tertiary（已完成，v2.57.10）
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TRIP_PAGE = readFileSync(join(__dirname, '../../src/pages/TripPage.tsx'), 'utf8');
+const TIMELINE_RAIL = readFileSync(join(__dirname, '../../src/components/trip/TimelineRail.tsx'), 'utf8');
+
+describe('TripPage — 內容欄 elevation 移到最外層（不只 .trip-content 窄框）', () => {
+  it('outer wrapper 有頁面專屬 class 疊在 .tp-shell 上', () => {
+    expect(TRIP_PAGE).toMatch(/className="tp-shell tp-trip-page-shell"/);
+  });
+
+  it('.tp-shell.tp-trip-page-shell 整片套 --color-secondary（覆蓋全域 .tp-shell 的 base）', () => {
+    expect(TRIP_PAGE).toMatch(/\.tp-shell\.tp-trip-page-shell\s*\{[^}]*background: var\(--color-secondary\);?[^}]*\}/);
+  });
+
+  it('.trip-content 不再重複宣告 background（外層已整片上色，內層重複宣告是 no-op 且會誤導下一個人)', () => {
+    const tripContentRule = TRIP_PAGE.match(/\.trip-content\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(tripContentRule).not.toMatch(/background:\s*var\(--color-secondary\)/);
+  });
+});
+
+describe('TimelineRail — 展開明細跟外層同色時的 elevation 修正', () => {
+  it('.tp-rail-detail fallback 從 --color-secondary 調高到 --color-tertiary（外層已是 secondary，展開卡要再高一階才看得出層次）', () => {
+    expect(TIMELINE_RAIL).toMatch(/\.tp-rail-detail\s*\{[\s\S]*?background: var\(--tone-subtle, var\(--color-tertiary\)\);/);
+    expect(TIMELINE_RAIL).not.toMatch(/\.tp-rail-detail\s*\{[\s\S]*?background: var\(--tone-subtle, var\(--color-secondary\)\);/);
+  });
+});

--- a/tests/unit/trip-detail-action-menu-edit.test.ts
+++ b/tests/unit/trip-detail-action-menu-edit.test.ts
@@ -1,39 +1,47 @@
 /**
- * v2.33.6 feat — TripPage 右上「⋯」EmbeddedActionMenu 加「編輯行程」入口。
+ * v2.33.6 feat — 行程頁右上「⋯」動作選單加「編輯行程」入口。
  *
  * 既有 menu: 共編設定 / AI 健檢 / 列印 / 下載格式
  * 新增: 編輯行程（放在最前，呼應 trip card menu 順序）
+ *
+ * v2.57.x：EmbeddedActionMenu 已從 TripsListPage.tsx 抽到共用元件
+ * ../../src/components/trip/TripActionsMenu.tsx（供 TripStackLayout 共用），
+ * 元件內部斷言改讀該檔；call-site（TripsListPage 的 onEdit wiring）仍讀 TripsListPage.tsx。
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-const SRC = readFileSync(
+const MENU_SRC = readFileSync(
+  path.resolve(__dirname, '../../src/components/trip/TripActionsMenu.tsx'),
+  'utf8',
+);
+const LIST_SRC = readFileSync(
   path.resolve(__dirname, '../../src/pages/TripsListPage.tsx'),
   'utf8',
 );
 
-describe('TripsListPage EmbeddedActionMenu — v2.33.6 編輯行程 entry', () => {
-  it('EmbeddedActionMenuProps 加 onEdit prop', () => {
-    expect(SRC).toMatch(/interface EmbeddedActionMenuProps\s*\{[\s\S]{0,300}onEdit:\s*\(\)\s*=>\s*void/);
+describe('TripActionsMenu — v2.33.6 編輯行程 entry', () => {
+  it('TripActionsMenuProps 加 onEdit prop', () => {
+    expect(MENU_SRC).toMatch(/interface TripActionsMenuProps\s*\{[\s\S]{0,300}onEdit:\s*\(\)\s*=>\s*void/);
   });
 
-  it('EmbeddedActionMenu 解構 onEdit', () => {
-    expect(SRC).toMatch(/function EmbeddedActionMenu\(\{[^}]*onEdit[^}]*\}/);
+  it('TripActionsMenu 解構 onEdit', () => {
+    expect(MENU_SRC).toMatch(/function TripActionsMenu\(\{[^}]*onEdit[^}]*\}/);
   });
 
   it('「編輯行程」menu item 存在 + Icon edit + testid', () => {
-    expect(SRC).toMatch(/編輯行程/);
-    expect(SRC).toMatch(/<Icon name="edit"\s*\/>\s*<span>編輯行程<\/span>/);
-    expect(SRC).toMatch(/data-testid=\{`trip-embedded-menu-edit-\$\{tripId\}`\}/);
+    expect(MENU_SRC).toMatch(/編輯行程/);
+    expect(MENU_SRC).toMatch(/<Icon name="edit"\s*\/>\s*<span>編輯行程<\/span>/);
+    expect(MENU_SRC).toMatch(/data-testid=\{`trip-embedded-menu-edit-\$\{tripId\}`\}/);
   });
 
   it('呼叫 onEdit 透過 runAndClose', () => {
-    expect(SRC).toMatch(/onClick=\{runAndClose\(onEdit\)\}/);
+    expect(MENU_SRC).toMatch(/onClick=\{runAndClose\(onEdit\)\}/);
   });
 
-  it('caller 傳 onEdit navigate 到 /trip/:id/edit', () => {
-    expect(SRC).toMatch(
+  it('TripsListPage call site 傳 onEdit navigate 到 /trip/:id/edit', () => {
+    expect(LIST_SRC).toMatch(
       /onEdit=\{\(\)\s*=>\s*navigate\(`\/trip\/\$\{encodeURIComponent\(effectiveSelectedId\)\}\/edit`\)\}/,
     );
   });

--- a/tests/unit/trip-export-pdf-menu-wiring.test.ts
+++ b/tests/unit/trip-export-pdf-menu-wiring.test.ts
@@ -14,7 +14,9 @@ const read = (rel: string) => readFileSync(join(ROOT, rel), 'utf8');
 
 const PDF = read('src/components/print/renderTripPrintPdf.tsx');
 const TRIP_PAGE = read('src/pages/TripPage.tsx');
-const LIST = read('src/pages/TripsListPage.tsx');
+// v2.57.x: export menu（含 triggerDownload 呼叫）從 TripsListPage.tsx 的
+// EmbeddedActionMenu 抽到共用元件 TripActionsMenu.tsx（供 TripStackLayout 共用）。
+const LIST = read('src/components/trip/TripActionsMenu.tsx');
 
 describe('renderTripPrintPdf — data-driven, not #tripContent', () => {
   it('renders TripPrintDocument from loadTripPrintData (not the live DOM)', () => {

--- a/tests/unit/trip-main-portal-context.test.tsx
+++ b/tests/unit/trip-main-portal-context.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * TripMainPortalContext — owner 2026-07-21 回報 #2 修復核心機制。
+ *
+ * push-based callback ref：host 的 placeholder <div ref={setPortalNode}> mount 時
+ * React 同步呼叫這個 callback，consumer（TripPageHost）拿到 node 後 createPortal
+ * 內容進去。第一版用 pull-based document.getElementById + useEffect 依
+ * location.pathname 重查，playwright e2e 實測抓到 race（新 host 的 placeholder
+ * 有時還沒 mount，effect 跑的當下查不到，之後也不會重查）——這個 context 就是
+ * 為了徹底避開那個 race 存在的。這裡驗證最基本的契約：mount 觸發 callback、
+ * unmount 觸發 callback 帶 null、沒有 Provider 時的 fallback 不噴錯。
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useState } from 'react';
+import { TripMainPortalContext, useTripMainPortal } from '../../src/contexts/TripMainPortalContext';
+
+function Placeholder({ mounted }: { mounted: boolean }) {
+  const { setPortalNode } = useTripMainPortal();
+  return mounted ? <div ref={setPortalNode} data-testid="placeholder" /> : null;
+}
+
+function Consumer({ onNodeChange }: { onNodeChange: (node: Element | null) => void }) {
+  const [node, setNode] = useState<Element | null>(null);
+  return (
+    <TripMainPortalContext.Provider value={{ setPortalNode: (n) => { setNode(n); onNodeChange(n); } }}>
+      <Placeholder mounted />
+    </TripMainPortalContext.Provider>
+  );
+}
+
+describe('TripMainPortalContext — push-based callback ref', () => {
+  it('placeholder mount → callback 立刻收到實際 DOM node（非 null）', () => {
+    const onNodeChange = vi.fn();
+    render(<Consumer onNodeChange={onNodeChange} />);
+    expect(onNodeChange).toHaveBeenCalled();
+    const lastCall = onNodeChange.mock.calls[onNodeChange.mock.calls.length - 1];
+    expect(lastCall[0]).not.toBeNull();
+    expect(lastCall[0]?.getAttribute('data-testid')).toBe('placeholder');
+  });
+
+  it('placeholder unmount → callback 收到 null（host 換了 / 離開時通知）', () => {
+    const onNodeChange = vi.fn();
+    function Wrapper({ mounted }: { mounted: boolean }) {
+      return (
+        <TripMainPortalContext.Provider value={{ setPortalNode: onNodeChange }}>
+          <Placeholder mounted={mounted} />
+        </TripMainPortalContext.Provider>
+      );
+    }
+    const { rerender } = render(<Wrapper mounted />);
+    onNodeChange.mockClear();
+    rerender(<Wrapper mounted={false} />);
+    expect(onNodeChange).toHaveBeenCalled();
+    expect(onNodeChange.mock.calls[0][0]).toBeNull();
+  });
+
+  it('沒有 Provider 時 useTripMainPortal() fallback 是 no-op（不噴錯，供手機/獨立頁面安全呼叫）', () => {
+    function Standalone() {
+      const { setPortalNode } = useTripMainPortal();
+      return <div ref={setPortalNode} data-testid="standalone" />;
+    }
+    expect(() => render(<Standalone />)).not.toThrow();
+  });
+});

--- a/tests/unit/trip-page-host-wiring.test.ts
+++ b/tests/unit/trip-page-host-wiring.test.ts
@@ -1,0 +1,27 @@
+/**
+ * main.tsx — TripPageHost 掛在 <Routes> 之上（owner 2026-07-21 回報 #2 修復）。
+ * Pure source-grep（main.tsx 是 app 進入點，full mount 需要整個 route tree +
+ * 一堆 provider，屬於 e2e scope；wiring 本身用 source-grep 鎖住不漂移）。
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MAIN = readFileSync(join(__dirname, '../../src/entries/main.tsx'), 'utf8');
+
+describe('main.tsx — TripPageHost wiring', () => {
+  it('import TripPageHost', () => {
+    expect(MAIN).toMatch(/import TripPageHost from ['"]\.\.\/components\/trip\/TripPageHost['"]/);
+  });
+
+  it('TripPageHost 包住 <Routes>（必須是 Routes 的祖先，不能是 Routes 的子路由，否則路由切換一樣會把它 unmount 掉）', () => {
+    const openIdx = MAIN.indexOf('<TripPageHost>');
+    const routesOpenIdx = MAIN.indexOf('<Routes>');
+    const routesCloseIdx = MAIN.indexOf('</Routes>');
+    const closeIdx = MAIN.indexOf('</TripPageHost>');
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(routesOpenIdx).toBeGreaterThan(openIdx);
+    expect(routesCloseIdx).toBeGreaterThan(routesOpenIdx);
+    expect(closeIdx).toBeGreaterThan(routesCloseIdx);
+  });
+});

--- a/tests/unit/trip-page-host.test.tsx
+++ b/tests/unit/trip-page-host.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * TripPageHost — owner 2026-07-21 回報 #2 修復核心：整個 app 只 render 一份
+ * <TripPage>，掛在 <Routes> 之上，切換 /trips?selected=X ↔ /trip/:id/{edit|...}
+ * 不應該讓它 unmount/remount（那就是 owner 講的「刷新第二欄」）。
+ *
+ * 用 mount-count 追蹤驗證：同一個 tripId 底下，路由在 /trips?selected=X 與
+ * /trip/:id/edit 之間來回切換，<TripPage> 只該 mount 一次；換成不同 tripId
+ * 才該重新 mount（這才是真的該重新抓資料的情況）。
+ *
+ * TripPageHost 內部用 lazyWithRetry 動態載入 TripPage（避免把 TripPage 的重
+ * 依賴打進每一頁都會載的主 bundle，見 TripPageHost.tsx 註解），所以斷言要用
+ * waitFor/findByTestId 等 Suspense resolve，不能假設同步出現。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEffect } from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import TripPageHost from '../../src/components/trip/TripPageHost';
+import { TRIP_MAIN_PORTAL_ID } from '../../src/lib/tripStackRoutes';
+
+let mockIsDesktop = true;
+vi.mock('../../src/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => mockIsDesktop,
+}));
+
+const mountLog: string[] = [];
+vi.mock('../../src/pages/TripPage', () => ({
+  default: ({ tripId }: { tripId?: string }) => {
+    useEffect(() => {
+      mountLog.push(`mount:${tripId}`);
+      return () => mountLog.push(`unmount:${tripId}`);
+    }, [tripId]);
+    return <div data-testid="mock-trip-page">{tripId}</div>;
+  },
+}));
+
+function Nav({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return <button data-testid={`go-${to}`} onClick={() => navigate(to)}>{to}</button>;
+}
+
+function Host({ initialEntry }: { initialEntry: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <TripPageHost>
+        <div id={TRIP_MAIN_PORTAL_ID} data-testid="portal-target" />
+        <Nav to="/trips?selected=t1" />
+        <Nav to="/trip/t1/edit" />
+        <Nav to="/trip/t1/collab" />
+        <Nav to="/trip/t2/edit" />
+        <Nav to="/chat" />
+        <Routes>
+          <Route path="/trips" element={<div>trips list</div>} />
+          <Route path="/trip/:tripId/edit" element={<div>edit</div>} />
+          <Route path="/trip/:tripId/collab" element={<div>collab</div>} />
+          <Route path="/chat" element={<div>chat</div>} />
+        </Routes>
+      </TripPageHost>
+    </MemoryRouter>
+  );
+}
+
+describe('TripPageHost — 桌機唯一 <TripPage> 實例，跨路由不 remount', () => {
+  beforeEach(() => {
+    mockIsDesktop = true;
+    mountLog.length = 0;
+  });
+
+  it('桌機 /trips?selected=t1 → render <TripPage tripId="t1">', async () => {
+    render(<Host initialEntry="/trips?selected=t1" />);
+    expect((await screen.findByTestId('mock-trip-page')).textContent).toBe('t1');
+    expect(mountLog).toEqual(['mount:t1']);
+  });
+
+  it('同一 tripId：/trips?selected=t1 → /trip/t1/edit → /trip/t1/collab 都不 remount', async () => {
+    const { getByTestId } = render(<Host initialEntry="/trips?selected=t1" />);
+    await screen.findByTestId('mock-trip-page');
+    fireEvent.click(getByTestId('go-/trip/t1/edit'));
+    fireEvent.click(getByTestId('go-/trip/t1/collab'));
+    fireEvent.click(getByTestId('go-/trips?selected=t1'));
+    await waitFor(() => expect(getByTestId('mock-trip-page')).toBeTruthy());
+    expect(mountLog).toEqual(['mount:t1']); // 完全沒有 unmount/remount
+  });
+
+  it('切換到不同 tripId（t1 → t2）才會 remount（這是應該重新抓資料的情況）', async () => {
+    const { getByTestId } = render(<Host initialEntry="/trip/t1/edit" />);
+    await screen.findByTestId('mock-trip-page');
+    fireEvent.click(getByTestId('go-/trip/t2/edit'));
+    await waitFor(() => expect(mountLog).toEqual(['mount:t1', 'unmount:t1', 'mount:t2']));
+  });
+
+  it('離開 trip 相關頁（/chat）→ <TripPage> unmount，沒有殘留 render', async () => {
+    const { getByTestId, queryByTestId } = render(<Host initialEntry="/trip/t1/edit" />);
+    await screen.findByTestId('mock-trip-page');
+    fireEvent.click(getByTestId('go-/chat'));
+    await waitFor(() => expect(mountLog).toEqual(['mount:t1', 'unmount:t1']));
+    expect(queryByTestId('mock-trip-page')).toBeNull();
+  });
+
+  it('手機（isDesktop=false）完全不 render <TripPage>（中欄概念只在桌機存在）', async () => {
+    mockIsDesktop = false;
+    const { queryByTestId } = render(<Host initialEntry="/trip/t1/edit" />);
+    // 給 Suspense/lazy 一個 tick 的機會，確保「不出現」不是還沒 resolve 而是真的沒 render。
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mountLog).toEqual([]);
+    expect(queryByTestId('mock-trip-page')).toBeNull();
+  });
+
+  it('非 trip 相關頁（/chat）一開始就不 render <TripPage>', async () => {
+    const { queryByTestId } = render(<Host initialEntry="/chat" />);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mountLog).toEqual([]);
+    expect(queryByTestId('mock-trip-page')).toBeNull();
+  });
+});

--- a/tests/unit/trip-page-portal-target.test.ts
+++ b/tests/unit/trip-page-portal-target.test.ts
@@ -1,0 +1,40 @@
+/**
+ * TripPage — usePortalMain / portalNode props（owner 2026-07-21 回報 #2 修復）。
+ *
+ * 第一版用 portalTargetId（字串 id）+ document.getElementById + useEffect 依
+ * location.pathname 重查 —— playwright e2e 實測抓到 race（TripPage 的 effect
+ * 觸發時新 host 的 placeholder 有時還沒 mount，撲空後永遠不會重試，中欄整個
+ * 空白）。改為 push-based：呼叫端（TripPageHost）透過 TripMainPortalContext
+ * 拿到 host placeholder 的 callback ref 結果（portalNode），直接當 prop 傳給
+ * TripPage，不再自己查詢 DOM。
+ *
+ * Pure source-grep — 同檔案其餘測試（trip-page-focus-id.test.tsx 等）都是這個
+ * 慣例，TripPage 依賴太重不 full mount。
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SRC = readFileSync(
+  path.resolve(__dirname, '../../src/pages/TripPage.tsx'),
+  'utf-8',
+);
+
+describe('TripPage — usePortalMain / portalNode props（owner 回報 #2）', () => {
+  it('TripPageProps 加 usePortalMain?: boolean 與 portalNode?: Element | null', () => {
+    expect(SRC).toMatch(/interface TripPageProps\s*\{[\s\S]{0,1500}usePortalMain\?:\s*boolean/);
+    expect(SRC).toMatch(/interface TripPageProps\s*\{[\s\S]{0,1500}portalNode\?:\s*Element \| null/);
+  });
+
+  it('不再用 document.getElementById 查詢 portal target（pull-based 已移除，改吃 prop）', () => {
+    expect(SRC).not.toMatch(/document\.getElementById\(portalTargetId\)/);
+  });
+
+  it('usePortalMain 時走 createPortal 到 portalNode，portalNode 暫時為 null 就不 render（避免內容出現在錯的地方）', () => {
+    expect(SRC).toMatch(/usePortalMain && portalNode \? createPortal\(wrappedMain, portalNode\) : null/);
+  });
+
+  it('沒有 usePortalMain（既有呼叫端，如 TripsListPage 手機分支）維持原本 inline render，不受影響', () => {
+    expect(SRC).toMatch(/!usePortalMain && wrappedMain/);
+  });
+});

--- a/tests/unit/trip-print-route-wiring.test.ts
+++ b/tests/unit/trip-print-route-wiring.test.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path';
 const ROOT = join(__dirname, '..', '..');
 const main = readFileSync(join(ROOT, 'src/entries/main.tsx'), 'utf8');
 const list = readFileSync(join(ROOT, 'src/pages/TripsListPage.tsx'), 'utf8');
+// v2.57.x: EmbeddedActionMenu 抽到 TripActionsMenu.tsx（供 TripStackLayout 共用）。
+const menu = readFileSync(join(ROOT, 'src/components/trip/TripActionsMenu.tsx'), 'utf8');
 
 describe('trip print route + menu wiring', () => {
   it('registers the print route under /trip/:tripId', () => {
@@ -17,9 +19,9 @@ describe('trip print route + menu wiring', () => {
     expect(main).toMatch(/const TripPrintPage = lazyWithRetry\(/);
   });
 
-  it('EmbeddedActionMenu accepts onPrint and the 列印 button uses it (fallback to togglePrint)', () => {
-    expect(list).toMatch(/onPrint\?: \(\) => void/);
-    expect(list).toMatch(/onPrint \? onPrint\(\) : tripPageRef\.current\?\.togglePrint\(\)/);
+  it('TripActionsMenu accepts onPrint and the 列印 button uses it (fallback to togglePrint)', () => {
+    expect(menu).toMatch(/onPrint\?: \(\) => void/);
+    expect(menu).toMatch(/onPrint \? onPrint\(\) : tripPageRef\.current\?\.togglePrint\(\)/);
   });
 
   it('call site navigates the 列印 menu to /print', () => {

--- a/tests/unit/trip-share-menu-entry.test.tsx
+++ b/tests/unit/trip-share-menu-entry.test.tsx
@@ -3,7 +3,8 @@
  *
  * - TripCardMenu (行程一覽卡片 ⋯): renders 分享連結 when onShare provided, not when
  *   omitted; click → onShare(tripId).
- * - EmbeddedActionMenu (行程頁右上角 ⋯, defined in TripsListPage) + the host wiring
+ * - TripActionsMenu (行程頁右上角 ⋯, src/components/trip/TripActionsMenu.tsx,
+ *   v2.57.x 抽出供 TripStackLayout 共用) + the host wiring
  *   (onShare on both menus + ShareLinkModal mount) — source-grep (rendering the
  *   embedded menu in isolation needs the whole page).
  */
@@ -41,12 +42,15 @@ describe('TripCardMenu — 分享連結 entry', () => {
   });
 });
 
-describe('TripsListPage wiring (source contracts)', () => {
+describe('TripActionsMenu wiring (source contracts)', () => {
+  // v2.57.x: EmbeddedActionMenu 抽到 TripActionsMenu.tsx（供 TripStackLayout 共用），
+  // menu item 本身斷言改讀該檔；call-site wiring 仍讀 TripsListPage.tsx。
+  const menuSrc = readFileSync(join(__dirname, '..', '..', 'src/components/trip/TripActionsMenu.tsx'), 'utf8');
   const src = readFileSync(join(__dirname, '..', '..', 'src/pages/TripsListPage.tsx'), 'utf8');
 
-  it('EmbeddedActionMenu has a 分享連結 item (trip-embedded-menu-share testid)', () => {
-    expect(src).toMatch(/trip-embedded-menu-share-/);
-    expect(src).toMatch(/分享連結/);
+  it('TripActionsMenu has a 分享連結 item (trip-embedded-menu-share testid)', () => {
+    expect(menuSrc).toMatch(/trip-embedded-menu-share-/);
+    expect(menuSrc).toMatch(/分享連結/);
   });
 
   it('wires onShare → setShareTripId on BOTH the card menu and the embedded menu', () => {

--- a/tests/unit/trip-stack-layout.test.tsx
+++ b/tests/unit/trip-stack-layout.test.tsx
@@ -1,10 +1,16 @@
 /**
  * TripStackLayout — rev2 桌機右欄操作堆疊 host 的分支 + 導航契約。
  *
- * 桌機（useMediaQuery=true）→ 3 欄 shell（sidebar｜中欄 <TripPage noShell>｜右欄 Outlet），
- *   context inStack=true、closeStack → /trips?selected=:id。
+ * 桌機（useMediaQuery=true）→ 3 欄 shell（sidebar｜中欄（TitleBar + portal placeholder）｜
+ *   右欄 Outlet），context inStack=true、closeStack → /trips?selected=:id。
  * 手機（false）→ passthrough bare <Outlet>（無第二個 shell / 無中欄詳情、inStack 預設 false）。
- * invalid :tripId → 中欄不掛 TripPage（main=null）、closeStack fallback /trips。
+ * invalid :tripId → 中欄不掛 placeholder（main=null）、closeStack fallback /trips。
+ *
+ * v2.57.x 第三輪（owner 回報 #2「開關第三欄面板會刷新第二欄」修復）：TripStackLayout
+ * 不再 inline render <TripPage> —— 改留一個 portal placeholder（TRIP_MAIN_PORTAL_ID），
+ * main.tsx 的 TripPageHost（唯一持續存在的 <TripPage> 實例）才是實際掛載處。這裡只驗證
+ * TripStackLayout 有留下正確的 placeholder，<TripPage> 本身的行為見
+ * tests/unit/trip-page-host.test.tsx。
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
@@ -12,18 +18,15 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import TripStackLayout from '../../src/pages/TripStackLayout';
 import { useSheetStack } from '../../src/contexts/SheetStackContext';
 import { TripContext } from '../../src/contexts/TripContext';
+import { TripPageHandleContext } from '../../src/contexts/TripPageHandleContext';
+import { TRIP_MAIN_PORTAL_ID } from '../../src/lib/tripStackRoutes';
 import type { UseTripReturn } from '../../src/hooks/useTrip';
 import type { Trip } from '../../src/types/trip';
+import type { TripPageHandle } from '../../src/pages/TripPage';
 
 let mockIsDesktop = true;
 vi.mock('../../src/hooks/useMediaQuery', () => ({
   useMediaQuery: () => mockIsDesktop,
-}));
-// 中欄詳情 / sidebar / bottom-nav 的重依賴（/api/trips fetch、地圖）在此 stub 掉。
-vi.mock('../../src/pages/TripPage', () => ({
-  default: ({ tripId, noShell }: { tripId?: string; noShell?: boolean }) => (
-    <div data-testid="mock-trip-detail" data-no-shell={String(noShell)}>{tripId}</div>
-  ),
 }));
 vi.mock('../../src/components/shell/DesktopSidebarConnected', () => ({
   default: () => <div data-testid="mock-sidebar" />,
@@ -31,6 +34,19 @@ vi.mock('../../src/components/shell/DesktopSidebarConnected', () => ({
 vi.mock('../../src/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ user: { userId: 'u1', email: 'ray@example.com' } }),
 }));
+
+// TripActionsMenu 的列印/下載透過 TripPageHandleContext 拿 ref（TripPageHost 持有的
+// 那一份）—— 這裡給一個 stub handle 讓 tripPageRef.current 有東西可呼叫。
+const mockTogglePrint = vi.fn();
+const mockTriggerDownload = vi.fn();
+const mockTripPageHandleRef = {
+  current: {
+    openSheet: vi.fn(),
+    triggerDownload: mockTriggerDownload,
+    togglePrint: mockTogglePrint,
+    openAddStop: vi.fn(),
+  } satisfies TripPageHandle,
+};
 
 function LocationProbe() {
   const { pathname, search } = useLocation();
@@ -69,15 +85,17 @@ function renderAt(path: string, desktop: boolean, tripCtx: UseTripReturn | null 
   return render(
     <MemoryRouter initialEntries={[path]}>
       <LocationProbe />
-      <TripContext.Provider value={tripCtx}>
-        <Routes>
-          <Route path="/trips" element={<div data-testid="trips-page">trips</div>} />
-          <Route path="/trip/:tripId" element={<TripStackLayout />}>
-            <Route path="add-stop" element={<OperationStub />} />
-            <Route path="stop/:entryId/change-poi" element={<OperationStub />} />
-          </Route>
-        </Routes>
-      </TripContext.Provider>
+      <TripPageHandleContext.Provider value={mockTripPageHandleRef}>
+        <TripContext.Provider value={tripCtx}>
+          <Routes>
+            <Route path="/trips" element={<div data-testid="trips-page">trips</div>} />
+            <Route path="/trip/:tripId" element={<TripStackLayout />}>
+              <Route path="add-stop" element={<OperationStub />} />
+              <Route path="stop/:entryId/change-poi" element={<OperationStub />} />
+            </Route>
+          </Routes>
+        </TripContext.Provider>
+      </TripPageHandleContext.Provider>
     </MemoryRouter>,
   );
 }
@@ -87,23 +105,22 @@ describe('TripStackLayout — 桌機/手機分支 + 導航', () => {
     mockIsDesktop = true;
   });
 
-  it('桌機：render 3 欄 host（sidebar｜中欄 TripPage noShell｜右欄 Outlet 操作），inStack=true', () => {
+  it('桌機：render 3 欄 host（sidebar｜中欄 TitleBar+portal placeholder｜右欄 Outlet 操作），inStack=true', () => {
     const { getByTestId } = renderAt('/trip/t1/add-stop', true);
     expect(getByTestId('app-shell')).toBeTruthy();
     expect(getByTestId('app-shell').getAttribute('data-layout')).toBe('3pane');
     expect(getByTestId('mock-sidebar')).toBeTruthy();
-    const detail = getByTestId('mock-trip-detail');
-    expect(detail.textContent).toBe('t1');
-    expect(detail.getAttribute('data-no-shell')).toBe('true');
+    // 中欄不再 inline render TripPage —— 只留 portal placeholder，TripPageHost portal 進來。
+    expect(getByTestId(TRIP_MAIN_PORTAL_ID)).toBeTruthy();
     const op = getByTestId('op-stub');
     expect(op).toBeTruthy();
     expect(op.getAttribute('data-in-stack')).toBe('true');
   });
 
-  it('手機：passthrough bare Outlet — 無 app-shell、無中欄詳情，inStack 預設 false', () => {
+  it('手機：passthrough bare Outlet — 無 app-shell、無中欄 placeholder，inStack 預設 false', () => {
     const { getByTestId, queryByTestId } = renderAt('/trip/t1/add-stop', false);
     expect(queryByTestId('app-shell')).toBeNull();
-    expect(queryByTestId('mock-trip-detail')).toBeNull();
+    expect(queryByTestId(TRIP_MAIN_PORTAL_ID)).toBeNull();
     const op = getByTestId('op-stub');
     expect(op).toBeTruthy();
     expect(op.getAttribute('data-in-stack')).toBe('false');
@@ -120,13 +137,13 @@ describe('TripStackLayout — 桌機/手機分支 + 導航', () => {
     const { getByTestId } = renderAt('/trip/t1/stop/42/change-poi', true);
     expect(getByTestId('app-shell')).toBeTruthy();
     expect(getByTestId('op-stub').getAttribute('data-in-stack')).toBe('true');
-    expect(getByTestId('mock-trip-detail').textContent).toBe('t1');
+    expect(getByTestId(TRIP_MAIN_PORTAL_ID)).toBeTruthy();
   });
 
-  it('invalid :tripId → 中欄不掛 TripPage（main=null）、closeStack fallback /trips', () => {
+  it('invalid :tripId → 中欄不掛 placeholder（main=null）、closeStack fallback /trips', () => {
     const { getByTestId, queryByTestId } = renderAt('/trip/bad!id/add-stop', true);
     expect(getByTestId('app-shell')).toBeTruthy();
-    expect(queryByTestId('mock-trip-detail')).toBeNull();
+    expect(queryByTestId(TRIP_MAIN_PORTAL_ID)).toBeNull();
     fireEvent.click(getByTestId('op-stub'));
     expect(getByTestId('loc').textContent).toBe('/trips');
   });
@@ -168,5 +185,85 @@ describe('TripStackLayout — 桌機/手機分支 + 導航', () => {
       makeTripCtx({ id: 't1', name: 't1', title: '2026 沖繩七日遊' }),
     );
     expect(queryByTestId('titlebar')).toBeNull();
+  });
+});
+
+// owner 2026-07-21（第二輪回報 #1，最嚴重）：開了第三欄面板後，中欄 TitleBar 只有
+// 標題 + 返回，操作入口（新增景點/共編/健檢/筆記/列印/下載/分享/編輯行程）全部消失。
+// 中欄 TitleBar 補回 TripActionsMenu（與 TripsListPage embedded 詳情共用同一元件）。
+describe('TripStackLayout — 中欄 TitleBar actions（owner 回報 #1：第三欄開啟後操作入口消失）', () => {
+  beforeEach(() => {
+    mockIsDesktop = true;
+    mockTogglePrint.mockClear();
+    mockTriggerDownload.mockClear();
+  });
+
+  const tripCtx = () => makeTripCtx({ id: 't1', name: 't1', title: '2026 沖繩七日遊' });
+
+  it('桌機：中欄 TitleBar 顯示「新增景點」+「⋯」動作選單 trigger', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    expect(getByTestId('trip-add-stop-trigger')).toBeTruthy();
+    expect(getByTestId('trips-embedded-menu-trigger')).toBeTruthy();
+  });
+
+  it('「新增景點」→ navigate 到 /trip/:id/add-entry（不離開 stack，中欄不重掛載）', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trip-add-stop-trigger'));
+    expect(getByTestId('loc').textContent).toBe('/trip/t1/add-entry');
+  });
+
+  it('⋯ 選單「編輯行程」→ navigate 到 /trip/:id/edit', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trips-embedded-menu-trigger'));
+    fireEvent.click(getByTestId('trip-embedded-menu-edit-t1'));
+    expect(getByTestId('loc').textContent).toBe('/trip/t1/edit');
+  });
+
+  it('⋯ 選單「AI 健檢」→ navigate 到 /trip/:id/health', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trips-embedded-menu-trigger'));
+    fireEvent.click(getByTestId('trip-embedded-menu-health-t1'));
+    expect(getByTestId('loc').textContent).toBe('/trip/t1/health');
+  });
+
+  it('⋯ 選單「行程筆記」→ navigate 到 /trip/:id/notes', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trips-embedded-menu-trigger'));
+    fireEvent.click(getByTestId('trip-embedded-menu-notes-t1'));
+    expect(getByTestId('loc').textContent).toBe('/trip/t1/notes');
+  });
+
+  it('⋯ 選單「列印」→ navigate 到 /trip/:id/print', () => {
+    const { getByTestId } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trips-embedded-menu-trigger'));
+    fireEvent.click(getByTestId('trip-embedded-menu-print-t1'));
+    expect(getByTestId('loc').textContent).toBe('/trip/t1/print');
+  });
+
+  it('⋯ 選單「下載格式 PDF/JSON」→ 透過 TripPageHandleContext 呼叫 triggerDownload', () => {
+    const { getByTestId, getByText } = renderAt('/trip/t1/add-stop', true, tripCtx());
+    fireEvent.click(getByTestId('trips-embedded-menu-trigger'));
+    fireEvent.click(getByText('PDF'));
+    expect(mockTriggerDownload).toHaveBeenCalledWith('pdf');
+  });
+
+  it('手機：中欄無 TitleBar → 也無「新增景點」/「⋯」actions（bare passthrough）', () => {
+    const { queryByTestId } = renderAt('/trip/t1/add-stop', false, tripCtx());
+    expect(queryByTestId('trip-add-stop-trigger')).toBeNull();
+    expect(queryByTestId('trips-embedded-menu-trigger')).toBeNull();
+  });
+});
+
+// 分享連結：ShareLinkModal 是 API-backed component（listShares 等），這裡不整個 render
+// 驗證行為（避免 test 需要 mock 網路層），改用 source-grep 鎖 wiring 與掛載,
+// 與 trip-share-menu-entry.test.tsx 對 TripsListPage 的作法一致。
+describe('TripStackLayout — 分享連結 wiring（source contract）', () => {
+  it('中欄 TitleBar 的 onShare 開啟 ShareLinkModal（shareTripId gate）', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const src = readFileSync(join(__dirname, '..', '..', 'src/pages/TripStackLayout.tsx'), 'utf8');
+    expect(src).toMatch(/import ShareLinkModal from/);
+    expect(src).toMatch(/onShare=\{\(\) => setShareTripId\(valid\)\}/);
+    expect(src).toMatch(/shareTripId && \(\s*<ShareLinkModal tripId=\{shareTripId\} open onClose/);
   });
 });

--- a/tests/unit/trip-stack-routes.test.ts
+++ b/tests/unit/trip-stack-routes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * resolveDesktopMiddleColumnTripId — owner 2026-07-21 回報 #2 修復用的路由判斷函式。
+ * 見 src/lib/tripStackRoutes.ts 檔頭註解。
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveDesktopMiddleColumnTripId, TRIP_STACK_OPERATION_PATTERNS } from '../../src/lib/tripStackRoutes';
+
+describe('resolveDesktopMiddleColumnTripId', () => {
+  it('/trips?selected=X → X', () => {
+    expect(resolveDesktopMiddleColumnTripId('/trips', '?selected=t1')).toBe('t1');
+  });
+
+  it('/trips（無 selected）→ null', () => {
+    expect(resolveDesktopMiddleColumnTripId('/trips', '')).toBeNull();
+  });
+
+  it('/trips/new → null（不是行程詳情）', () => {
+    expect(resolveDesktopMiddleColumnTripId('/trips/new', '')).toBeNull();
+  });
+
+  it.each([
+    ['/trip/t1/edit', 't1'],
+    ['/trip/t1/add-stop', 't1'],
+    ['/trip/t1/add-entry', 't1'],
+    ['/trip/t1/collab', 't1'],
+    ['/trip/t1/health', 't1'],
+    ['/trip/t1/notes', 't1'],
+    ['/trip/t1/stop/42/copy', 't1'],
+    ['/trip/t1/stop/42/move', 't1'],
+    ['/trip/t1/stop/42/change-poi', 't1'],
+    ['/trip/t1/stop/42/edit', 't1'],
+  ])('%s → %s（9 條操作路由都要中欄顯示 TripPage）', (pathname, expected) => {
+    expect(resolveDesktopMiddleColumnTripId(pathname, '')).toBe(expected);
+  });
+
+  it.each([
+    '/trip/t1',
+    '/trip/t1/map',
+    '/trip/t1/stop/42',
+    '/trip/t1/stop/42/map',
+    '/trip/t1/print',
+  ])('%s → null（獨立整頁，不經過中欄，不該掛 TripPage）', (pathname) => {
+    expect(resolveDesktopMiddleColumnTripId(pathname, '')).toBeNull();
+  });
+
+  it('非 trip 相關頁（/chat、/map、/favorites）→ null', () => {
+    expect(resolveDesktopMiddleColumnTripId('/chat', '')).toBeNull();
+    expect(resolveDesktopMiddleColumnTripId('/map', '')).toBeNull();
+    expect(resolveDesktopMiddleColumnTripId('/favorites', '')).toBeNull();
+  });
+});
+
+describe('TRIP_STACK_OPERATION_PATTERNS cross-check against main.tsx route 表', () => {
+  const MAIN = readFileSync(join(__dirname, '../../src/entries/main.tsx'), 'utf8');
+
+  it('main.tsx 的 <Route element={<TripStackLayout />}> 區塊剛好有 10 條 path="..."（9 操作 + add-custom-stop 例外）', () => {
+    const block = MAIN.match(/<Route element=\{<TripStackLayout \/>\}>([\s\S]*?)<\/Route>/);
+    expect(block).toBeTruthy();
+    const paths = [...(block?.[1] ?? '').matchAll(/path="([^"]+)"/g)].map((m) => m[1]);
+    expect(paths.sort()).toEqual(
+      [
+        'edit',
+        'add-stop',
+        'add-entry',
+        'collab',
+        'health',
+        'notes',
+        'stop/:entryId/copy',
+        'stop/:entryId/move',
+        'stop/:entryId/change-poi',
+        'stop/:entryId/edit',
+      ].sort(),
+    );
+  });
+
+  it('每一條 main.tsx 路由 path 都被 TRIP_STACK_OPERATION_PATTERNS 其中一條 pattern 命中（避免清單漂移）', () => {
+    const block = MAIN.match(/<Route element=\{<TripStackLayout \/>\}>([\s\S]*?)<\/Route>/);
+    const paths = [...(block?.[1] ?? '').matchAll(/path="([^"]+)"/g)].map((m) => m[1]);
+    for (const routePath of paths) {
+      // main.tsx 用 :entryId route param，實際 URL 是數字/字串 id — 用一個代表值替換掉再測。
+      const concrete = routePath.replace(':entryId', '42');
+      const hit = TRIP_STACK_OPERATION_PATTERNS.some((re) => re.test(concrete));
+      expect(hit, `path="${routePath}" (as "${concrete}") 沒有被任何 pattern 命中`).toBe(true);
+    }
+  });
+});

--- a/tests/unit/trips-list-page.test.tsx
+++ b/tests/unit/trips-list-page.test.tsx
@@ -13,6 +13,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { NewTripProvider } from '../../src/contexts/NewTripContext';
 import { writeTripView } from '../../src/lib/tripViewState';
+import { TRIP_MAIN_PORTAL_ID } from '../../src/lib/tripStackRoutes';
 
 vi.mock('../../src/hooks/useRequireAuth', () => ({
   useRequireAuth: () => ({
@@ -137,12 +138,17 @@ describe('TripsListPage', () => {
     expect(screen.queryByTestId('embedded-trip-page')).toBeNull();
   });
 
-  it('desktop + ?selected=seoul: embedded TripPage replaces grid 滿版 (PR-PP)', async () => {
+  // owner 2026-07-21 回報 #2「開關第三欄面板會刷新第二欄」修復：桌機不再由
+  // TripsListPage 自己 inline render <TripPage>（那是造成路由切換時 remount 的
+  // root cause），改留一個 portal placeholder，讓 main.tsx 的 TripPageHost
+  // （唯一一份持續存在的 <TripPage>）portal 內容進來。見 TripPageHost.tsx。
+  // 手機沒有這個機制（下方 mobile 測試維持 inline <TripPage>，見 148 行起）。
+  it('desktop + ?selected=seoul: main 留 portal placeholder（不再 inline render TripPage，交給 TripPageHost）(PR-PP + owner #2)', async () => {
     vi.stubGlobal('fetch', mockApi([{ tripId: 'okinawa' }, { tripId: 'seoul' }], SAMPLE));
     render(<MemoryRouter initialEntries={['/trips?selected=seoul']}><NewTripProvider><TripsListPage /></NewTripProvider></MemoryRouter>);
-    await waitFor(() => expect(screen.queryByTestId('embedded-trip-page')).toBeTruthy());
-    expect(screen.getByTestId('embedded-trip-page').getAttribute('data-trip-id')).toBe('seoul');
-    expect(screen.getByTestId('embedded-trip-page').getAttribute('data-no-shell')).toBe('true');
+    await waitFor(() => expect(screen.queryByTestId(TRIP_MAIN_PORTAL_ID)).toBeTruthy());
+    // 桌機不 inline render TripPage 了 —— TripPageHost 才是唯一呼叫端。
+    expect(screen.queryByTestId('embedded-trip-page')).toBeNull();
   });
 
   it('mobile + no ?selected: card grid renders, no embedded TripPage in main', async () => {
@@ -250,13 +256,13 @@ describe('TripsListPage — 進 /trips 還原上次檢視（v2.55.x bug 1）', (
   beforeEach(() => localStorage.clear());
   afterEach(() => localStorage.clear());
 
-  it('桌機 + 無 ?selected + 有上次檢視紀錄 → 自動開回該行程（嵌入 TripPage）', async () => {
+  it('桌機 + 無 ?selected + 有上次檢視紀錄 → 自動開回該行程（留 portal placeholder 給 TripPageHost）', async () => {
     mockMatchMedia(true);
     writeTripView({ tripId: 'okinawa', dayNum: 2 });
     vi.stubGlobal('fetch', mockApi([{ tripId: 'okinawa' }, { tripId: 'seoul' }], SAMPLE));
     render(<MemoryRouter initialEntries={['/trips']}><NewTripProvider><TripsListPage /></NewTripProvider></MemoryRouter>);
-    await waitFor(() => expect(screen.queryByTestId('embedded-trip-page')).toBeTruthy());
-    expect(screen.getByTestId('embedded-trip-page').getAttribute('data-trip-id')).toBe('okinawa');
+    await waitFor(() => expect(screen.queryByTestId(TRIP_MAIN_PORTAL_ID)).toBeTruthy());
+    expect(screen.queryByTestId('embedded-trip-page')).toBeNull();
   });
 
   it('手機 + 有上次檢視紀錄 → 不自動還原（Trips 分頁顯示清單）', async () => {

--- a/tests/unit/trips-menu-dropup-clone-title.test.ts
+++ b/tests/unit/trips-menu-dropup-clone-title.test.ts
@@ -22,7 +22,10 @@ describe('複製行程 title 後綴「-複製」（QA）', () => {
 });
 
 describe('行程卡 ⋮ menu dropUp（選單被遮修復，QA）', () => {
-  const src = read('src/pages/TripsListPage.tsx');
+  // v2.57.x: 這組 dropUp/BOTTOM_SAFE_AREA 邏輯屬於行程詳情頁右上角「⋯」動作選單
+  // （原 TripsListPage 的 EmbeddedActionMenu），已抽到共用元件 TripActionsMenu.tsx
+  // （供 TripStackLayout 共用）。
+  const src = read('src/components/trip/TripActionsMenu.tsx');
 
   it('recompute 有 dropUp 邏輯（下方空間被 bottom nav 遮 → 往上展開）', () => {
     expect(src).toMatch(/const dropUp =/);


### PR DESCRIPTION
owner 2026-07-21 回報的六項桌機 shell 問題。

## 六項

| # | 問題 | 修法 |
|---|---|---|
| 1 | 第三欄開啟後，第二欄 header 右上角功能消失 | 抽出共用 `TripActionsMenu`，`TripsListPage` 與 `TripStackLayout` 共用。根因：`TripStackLayout` 中欄 TitleBar 從第一版就只有 title+back，actions slot 沒接 |
| 2 | 開關第三欄會刷新第二欄 | **架構改動**，見下 |
| 3 | 第三欄 header 與第二欄不等高 | `StackPanelHeader` 從寫死 52px 改用 `--titlebar-h`，與中欄同一 token 來源 |
| 4 | 桌機 tab 效果沒比照手機 | `DesktopSidebar` 套同一組 `--tabbar-*` |
| 5 | 面板缺 tertiary elevation | 6 個改 5 個（`EditEntryPage` 的 shell class 全專案無 CSS 定義，本來就透出 tertiary base） |
| 6 | 行程內容欄兩側深黑 | elevation 從 `.trip-content`（527px 窄框）移到 `.tp-trip-page-shell`（滿欄） |

## #2 的架構改動與一個實測才發現的 bug

**根因**：`/trips?selected=X` 與 `/trip/:id/{edit|...}` 是兩個獨立頂層 Route，各自 inline render 自己的 `<TripPage>`。路由切換必然 unmount 一份、mount 另一份，而 TripPage 無跨 mount cache → 重新打 API。

**修法**：`TripPageHost` 讓整個 app 只 render 一份 `<TripPage>`，掛在 `<Routes>` 之上，用 React Portal 投進各頁 placeholder。只有換到不同 tripId 才 `key={tripId}` 重新 mount。

⚠️ **過程中抓到真 bug**：第一版用 pull-based（`getElementById` + `useEffect` 依 pathname 重查 portal target）。靜態審查看不出問題，**playwright 實測才發現「關閉面板回列表」會永遠找不到新 placeholder、中欄整個空白** —— 兩個 host 是獨立 subtree，effect 觸發時新 host 可能還沒 mount，撲空後不重試。改成 push-based（`TripMainPortalContext`，ref callback 在同一 commit 內同步觸發）。

## 驗證（coordinator 獨立重跑，未採信轉述）

| 項目 | 結果 |
|---|---|
| `tsc --noEmit` ×2 | 0 error |
| `npm run lint` | clean |
| unit | **456 files / 3989 tests** |
| api | **102 files / 1148 tests** |
| e2e chromium + mobile-chrome | **96 passed / 10 skipped / 0 失敗** |
| `/tp-code-verify` | 通過 |
| `/review` | 通過 |
| `/cso --diff` | 零發現 |

`#2` 的 e2e 用 `page.on('request')` 直接量 `/days` 實際呼叫次數：**關閉面板 0 次額外呼叫**，portal innerHTML 全程未清空。深連結冷啟也驗過。

`#6` 用 dark mode 實測：`.tp-trip-page-shell` 607px @ x=216 `#2C2C2E`，與 `.app-shell-main` 同寬同位（修復前窄 80px，兩側露出 base）。

## ⚠️ 測試基礎設施：一項權宜

本分支新增測試檔後把 unit 套件推過機器平行度上限，預設並行會撞 `createTestDb()` 30s hook timeout。`npm test` 已加 `--maxWorkers=2`。

逐條實測區分（不是猜的）：分支+預設並行 → 紅；**master+同樣三支 → 綠**；分支+單獨跑 → 綠但 42.5 秒；分支+maxWorkers=2 → 全綠。**不是回歸，是平行度問題。**

沒調高 `hookTimeout` —— 那等於把訊號關掉。根本解是共用一份已 migrate 的 D1 快照，獨立工程，未塞進本 PR。

## 待 owner 決定（merge 前）

- **mockup 簽核**：`docs/design-sessions/2026-07-21-third-column-followups.html`（#3 高度 + #4 材質 before/after）。#3/#4 是既有元件的缺陷修復而非 new page，是否適用 mockup-first gate 請你判定 —— 我不替你豁免。
- **殘留（agent 誠實揭露，未修）**：`TripLayout` 仍為 TitleBar 的行程名稱多打一次 `/days`。**先於本次改動即存在**，只影響標題可能閃「載入中…」，不影響中欄內容。要不要一併修是範圍決定。
- **未實測的角落**：`#6` 的 tertiary fallback 沒在無 `data-tone` 的 entry 上實測（demo 資料找不到這種 entry），只有原始碼層級確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyGJtRTg9ZeBfZoGwAM3Ee